### PR TITLE
Parallelize GitHub fetches and add end-to-end integration tests

### DIFF
--- a/cli/src/commands/admin.rs
+++ b/cli/src/commands/admin.rs
@@ -18,18 +18,18 @@ enum AdminOutput {
     ReopenThesis { issue: u64 },
 }
 
-pub fn run(ctx: &AppContext, args: &AdminArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &AdminArgs) -> Result<()> {
     ensure_lead(ctx)?;
     match &args.command {
-        AdminCommands::ReleaseClaim(args) => release_claim(ctx, args),
-        AdminCommands::AcknowledgeInvalid(args) => acknowledge_invalid(ctx, args),
-        AdminCommands::ReopenThesis(args) => reopen_thesis(ctx, args),
-        AdminCommands::ReconcileLedger => crate::commands::sync::run(ctx),
+        AdminCommands::ReleaseClaim(args) => release_claim(ctx, args).await,
+        AdminCommands::AcknowledgeInvalid(args) => acknowledge_invalid(ctx, args).await,
+        AdminCommands::ReopenThesis(args) => reopen_thesis(ctx, args).await,
+        AdminCommands::ReconcileLedger => crate::commands::sync::run(ctx).await,
     }
 }
 
-fn release_claim(ctx: &AppContext, args: &AdminReleaseClaimArgs) -> Result<()> {
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+async fn release_claim(ctx: &AppContext, args: &AdminReleaseClaimArgs) -> Result<()> {
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let thesis = find_thesis(&repo_state, args.issue)?;
     if !thesis
         .active_claims
@@ -72,8 +72,8 @@ fn release_claim(ctx: &AppContext, args: &AdminReleaseClaimArgs) -> Result<()> {
     })
 }
 
-fn acknowledge_invalid(ctx: &AppContext, args: &AdminAcknowledgeInvalidArgs) -> Result<()> {
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+async fn acknowledge_invalid(ctx: &AppContext, args: &AdminAcknowledgeInvalidArgs) -> Result<()> {
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let finding = repo_state
         .audit_findings
         .iter()
@@ -116,7 +116,7 @@ fn acknowledge_invalid(ctx: &AppContext, args: &AdminAcknowledgeInvalidArgs) -> 
     })
 }
 
-fn reopen_thesis(ctx: &AppContext, args: &AdminReopenThesisArgs) -> Result<()> {
+async fn reopen_thesis(ctx: &AppContext, args: &AdminReopenThesisArgs) -> Result<()> {
     if !ctx.cli.dry_run {
         ctx.github.reopen_issue(args.issue)?;
         let note = ProtocolComment::AdminNote {

--- a/cli/src/commands/attempt.rs
+++ b/cli/src/commands/attempt.rs
@@ -16,9 +16,9 @@ struct AttemptOutput {
     attempt_number: usize,
 }
 
-pub fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let thesis = require_claimed_thesis(&repo_state, args.issue, &node)?;
 
     let branch = current_branch(&ctx.repo_root)?;

--- a/cli/src/commands/audit.rs
+++ b/cli/src/commands/audit.rs
@@ -15,8 +15,8 @@ struct AuditOutput {
     findings: Vec<crate::validation::AuditFinding>,
 }
 
-pub fn run(ctx: &AppContext) -> Result<()> {
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+pub async fn run(ctx: &AppContext) -> Result<()> {
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     let ledger_current = ledger.is_current(&repo_state);
     let mut findings = repo_state.audit_findings.clone();

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::cli::IssueArgs;
 use crate::commands::guards::require_claimable_thesis;
-use crate::commands::{AppContext, create_thesis_branch, print_value, read_node_id};
+use crate::commands::{AppContext, create_thesis_branch, print_value, read_node_id, slugify};
 use crate::comments::ProtocolComment;
 use crate::state::RepositoryState;
 
@@ -14,9 +14,9 @@ struct ClaimOutput {
     branch: String,
 }
 
-pub fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let thesis = require_claimable_thesis(&repo_state, args.issue)?;
     if !thesis.active_claims.is_empty() {
         let nodes = thesis
@@ -32,7 +32,15 @@ pub fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
 
-    let branch = create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
+    let branch = if ctx.cli.dry_run {
+        format!(
+            "thesis/{}-{}",
+            thesis.issue.number,
+            slugify(&thesis.issue.title)
+        )
+    } else {
+        create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?
+    };
 
     let comment = ProtocolComment::Claim {
         thesis: thesis.issue.number,

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -18,9 +18,9 @@ struct DecideOutput {
     confirmations: u64,
 }
 
-pub fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     ensure_clean_audit(&repo_state, "decide PRs")?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     let (thesis, pr_state) = require_decidable_pr(&repo_state, args.pr)?;

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -16,9 +16,9 @@ struct GenerateOutput {
     warned_below_min_queue_depth: bool,
 }
 
-pub fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     ensure_clean_audit(&repo_state, "generate theses")?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     if !ledger.is_current(&repo_state) {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -14,7 +14,7 @@ struct InitOutput {
     github_login: String,
 }
 
-pub fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let node = args.node.clone().unwrap_or_else(default_node_id);
     let login = ctx.github.current_login()?;
     let _ = ctx.github.auth_status()?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -17,40 +17,41 @@ pub mod sync;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Arc;
 
 use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
 use crate::config::{ProgramSpec, ProtocolConfig};
-use crate::github::{GitHubClient, RepoRef};
+use crate::github::{GitHubApi, RepoRef};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppContext {
     pub cli: Cli,
     pub repo_root: PathBuf,
     pub repo: RepoRef,
-    pub github: GitHubClient,
+    pub github: Arc<dyn GitHubApi>,
     pub config: ProtocolConfig,
     pub program: ProgramSpec,
 }
 
 pub async fn run(ctx: AppContext) -> Result<()> {
     match &ctx.cli.command {
-        Commands::Init(args) => init::run(&ctx, args),
-        Commands::Status(args) => status::run(&ctx, args),
-        Commands::Claim(args) => claim::run(&ctx, args),
-        Commands::Attempt(args) => attempt::run(&ctx, args),
-        Commands::Release(args) => release::run(&ctx, args),
-        Commands::Submit(args) => submit::run(&ctx, args),
-        Commands::ReviewClaim(args) => review_claim::run(&ctx, args),
-        Commands::Review(args) => review::run(&ctx, args),
-        Commands::Audit => audit::run(&ctx),
-        Commands::Admin(args) => admin::run(&ctx, args),
-        Commands::Sync => sync::run(&ctx),
-        Commands::Generate(args) => generate::run(&ctx, args),
-        Commands::PolicyCheck(args) => policy_check::run(&ctx, args),
-        Commands::Decide(args) => decide::run(&ctx, args),
+        Commands::Init(args) => init::run(&ctx, args).await,
+        Commands::Status(args) => status::run(&ctx, args).await,
+        Commands::Claim(args) => claim::run(&ctx, args).await,
+        Commands::Attempt(args) => attempt::run(&ctx, args).await,
+        Commands::Release(args) => release::run(&ctx, args).await,
+        Commands::Submit(args) => submit::run(&ctx, args).await,
+        Commands::ReviewClaim(args) => review_claim::run(&ctx, args).await,
+        Commands::Review(args) => review::run(&ctx, args).await,
+        Commands::Audit => audit::run(&ctx).await,
+        Commands::Admin(args) => admin::run(&ctx, args).await,
+        Commands::Sync => sync::run(&ctx).await,
+        Commands::Generate(args) => generate::run(&ctx, args).await,
+        Commands::PolicyCheck(args) => policy_check::run(&ctx, args).await,
+        Commands::Decide(args) => decide::run(&ctx, args).await,
     }
 }
 

--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -15,9 +15,9 @@ struct PolicyCheckOutput {
     violating_files: Vec<String>,
 }
 
-pub fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     ensure_clean_audit(&repo_state, "policy-check PRs")?;
     let pr = ctx.github.get_pull_request(args.pr)?;
     let thesis_number = parse_thesis_number_from_branch(&pr.head_ref_name);

--- a/cli/src/commands/release.rs
+++ b/cli/src/commands/release.rs
@@ -14,9 +14,9 @@ struct ReleaseOutput {
     reason: String,
 }
 
-pub fn run(ctx: &AppContext, args: &ReleaseArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &ReleaseArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let _thesis = require_claimed_thesis(&repo_state, args.issue, &node)?;
 
     let comment = ProtocolComment::Release {

--- a/cli/src/commands/review.rs
+++ b/cli/src/commands/review.rs
@@ -23,9 +23,9 @@ struct ReviewOutput {
     env_sha: Option<String>,
 }
 
-pub fn run(ctx: &AppContext, args: &ReviewArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &ReviewArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let (thesis, pr_state) = require_claimed_review_pr(&repo_state, args.pr, &node)?;
 
     let candidate_sha = pr_state

--- a/cli/src/commands/review_claim.rs
+++ b/cli/src/commands/review_claim.rs
@@ -14,10 +14,10 @@ struct ReviewClaimOutput {
     node: String,
 }
 
-pub fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let login = ctx.github.current_login()?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let (thesis, _pr_state) = require_reviewable_pr(&repo_state, args.pr, &login)?;
 
     let comment = ProtocolComment::ReviewClaim {

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -21,8 +21,8 @@ struct StatusOutput {
     theses: Vec<crate::state::ThesisState>,
 }
 
-pub fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     if args.tui {
         return crate::tui::run_dashboard(ctx, repo_state, ledger);

--- a/cli/src/commands/submit.rs
+++ b/cli/src/commands/submit.rs
@@ -15,9 +15,9 @@ struct SubmitOutput {
     pr_url: Option<String>,
 }
 
-pub fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
+pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let thesis = require_claimed_thesis(&repo_state, args.issue, &node)?;
 
     let branch = current_branch(&ctx.repo_root)?;

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -12,9 +12,9 @@ struct SyncOutput {
     attempts: Vec<String>,
 }
 
-pub fn run(ctx: &AppContext) -> Result<()> {
+pub async fn run(ctx: &AppContext) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let mut ledger = Ledger::load(&ctx.repo_root)?;
     let missing_rows = ledger.missing_rows(&repo_state);
 

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Context, Result, eyre};
@@ -65,6 +67,31 @@ impl RepoRef {
 #[derive(Debug, Clone)]
 pub struct GitHubClient {
     repo: RepoRef,
+}
+
+pub trait GitHubApi: Send + Sync {
+    fn current_login(&self) -> Result<String>;
+    fn auth_status(&self) -> Result<String>;
+    fn auth_token(&self) -> Result<String>;
+    fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>>;
+    fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>>;
+    fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<Issue>;
+    fn post_issue_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment>;
+    fn close_issue(&self, issue_number: u64) -> Result<Issue>;
+    fn reopen_issue(&self, issue_number: u64) -> Result<Issue>;
+    fn list_pull_requests(&self, state: PullRequestListState) -> Result<Vec<PullRequest>>;
+    fn get_pull_request(&self, pr_number: u64) -> Result<PullRequest>;
+    fn list_pull_request_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>>;
+    fn list_pull_request_files(&self, pr_number: u64) -> Result<Vec<PullRequestFile>>;
+    fn create_pull_request(
+        &self,
+        branch: &str,
+        title: &str,
+        body: &str,
+        base: &str,
+    ) -> Result<PullRequest>;
+    fn close_pull_request(&self, pr_number: u64) -> Result<serde_json::Value>;
+    fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value>;
 }
 
 impl GitHubClient {
@@ -331,6 +358,143 @@ impl GitHubClient {
         command.args(args);
         run_text_command(command)
     }
+}
+
+impl GitHubApi for GitHubClient {
+    fn current_login(&self) -> Result<String> {
+        GitHubClient::current_login(self)
+    }
+
+    fn auth_status(&self) -> Result<String> {
+        GitHubClient::auth_status(self)
+    }
+
+    fn auth_token(&self) -> Result<String> {
+        GitHubClient::auth_token(self)
+    }
+
+    fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>> {
+        GitHubClient::list_thesis_issues(self, state)
+    }
+
+    fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>> {
+        GitHubClient::list_issue_comments(self, issue_number)
+    }
+
+    fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<Issue> {
+        GitHubClient::create_issue(self, title, body, labels)
+    }
+
+    fn post_issue_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment> {
+        GitHubClient::post_issue_comment(self, issue_number, body)
+    }
+
+    fn close_issue(&self, issue_number: u64) -> Result<Issue> {
+        GitHubClient::close_issue(self, issue_number)
+    }
+
+    fn reopen_issue(&self, issue_number: u64) -> Result<Issue> {
+        GitHubClient::reopen_issue(self, issue_number)
+    }
+
+    fn list_pull_requests(&self, state: PullRequestListState) -> Result<Vec<PullRequest>> {
+        GitHubClient::list_pull_requests(self, state)
+    }
+
+    fn get_pull_request(&self, pr_number: u64) -> Result<PullRequest> {
+        GitHubClient::get_pull_request(self, pr_number)
+    }
+
+    fn list_pull_request_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>> {
+        GitHubClient::list_pull_request_comments(self, pr_number)
+    }
+
+    fn list_pull_request_files(&self, pr_number: u64) -> Result<Vec<PullRequestFile>> {
+        GitHubClient::list_pull_request_files(self, pr_number)
+    }
+
+    fn create_pull_request(
+        &self,
+        branch: &str,
+        title: &str,
+        body: &str,
+        base: &str,
+    ) -> Result<PullRequest> {
+        GitHubClient::create_pull_request(self, branch, title, body, base)
+    }
+
+    fn close_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
+        GitHubClient::close_pull_request(self, pr_number)
+    }
+
+    fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
+        GitHubClient::merge_pull_request(self, pr_number)
+    }
+}
+
+pub async fn fetch_lists(github: Arc<dyn GitHubApi>) -> Result<(Vec<Issue>, Vec<PullRequest>)> {
+    let github_for_issues = Arc::clone(&github);
+    let github_for_prs = Arc::clone(&github);
+
+    tokio::try_join!(
+        run_blocking(move || github_for_issues.list_thesis_issues(IssueListState::All)),
+        run_blocking(move || github_for_prs.list_pull_requests(PullRequestListState::All)),
+    )
+}
+
+pub async fn fetch_all_comments(
+    github: Arc<dyn GitHubApi>,
+    issue_numbers: &[u64],
+    pr_numbers: &[u64],
+) -> Result<(
+    HashMap<u64, Vec<IssueComment>>,
+    HashMap<u64, Vec<IssueComment>>,
+)> {
+    let mut issue_tasks = tokio::task::JoinSet::new();
+    for issue_number in issue_numbers.iter().copied() {
+        let github = Arc::clone(&github);
+        issue_tasks.spawn_blocking(move || {
+            github
+                .list_issue_comments(issue_number)
+                .map(|comments| (issue_number, comments))
+        });
+    }
+
+    let mut pr_tasks = tokio::task::JoinSet::new();
+    for pr_number in pr_numbers.iter().copied() {
+        let github = Arc::clone(&github);
+        pr_tasks.spawn_blocking(move || {
+            github
+                .list_pull_request_comments(pr_number)
+                .map(|comments| (pr_number, comments))
+        });
+    }
+
+    let mut issue_comments = HashMap::new();
+    while let Some(result) = issue_tasks.join_next().await {
+        let (issue_number, comments) =
+            result.map_err(|err| eyre!("issue comment fetch task failed: {err}"))??;
+        issue_comments.insert(issue_number, comments);
+    }
+
+    let mut pr_comments = HashMap::new();
+    while let Some(result) = pr_tasks.join_next().await {
+        let (pr_number, comments) =
+            result.map_err(|err| eyre!("pull request comment fetch task failed: {err}"))??;
+        pr_comments.insert(pr_number, comments);
+    }
+
+    Ok((issue_comments, pr_comments))
+}
+
+async fn run_blocking<T, F>(operation: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|err| eyre!("blocking GitHub operation failed: {err}"))?
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod cli;
+pub mod commands;
+pub mod comments;
+pub mod config;
+pub mod github;
+pub mod ledger;
+pub mod state;
+pub mod tui;
+pub mod validation;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,23 +1,14 @@
-mod cli;
-mod commands;
-mod comments;
-mod config;
-mod github;
-mod ledger;
-mod state;
-mod tui;
-mod validation;
-
 use std::env;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Parser;
 use color_eyre::eyre::{Context, Result};
-
-use crate::cli::Cli;
-use crate::commands::AppContext;
-use crate::config::{ProgramSpec, ProtocolConfig};
-use crate::github::{GitHubClient, RepoRef};
+use polyresearch_cli::cli::Cli;
+use polyresearch_cli::commands;
+use polyresearch_cli::commands::AppContext;
+use polyresearch_cli::config::{ProgramSpec, ProtocolConfig};
+use polyresearch_cli::github::{GitHubApi, GitHubClient, RepoRef};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -27,7 +18,7 @@ async fn main() -> Result<()> {
     let cwd = env::current_dir().wrap_err("failed to determine current working directory")?;
     let repo_root = discover_repo_root(&cwd)?;
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
-    let github = GitHubClient::new(repo.clone());
+    let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
     let config = ProtocolConfig::load(&repo_root)?;
     let program = ProgramSpec::load(&repo_root, &config)?;
 

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::Result;
@@ -6,7 +7,7 @@ use serde::Serialize;
 
 use crate::comments::{Observation, Outcome, ReleaseReason};
 use crate::config::{MetricDirection, ProtocolConfig};
-use crate::github::{GitHubClient, Issue, IssueListState, PullRequest, PullRequestListState};
+use crate::github::{GitHubApi, Issue, IssueComment, PullRequest, fetch_all_comments, fetch_lists};
 use crate::validation::{AuditFinding, ProtocolEnvelope, validate_issue, validate_pull_request};
 
 #[derive(Debug, Clone, Serialize)]
@@ -116,17 +117,26 @@ pub struct ActivityEvent {
 }
 
 impl RepositoryState {
-    pub fn derive(github: &GitHubClient, config: &ProtocolConfig) -> Result<Self> {
-        let issues = github.list_thesis_issues(IssueListState::All)?;
-        let prs = github.list_pull_requests(PullRequestListState::All)?;
+    pub async fn derive(github: &Arc<dyn GitHubApi>, config: &ProtocolConfig) -> Result<Self> {
+        let (issues, prs) = fetch_lists(Arc::clone(github)).await?;
+        let issue_numbers = issues.iter().map(|issue| issue.number).collect::<Vec<_>>();
+        let pr_numbers = prs.iter().map(|pr| pr.number).collect::<Vec<_>>();
+        let (mut issue_comments, mut pr_comments) =
+            fetch_all_comments(Arc::clone(github), &issue_numbers, &pr_numbers).await?;
         let pr_states = prs
             .into_iter()
-            .map(|pr| PullRequestState::derive(github, pr, config))
+            .map(|pr| {
+                let comments = pr_comments.remove(&pr.number).unwrap_or_default();
+                PullRequestState::derive(pr, comments, config)
+            })
             .collect::<Result<Vec<_>>>()?;
 
         let mut theses = issues
             .into_iter()
-            .map(|issue| ThesisState::derive(github, issue, &pr_states, config))
+            .map(|issue| {
+                let comments = issue_comments.remove(&issue.number).unwrap_or_default();
+                ThesisState::derive(issue, comments, &pr_states, config)
+            })
             .collect::<Result<Vec<_>>>()?;
 
         theses.sort_by_key(|thesis| thesis.issue.number);
@@ -199,13 +209,12 @@ impl RepositoryState {
 
 impl ThesisState {
     fn derive(
-        github: &GitHubClient,
         issue: Issue,
+        comments: Vec<IssueComment>,
         pr_states: &[PullRequestState],
         config: &ProtocolConfig,
     ) -> Result<Self> {
-        let comments = github
-            .list_issue_comments(issue.number)?
+        let comments = comments
             .into_iter()
             .map(ProtocolEnvelope::from_issue_comment)
             .collect::<Result<Vec<_>>>()?;
@@ -367,9 +376,12 @@ impl ThesisState {
 }
 
 impl PullRequestState {
-    fn derive(github: &GitHubClient, pr: PullRequest, config: &ProtocolConfig) -> Result<Self> {
-        let comments = github
-            .list_pull_request_comments(pr.number)?
+    fn derive(
+        pr: PullRequest,
+        comments: Vec<IssueComment>,
+        config: &ProtocolConfig,
+    ) -> Result<Self> {
+        let comments = comments
             .into_iter()
             .map(ProtocolEnvelope::from_issue_comment)
             .collect::<Result<Vec<_>>>()?;

--- a/cli/src/tui/app.rs
+++ b/cli/src/tui/app.rs
@@ -57,7 +57,10 @@ impl DashboardApp {
     }
 
     pub fn refresh(&mut self, ctx: &AppContext) -> color_eyre::eyre::Result<()> {
-        self.repo_state = RepositoryState::derive(&ctx.github, &ctx.config)?;
+        self.repo_state = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(RepositoryState::derive(&ctx.github, &ctx.config))
+        })?;
         self.ledger = Ledger::load(&ctx.repo_root)?;
         if self.repo_state.theses.is_empty() {
             self.table_state.select(None);

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,0 +1,509 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use color_eyre::eyre::{Result, eyre};
+use polyresearch_cli::cli::{
+    AttemptArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
+};
+use polyresearch_cli::commands;
+use polyresearch_cli::comments::Observation;
+use polyresearch_cli::config::{MetricDirection, ProgramSpec, ProtocolConfig};
+use polyresearch_cli::github::{
+    GitHubApi, Issue, IssueComment, IssueListState, PullRequest, PullRequestFile,
+    PullRequestListState, RepoRef,
+};
+use polyresearch_cli::state::RepositoryState;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueFixture {
+    lead_github_login: String,
+    issue: Issue,
+    comments: Vec<IssueComment>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestFixture {
+    pr: PullRequest,
+    comments: Vec<IssueComment>,
+}
+
+#[derive(Default)]
+struct MockGitHubClient {
+    current_login: String,
+    issues: Vec<Issue>,
+    issue_comments: HashMap<u64, Vec<IssueComment>>,
+    pull_requests: Vec<PullRequest>,
+    pr_comments: HashMap<u64, Vec<IssueComment>>,
+    posted_issue_comments: Mutex<Vec<(u64, String)>>,
+}
+
+impl MockGitHubClient {
+    fn new(
+        current_login: impl Into<String>,
+        issues: Vec<Issue>,
+        issue_comments: HashMap<u64, Vec<IssueComment>>,
+        pull_requests: Vec<PullRequest>,
+        pr_comments: HashMap<u64, Vec<IssueComment>>,
+    ) -> Self {
+        Self {
+            current_login: current_login.into(),
+            issues,
+            issue_comments,
+            pull_requests,
+            pr_comments,
+            posted_issue_comments: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl GitHubApi for MockGitHubClient {
+    fn current_login(&self) -> Result<String> {
+        Ok(self.current_login.clone())
+    }
+
+    fn auth_status(&self) -> Result<String> {
+        Ok("logged in".to_string())
+    }
+
+    fn auth_token(&self) -> Result<String> {
+        Ok("test-token".to_string())
+    }
+
+    fn list_thesis_issues(&self, _state: IssueListState) -> Result<Vec<Issue>> {
+        Ok(self.issues.clone())
+    }
+
+    fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>> {
+        Ok(self
+            .issue_comments
+            .get(&issue_number)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn create_issue(&self, _title: &str, _body: &str, _labels: &[&str]) -> Result<Issue> {
+        Err(eyre!("unexpected create_issue call in test"))
+    }
+
+    fn post_issue_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment> {
+        self.posted_issue_comments
+            .lock()
+            .unwrap()
+            .push((issue_number, body.to_string()));
+        Ok(IssueComment {
+            id: 9999,
+            body: body.to_string(),
+            user: polyresearch_cli::github::CommentUser {
+                login: self.current_login.clone(),
+            },
+            created_at: chrono::Utc::now(),
+            updated_at: None,
+        })
+    }
+
+    fn close_issue(&self, _issue_number: u64) -> Result<Issue> {
+        Err(eyre!("unexpected close_issue call in test"))
+    }
+
+    fn reopen_issue(&self, _issue_number: u64) -> Result<Issue> {
+        Err(eyre!("unexpected reopen_issue call in test"))
+    }
+
+    fn list_pull_requests(&self, _state: PullRequestListState) -> Result<Vec<PullRequest>> {
+        Ok(self.pull_requests.clone())
+    }
+
+    fn get_pull_request(&self, pr_number: u64) -> Result<PullRequest> {
+        self.pull_requests
+            .iter()
+            .find(|pr| pr.number == pr_number)
+            .cloned()
+            .ok_or_else(|| eyre!("mock PR #{} not found", pr_number))
+    }
+
+    fn list_pull_request_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>> {
+        Ok(self
+            .pr_comments
+            .get(&pr_number)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn list_pull_request_files(&self, _pr_number: u64) -> Result<Vec<PullRequestFile>> {
+        Ok(Vec::new())
+    }
+
+    fn create_pull_request(
+        &self,
+        _branch: &str,
+        _title: &str,
+        _body: &str,
+        _base: &str,
+    ) -> Result<PullRequest> {
+        Err(eyre!("unexpected create_pull_request call in test"))
+    }
+
+    fn close_pull_request(&self, _pr_number: u64) -> Result<serde_json::Value> {
+        Err(eyre!("unexpected close_pull_request call in test"))
+    }
+
+    fn merge_pull_request(&self, _pr_number: u64) -> Result<serde_json::Value> {
+        Err(eyre!("unexpected merge_pull_request call in test"))
+    }
+}
+
+struct TestRepo {
+    path: PathBuf,
+}
+
+impl TestRepo {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("polyresearch-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+
+impl Drop for TestRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+#[tokio::test]
+async fn init_writes_node_identity() {
+    let repo = TestRepo::new("init");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Init(InitArgs {
+            node: Some("test-node".to_string()),
+        }),
+    );
+
+    commands::init::run(
+        &ctx,
+        &InitArgs {
+            node: Some("test-node".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let node_file = repo.path.join(".polyresearch-node");
+    assert_eq!(fs::read_to_string(node_file).unwrap(), "test-node\n");
+}
+
+#[tokio::test]
+async fn status_and_audit_succeed_on_fixture_snapshot() {
+    let repo = TestRepo::new("status-audit");
+    let issue_fixture = load_issue_fixture("duplicate_claim_issue.json");
+    let pr_fixture = load_pr_fixture("non_lead_decision_pr.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue_fixture.issue.clone()],
+        HashMap::from([(issue_fixture.issue.number, issue_fixture.comments.clone())]),
+        vec![pr_fixture.pr.clone()],
+        HashMap::from([(pr_fixture.pr.number, pr_fixture.comments.clone())]),
+    ));
+
+    let status_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &issue_fixture.lead_github_login,
+        false,
+        Commands::Status(StatusArgs { tui: false }),
+    );
+    commands::status::run(&status_ctx, &StatusArgs { tui: false })
+        .await
+        .unwrap();
+
+    let audit_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &issue_fixture.lead_github_login,
+        false,
+        Commands::Audit,
+    );
+    commands::audit::run(&audit_ctx).await.unwrap();
+
+    let repo_state = RepositoryState::derive(&status_ctx.github, &status_ctx.config)
+        .await
+        .unwrap();
+    assert_eq!(repo_state.theses.len(), 1);
+    assert_eq!(repo_state.active_nodes, vec!["node-a".to_string()]);
+    assert_eq!(repo_state.audit_findings.len(), 2);
+}
+
+#[tokio::test]
+async fn claim_rejects_already_claimed_thesis() {
+    let repo = TestRepo::new("claim-reject");
+    let fixture = load_issue_fixture("duplicate_claim_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "node-b").unwrap();
+
+    let error = commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("not claimable"));
+}
+
+#[tokio::test]
+async fn claim_rejects_closed_thesis() {
+    let repo = TestRepo::new("claim-closed");
+    let fixture = load_issue_fixture("attempt_after_closure_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "server").unwrap();
+
+    let error = commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("is not open"));
+}
+
+#[tokio::test]
+async fn attempt_rejects_node_without_canonical_claim() {
+    let repo = TestRepo::new("attempt-reject");
+    let fixture = load_issue_fixture("duplicate_claim_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Attempt(AttemptArgs {
+            issue: fixture.issue.number,
+            metric: 0.51,
+            baseline: 0.50,
+            observation: Observation::Improved,
+            summary: "test".to_string(),
+        }),
+    );
+    commands::write_node_id(&repo.path, "node-b").unwrap();
+
+    let error = commands::attempt::run(
+        &ctx,
+        &AttemptArgs {
+            issue: fixture.issue.number,
+            metric: 0.51,
+            baseline: 0.50,
+            observation: Observation::Improved,
+            summary: "test".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("not currently claimed"));
+}
+
+#[tokio::test]
+async fn generate_is_blocked_by_dirty_audit() {
+    let repo = TestRepo::new("generate-dirty");
+    let fixture = load_issue_fixture("duplicate_claim_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    let error = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("cannot generate theses while audit findings are present")
+    );
+}
+
+#[tokio::test]
+async fn lead_only_command_rejects_non_lead_login() {
+    let repo = TestRepo::new("non-lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", true, Commands::Sync);
+
+    let error = commands::sync::run(&ctx).await.unwrap_err();
+    assert!(error.to_string().contains("lead-only"));
+}
+
+#[tokio::test]
+async fn valid_claim_succeeds_in_dry_run_without_writing() {
+    let repo = TestRepo::new("valid-claim");
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        true,
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "node-a").unwrap();
+
+    commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
+}
+
+fn make_ctx(
+    repo_root: PathBuf,
+    github: Arc<dyn GitHubApi>,
+    lead_github_login: &str,
+    dry_run: bool,
+    command: Commands,
+) -> commands::AppContext {
+    commands::AppContext {
+        cli: Cli {
+            repo: None,
+            json: false,
+            dry_run,
+            command,
+        },
+        repo_root,
+        repo: RepoRef {
+            owner: "test-owner".to_string(),
+            name: "test-repo".to_string(),
+        },
+        github,
+        config: ProtocolConfig {
+            required_confirmations: 0,
+            metric_tolerance: Some(0.01),
+            metric_direction: MetricDirection::HigherIsBetter,
+            lead_github_login: Some(lead_github_login.to_string()),
+            assignment_timeout: Duration::from_secs(24 * 60 * 60),
+            review_timeout: Duration::from_secs(12 * 60 * 60),
+            min_queue_depth: 5,
+            max_queue_depth: Some(10),
+        },
+        program: ProgramSpec {
+            can_modify: vec!["system_prompt.md".to_string()],
+            cannot_modify: vec!["PREPARE.md".to_string()],
+        },
+    }
+}
+
+fn load_issue_fixture(name: &str) -> IssueFixture {
+    serde_json::from_str(include_str_fixture(name)).unwrap()
+}
+
+fn load_pr_fixture(name: &str) -> PullRequestFixture {
+    serde_json::from_str(include_str_fixture(name)).unwrap()
+}
+
+fn include_str_fixture(name: &str) -> &'static str {
+    match name {
+        "duplicate_claim_issue.json" => include_str!("fixtures/duplicate_claim_issue.json"),
+        "non_lead_decision_pr.json" => include_str!("fixtures/non_lead_decision_pr.json"),
+        "attempt_after_closure_issue.json" => {
+            include_str!("fixtures/attempt_after_closure_issue.json")
+        }
+        "acknowledged_invalid_issue.json" => {
+            include_str!("fixtures/acknowledged_invalid_issue.json")
+        }
+        other => panic!("unknown fixture: {other}"),
+    }
+}

--- a/examples/pokeragent/POLYRESEARCH.md
+++ b/examples/pokeragent/POLYRESEARCH.md
@@ -18,16 +18,16 @@ Drop this file into your repository unchanged. Put project-specific coordination
 This table defines the protocol parameters. Put the concrete values for your project in a `## Configuration` section in `PROGRAM.md`. Agents read those values from `PROGRAM.md`.
 
 
-| Parameter                | Description                                                                                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `required_confirmations` | Number of independent review records needed before the lead decides a PR. `0` means the lead decides without peer review. Default: `0`.                 |
-| `metric_tolerance`       | Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance. |
-| `metric_direction`       | `lower_is_better` or `higher_is_better`.                                                                                                                |
-| `lead_github_login`      | GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.                          |
-| `assignment_timeout`     | Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.                                                           |
-| `review_timeout`         | Time before an incomplete review claim expires. Default: `12h`.                                                                                         |
+| Parameter                | Description                                                                                                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `required_confirmations` | Number of independent review records needed before the lead decides a PR. `0` means the lead decides without peer review. Default: `0`.                                     |
+| `metric_tolerance`       | Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance.                     |
+| `metric_direction`       | `lower_is_better` or `higher_is_better`.                                                                                                                                    |
+| `lead_github_login`      | GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.                                           |
+| `assignment_timeout`     | Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.                                                                               |
+| `review_timeout`         | Time before an incomplete review claim expires. Default: `12h`.                                                                                                             |
 | `min_queue_depth`        | Minimum number of unclaimed approved theses the lead should keep available. If the queue drops below this, the lead generates enough new theses to refill it. Default: `5`. |
-| `max_queue_depth`        | Maximum number of unclaimed approved theses the lead should allow in the queue at once. When omitted, there is no upper bound.                         |
+| `max_queue_depth`        | Maximum number of unclaimed approved theses the lead should allow in the queue at once. When omitted, there is no upper bound.                                              |
 
 
 The parameter definitions live here. Concrete project values live in `PROGRAM.md`.
@@ -131,6 +131,7 @@ The event table below defines what to log:
 | Attempt discarded (never became a PR) | `polyresearch:attempt` comments on thesis issue          | Append row with self-reported metric                 |
 | Thesis closed without any candidate   | `polyresearch:release` + `polyresearch:attempt` comments | Append rows for all logged attempts                  |
 
+
 ### Generate theses
 
 Complete all of these before opening any new thesis issue:
@@ -181,7 +182,6 @@ If `required_confirmations` is `0`, skip peer review. The lead decides using thi
 4. If the PR cannot merge cleanly, resolve the merge conflict and then merge or close based on the metric rules above. Do not close a PR solely because it has a merge conflict.
 
 Do not use `outcome: stale` when `required_confirmations` is `0`. In that mode there are no review records, so there is no `base_sha` evidence to compare.
-
 
 ---
 


### PR DESCRIPTION
## Summary

- Parallelizes all GitHub API comment fetches in `RepositoryState::derive` using `tokio::task::JoinSet` and `spawn_blocking`, cutting `polyresearch status` wall time from ~24s to ~2.4s on a 38-thesis repo. No caching involved.
- Extracts a `GitHubApi` trait from `GitHubClient` so the entire command surface can be tested against a mock without hitting the real GitHub API.
- Converts the crate from binary-only to library + binary (`lib.rs` + `main.rs`) so integration tests can import and call real command handlers.
- Makes `RepositoryState::derive` async and updates all 14 command handlers to `.await` it.
- Adds 8 end-to-end integration tests in `cli/tests/e2e.rs` covering: init, status, audit, claim rejection (already claimed + closed thesis), attempt rejection (wrong node), generate blocked by dirty audit, lead-only command rejection, and valid dry-run claim.

## Test plan

- [x] `cargo test` passes with 11 unit tests + 8 e2e tests
- [x] Live `polyresearch status` against `pokeragent-test` runs in ~2.4s (down from ~24s)
- [ ] Verify `polyresearch audit` still produces correct finding counts on a live repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors `RepositoryState::derive` and all CLI command entrypoints to async and adds concurrent `spawn_blocking` GitHub fetches, which could introduce subtle ordering/concurrency/perf regressions or runtime blocking issues. Changes also abstract GitHub access behind a trait, affecting many call sites but with added integration tests to mitigate risk.
> 
> **Overview**
> **Speeds up repository state derivation** by making `RepositoryState::derive` async and fetching issue/PR lists plus all comments concurrently (via new `fetch_lists`/`fetch_all_comments` helpers using `tokio` blocking tasks).
> 
> **Refactors the CLI execution surface** to support async end-to-end: all command `run` functions now `await` state derivation, `AppContext` now holds `Arc<dyn GitHubApi>` (trait extracted from `GitHubClient`), and the TUI refresh path bridges async with `block_in_place`.
> 
> **Improves testability and coverage** by splitting the crate into library + binary and adding `cli/tests/e2e.rs` with mock GitHub-backed integration tests covering common command flows and key rejection/guard cases; also tweaks `claim` dry-run to compute the branch name without touching git.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba0038cd5b3b1814cf3866e0e4c924f187b1dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->