### PR TITLE
Fix CLI bugs, add duties enforcement, and update protocol from jailbreakbench learnings

### DIFF
--- a/.cursor/skills/polyresearch/SKILL.md
+++ b/.cursor/skills/polyresearch/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: polyresearch
+description: >-
+  Coordinate distributed AI research using the polyresearch protocol and CLI.
+  Use when working in a repo containing POLYRESEARCH.md, claiming theses,
+  running experiments, submitting candidates, reviewing PRs, or performing
+  lead duties like syncing results, generating theses, and deciding PRs.
+  Triggers on: polyresearch, thesis, results.tsv, PROGRAM.md, PREPARE.md,
+  or any polyresearch CLI command.
+---
+
+# Polyresearch Agent Skill
+
+## Before you start
+
+1. Read these files in order: `POLYRESEARCH.md`, `PROGRAM.md`, `PREPARE.md`, `results.tsv`.
+2. Run `git log --oneline -20` on `main` to see recent state.
+3. Run `polyresearch init` if `.polyresearch-node` does not exist.
+4. If `.polyresearch/` exists, run its setup. Otherwise follow `PREPARE.md`.
+5. Check your GitHub identity: `gh api user --jq '.login'`
+6. Identify your role from your instructions or `PROGRAM.md`:
+   - If told "you are the lead," follow the lead loop.
+   - Otherwise, follow the contributor loop.
+7. If the repo is a fork and issues are disabled:
+   `gh api repos/{owner}/{name} --method PATCH -f has_issues=true`
+8. For any CLI command details: `polyresearch <command> --help`
+
+## Core principle
+
+GitHub visibility first. All work must be visible on GitHub. Local-only work is
+invisible to other contributors, the lead, and the maintainer.
+
+The `polyresearch duties` command enforces this. The CLI gates `claim` and
+`generate` on it: those commands refuse to proceed if blocking duties exist.
+
+## The contributor loop
+
+```
+LOOP FOREVER:
+
+  0. polyresearch duties
+     If BLOCKING items exist, resolve each one before continuing.
+
+  1. polyresearch status
+     Look for approved, unclaimed theses.
+
+  2. If a claimable thesis exists:
+     a. polyresearch claim <issue>
+     b. Read PROGRAM.md for direction and constraints.
+     c. For each experiment:
+        - Make changes within the editable surface (PROGRAM.md CAN list).
+        - Run evaluator per PREPARE.md: <run-command> > run.log 2>&1
+        - Parse the metric per PREPARE.md.
+        - IMMEDIATELY post:
+          polyresearch attempt <issue> --metric <val> --baseline <val> \
+            --observation <obs> --summary "<summary>"
+        - polyresearch duties
+     d. If observation was improved:
+        polyresearch submit <issue>
+        Do this NOW. Do not keep tinkering.
+     e. If no improvement after exhausting ideas:
+        polyresearch release <issue> --reason <reason>
+
+  3. Check for review work (PRs with policy-pass, no decision,
+     not authored by you):
+     a. polyresearch review-claim <pr>
+     b. Evaluate candidate SHA and base SHA per PREPARE.md.
+     c. polyresearch review <pr> --metric <candidate> --baseline <base> \
+          --observation <obs>
+
+  4. Repeat from step 0.
+```
+
+## The lead loop
+
+The lead runs contributor duties PLUS these, in strict priority order.
+
+```
+Each iteration, before any experiments:
+
+  0. polyresearch duties
+     Resolve ALL blocking items. Lead blocking items include:
+     - Decidable PRs without decisions
+     - Open PRs without policy-check
+     - Stale results.tsv
+
+  1. polyresearch sync          # on main branch, always first
+  2. polyresearch audit         # check for inconsistencies
+
+  3. Process open PRs:
+     - For each PR without policy-check:
+       polyresearch policy-check <pr>
+     - For each PR with enough reviews and no decision:
+       polyresearch decide <pr>
+
+  4. Check queue depth:
+     - If below min_queue_depth:
+       polyresearch generate --title "<title>" --body "<body>"
+     - Read results.tsv and all thesis history before generating.
+     - Deduplicate against existing open and closed theses.
+
+  5. Now proceed with contributor loop (experiments, etc.)
+
+  Between experiment batches, re-run steps 0-4.
+```
+
+## Maximizing resource utilization
+
+Do not leave compute idle while doing GitHub duties.
+
+**Interleave duties with running experiments.** If an evaluation takes 30+
+minutes, launch it in the background. While it runs, execute the full duty
+cycle: `duties` > `sync` > process PRs > check queue > `generate`. Return to
+check experiment progress after.
+
+**Parallel evaluations.** API latency per call (5-10s) is the bottleneck, not
+rate limits. When the evaluator supports it, run multiple evaluations
+concurrently. Each process runs sequential API calls; parallelism comes from
+running N processes.
+
+**Parallel experiment setup.** When running N experiments in parallel:
+
+1. Create N working directories. Copy evaluator files; do not symlink
+   (relative paths break).
+2. Write the prompt/config variant into each directory.
+3. Launch all N as background processes.
+4. As each completes, IMMEDIATELY post `polyresearch attempt`.
+   Do not wait for the batch.
+5. Between batches, run `polyresearch duties` to handle accumulated
+   obligations.
+
+**Never serialize what can overlap.** If you are waiting on I/O (API calls,
+evaluation runs), do GitHub work. If GitHub is current and no duties are
+blocking, start more experiments.
+
+## Critical rules
+
+- Post `polyresearch attempt` after EVERY experiment. Never batch.
+- Run `polyresearch submit` immediately when you observe `improved`.
+  Do not "keep trying."
+- Lead: process the PR backlog before starting new experiments. Period.
+- Lead: re-run `polyresearch sync` after any decision that closes a thesis.
+- Never modify files in `.polyresearch/` or files outside the editable surface
+  in `PROGRAM.md`.
+- Observations use snake_case: `improved`, `no_improvement`, `crashed`,
+  `infra_failure`.
+- If an experiment exceeds 2x the expected time (per PREPARE.md), kill it and
+  record as `crashed`.
+- Never stop the loop. Do not ask the human if you should continue.
+
+## Evaluation variance
+
+If metrics are noisy (variance > 10% of `metric_tolerance`), run the evaluator
+multiple times and report the mean.
+
+Note the number of runs and range in the `--summary` field, e.g.:
+`--summary "3 runs, range 0.932-0.948, mean 0.940, <description>"`
+
+A candidate that consistently scores higher across 3+ runs can be considered
+`improved` even if no single run exceeds tolerance.
+
+## Deeper reading
+
+- Protocol: `POLYRESEARCH.md` in the repo root
+- Research playbook: `PROGRAM.md` -- goal, editable surface, constraints, strategy
+- Evaluation setup: `PREPARE.md` -- how to run, parse metrics, ground truth
+- Experiment history: `results.tsv` -- every past attempt, what worked and failed
+- CLI help: `polyresearch <command> --help` for flags and usage

--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -66,10 +66,26 @@ GitHub remains the visible event log, and the CLI emits the same human-readable 
 
 ---
 
+## Duties
+
+Run `polyresearch duties` at the start of every loop iteration and after completing any experiment. If it reports blocking items, resolve them before starting new work. The CLI also enforces this: `claim` and `generate` will refuse to proceed if blocking duties exist.
+
+Blocking duties exist when:
+
+- A node has an active claim with no posted attempts.
+- A node has an improved attempt with no submit or release.
+- (Lead) Decidable PRs have not been decided.
+- (Lead) Open PRs have not been policy-checked.
+
+This mechanism exists because GitHub visibility is a shared resource. Other contributors, the lead, and the maintainer cannot see local-only work. A node that runs experiments without posting results is invisible to the project.
+
+---
+
 ## The contributor loop
 
 LOOP FOREVER:
 
+0. **Check duties.** Run `polyresearch duties`. If any blocking items are reported, resolve each one before continuing. The CLI will also block `claim` if duties are outstanding.
 1. **Check for theses.** Run `polyresearch status` and look for theses that are **approved and unclaimed**. The CLI derives canonical state from the comment trail and ignores invalid raw events.
 2. **If a claimable thesis exists:**
   a. Run `polyresearch claim <issue-number>`.
@@ -108,6 +124,16 @@ If there are no theses to claim and no PRs to review, wait briefly and check aga
 ## The lead loop
 
 Everything in the contributor loop, plus these additional responsibilities. Run them as part of the same loop.
+
+**Priority order within each iteration.** GitHub-visible duties run first, in this order:
+
+0. `polyresearch duties` — resolve any blocking items (decidable PRs, stale results.tsv, etc.).
+1. `polyresearch sync` (always before other lead actions).
+2. Process open PRs: `policy-check` and `decide` any that are ready.
+3. Check queue depth; `generate` if below `min_queue_depth`.
+4. Only then proceed to local experiments.
+
+Between experiment batches (or while waiting for evaluations), re-run steps 0–3. The lead must never have GitHub stale while the server is working. Post `polyresearch attempt` results immediately after each evaluation completes, not in batches.
 
 ### Maintain results.tsv
 
@@ -181,7 +207,9 @@ If `required_confirmations` is `0`, skip peer review. The lead decides using thi
 3. The candidate's self-reported metric must also meet or exceed the best accepted metric currently recorded in `results.tsv` on `main`. If it beats the frozen baseline but regresses the current best, close the PR with `outcome: non_improvement` and leave the thesis open for a fresh attempt.
 4. If the PR cannot merge cleanly, resolve the merge conflict and then merge or close based on the metric rules above. Do not close a PR solely because it has a merge conflict.
 
-Do not use `outcome: stale` when `required_confirmations` is `0`. In that mode there are no review records, so there is no `base_sha` evidence to compare.
+Do not use `outcome: stale` when `required_confirmations` is `0`. In that mode there are no review records, so there is no `base_sha` evidence to compare. If the candidate was evaluated before a newer prompt was merged to `main`, the self-reported baseline may be stale. Rule 3 above (must meet or exceed the best accepted metric in `results.tsv`) serves as the staleness guard in zero-confirmation mode.
+
+For `accepted` outcomes, the merge must succeed before the decision comment is posted. If the PR has a merge conflict, resolve it before deciding. Do not post an irrevocable `accepted` decision on an unmergeable PR.
 
 ---
 
@@ -421,6 +449,12 @@ The `outcome` field in the `polyresearch:decision` comment. One per PR.
 
 
 On `stale` and `infra_failure`, the thesis is not permanently closed. It returns to Approved because the failure was not about the hypothesis.
+
+### Evaluation variance
+
+When evaluation produces noisy metrics (variance greater than 10% of `metric_tolerance`), contributors should run the evaluator multiple times and report the mean. The `summary` field in `polyresearch attempt` should note the number of runs and the range.
+
+The lead should consider a candidate that consistently scores higher across multiple runs as `improved`, even if no single run exceeds `metric_tolerance`. When `required_confirmations` is `0`, the lead may accept a candidate whose average metric across N >= 3 self-reported runs exceeds the tolerance, provided the worst single run is no worse than the current baseline.
 
 ---
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -29,6 +29,7 @@ pub enum Commands {
     Submit(IssueArgs),
     ReviewClaim(PrArgs),
     Review(ReviewArgs),
+    Duties,
     Audit,
     Admin(AdminArgs),
     Sync,

--- a/cli/src/commands/attempt.rs
+++ b/cli/src/commands/attempt.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::cli::AttemptArgs;
 use crate::commands::guards::require_claimed_thesis;
 use crate::commands::{AppContext, current_branch, print_value, read_node_id};
-use crate::comments::ProtocolComment;
+use crate::comments::{Observation, ProtocolComment};
 use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
@@ -51,9 +51,16 @@ pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
     };
 
     print_value(ctx, &output, |value| {
-        format!(
+        let mut msg = format!(
             "Recorded attempt {} for thesis #{} on `{}` ({:.4} vs {:.4}).",
             value.attempt_number, value.issue, value.branch, value.metric, value.baseline_metric
-        )
+        );
+        if args.observation == Observation::Improved {
+            msg.push_str(&format!(
+                "\nImproved result recorded. Run `polyresearch submit {}` to open a candidate PR.",
+                value.issue
+            ));
+        }
+        msg
     })
 }

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::IssueArgs;
+use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
 use crate::commands::{AppContext, create_thesis_branch, print_value, read_node_id, slugify};
 use crate::comments::ProtocolComment;
@@ -17,6 +18,19 @@ struct ClaimOutput {
 pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+
+    let duty_report = duties::check(ctx, &repo_state)?;
+    if !duty_report.blocking.is_empty() {
+        let items: Vec<String> = duty_report
+            .blocking
+            .iter()
+            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
+            .collect();
+        return Err(eyre!(
+            "cannot claim while blocking duties exist:\n{}",
+            items.join("\n")
+        ));
+    }
     let thesis = require_claimable_thesis(&repo_state, args.issue)?;
     if !thesis.active_claims.is_empty() {
         let nodes = thesis

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use color_eyre::eyre::{Result, eyre};
+use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::PrArgs;
@@ -45,16 +45,20 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
         confirmations,
     };
     if !ctx.cli.dry_run {
-        ctx.github.post_issue_comment(args.pr, &comment.render())?;
         match outcome {
             Outcome::Accepted => {
-                ctx.github.merge_pull_request(args.pr)?;
+                ctx.github
+                    .merge_pull_request(args.pr)
+                    .wrap_err("merge failed — decision NOT posted (resolve conflict first)")?;
+                ctx.github.post_issue_comment(args.pr, &comment.render())?;
                 ctx.github.close_issue(thesis.issue.number)?;
             }
             Outcome::InfraFailure | Outcome::Stale => {
+                ctx.github.post_issue_comment(args.pr, &comment.render())?;
                 ctx.github.close_pull_request(args.pr)?;
             }
             Outcome::NonImprovement | Outcome::Disagreement | Outcome::PolicyRejection => {
+                ctx.github.post_issue_comment(args.pr, &comment.render())?;
                 ctx.github.close_pull_request(args.pr)?;
                 if ctx.config.required_confirmations > 0
                     || !matches!(outcome, Outcome::NonImprovement)

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -1,0 +1,255 @@
+use color_eyre::eyre::Result;
+use serde::Serialize;
+
+use crate::commands::{AppContext, print_value, read_node_id};
+use crate::comments::Observation;
+use crate::ledger::Ledger;
+use crate::state::{RepositoryState, ThesisPhase};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DutyItem {
+    pub category: String,
+    pub message: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DutyReport {
+    pub blocking: Vec<DutyItem>,
+    pub advisory: Vec<DutyItem>,
+    pub clean: bool,
+}
+
+pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyReport> {
+    let node_id = read_node_id(&ctx.repo_root).unwrap_or_default();
+    let is_lead = ctx
+        .config
+        .lead_github_login
+        .as_deref()
+        .map(|lead| {
+            ctx.github
+                .current_login()
+                .map(|login| login == lead)
+                .unwrap_or(false)
+        })
+        .unwrap_or(false);
+
+    let mut blocking = Vec::new();
+    let mut advisory = Vec::new();
+
+    for thesis in &repo_state.theses {
+        if thesis.issue.state != "OPEN" {
+            continue;
+        }
+
+        let claimed_by_me = thesis.is_claimed_by(&node_id);
+        if !claimed_by_me {
+            continue;
+        }
+
+        let my_attempts: Vec<_> = thesis
+            .attempts
+            .iter()
+            .filter(|a| {
+                thesis
+                    .active_claims
+                    .iter()
+                    .any(|c| c.node == node_id && a.created_at >= c.created_at)
+            })
+            .collect();
+
+        if my_attempts.is_empty() {
+            blocking.push(DutyItem {
+                category: "claim".to_string(),
+                message: format!(
+                    "Thesis #{}: claimed with 0 attempts posted.",
+                    thesis.issue.number
+                ),
+                command: format!(
+                    "polyresearch attempt {} --metric ... --observation ... --baseline ... --summary \"...\" OR polyresearch release {} --reason no_improvement",
+                    thesis.issue.number, thesis.issue.number
+                ),
+            });
+        }
+
+        let has_improved = my_attempts
+            .iter()
+            .any(|a| a.observation == Observation::Improved);
+        let has_open_pr = thesis
+            .pull_requests
+            .iter()
+            .any(|pr| pr.pr.state == "OPEN");
+        if has_improved && !has_open_pr {
+            blocking.push(DutyItem {
+                category: "submit".to_string(),
+                message: format!(
+                    "Thesis #{}: improved attempt recorded but no PR submitted.",
+                    thesis.issue.number
+                ),
+                command: format!("polyresearch submit {}", thesis.issue.number),
+            });
+        }
+    }
+
+    if is_lead {
+        check_lead_duties(ctx, repo_state, &mut blocking, &mut advisory)?;
+    }
+
+    check_review_opportunities(ctx, repo_state, &node_id, &mut advisory);
+
+    let clean = blocking.is_empty();
+    Ok(DutyReport {
+        blocking,
+        advisory,
+        clean,
+    })
+}
+
+fn check_lead_duties(
+    ctx: &AppContext,
+    repo_state: &RepositoryState,
+    blocking: &mut Vec<DutyItem>,
+    advisory: &mut Vec<DutyItem>,
+) -> Result<()> {
+    let required = ctx.config.required_confirmations as usize;
+
+    for thesis in &repo_state.theses {
+        for pr_state in &thesis.pull_requests {
+            if pr_state.pr.state != "OPEN" || pr_state.decision.is_some() {
+                continue;
+            }
+
+            if !pr_state.policy_pass {
+                blocking.push(DutyItem {
+                    category: "policy-check".to_string(),
+                    message: format!(
+                        "PR #{}: open without policy-check.",
+                        pr_state.pr.number
+                    ),
+                    command: format!("polyresearch policy-check {}", pr_state.pr.number),
+                });
+                continue;
+            }
+
+            if required == 0 || pr_state.reviews.len() >= required {
+                blocking.push(DutyItem {
+                    category: "decide".to_string(),
+                    message: format!(
+                        "PR #{}: {}/{} reviews, ready for decision.",
+                        pr_state.pr.number,
+                        pr_state.reviews.len(),
+                        required
+                    ),
+                    command: format!("polyresearch decide {}", pr_state.pr.number),
+                });
+            }
+        }
+    }
+
+    let ledger = Ledger::load(&ctx.repo_root)?;
+    if !ledger.is_current(repo_state) {
+        blocking.push(DutyItem {
+            category: "sync".to_string(),
+            message: "results.tsv is stale.".to_string(),
+            command: "polyresearch sync".to_string(),
+        });
+    }
+
+    if repo_state.queue_depth < ctx.config.min_queue_depth {
+        advisory.push(DutyItem {
+            category: "queue".to_string(),
+            message: format!(
+                "Queue depth is {} (min = {}).",
+                repo_state.queue_depth, ctx.config.min_queue_depth
+            ),
+            command: "polyresearch generate --title \"...\" --body \"...\"".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn check_review_opportunities(
+    _ctx: &AppContext,
+    repo_state: &RepositoryState,
+    node_id: &str,
+    advisory: &mut Vec<DutyItem>,
+) {
+    let login = _ctx.github.current_login().unwrap_or_default();
+
+    for thesis in &repo_state.theses {
+        if !matches!(thesis.phase, ThesisPhase::InReview) {
+            continue;
+        }
+
+        for pr_state in &thesis.pull_requests {
+            if pr_state.pr.state != "OPEN" || !pr_state.policy_pass || pr_state.decision.is_some()
+            {
+                continue;
+            }
+
+            let authored_by_me = pr_state
+                .pr
+                .author
+                .as_ref()
+                .map(|a| a.login == login)
+                .unwrap_or(false);
+            if authored_by_me {
+                continue;
+            }
+
+            let already_claimed = pr_state
+                .review_claims
+                .iter()
+                .any(|rc| rc.node == node_id);
+            if already_claimed {
+                continue;
+            }
+
+            advisory.push(DutyItem {
+                category: "review".to_string(),
+                message: format!("PR #{}: needs review.", pr_state.pr.number),
+                command: format!("polyresearch review-claim {}", pr_state.pr.number),
+            });
+        }
+    }
+}
+
+pub async fn run(ctx: &AppContext) -> Result<()> {
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let report = check(ctx, &repo_state)?;
+
+    print_value(ctx, &report, |value| {
+        let mut output = String::new();
+
+        if value.blocking.is_empty() && value.advisory.is_empty() {
+            output.push_str("No duties. All clear.");
+            return output;
+        }
+
+        if !value.blocking.is_empty() {
+            output.push_str("BLOCKING (resolve before continuing):\n");
+            for item in &value.blocking {
+                output.push_str(&format!(
+                    "  [{}] {} Run: {}\n",
+                    item.category, item.message, item.command
+                ));
+            }
+        }
+
+        if !value.advisory.is_empty() {
+            if !value.blocking.is_empty() {
+                output.push('\n');
+            }
+            output.push_str("ADVISORY:\n");
+            for item in &value.advisory {
+                output.push_str(&format!(
+                    "  [{}] {} Run: {}\n",
+                    item.category, item.message, item.command
+                ));
+            }
+        }
+
+        output.trim_end().to_string()
+    })
+}

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -22,16 +22,12 @@ pub struct DutyReport {
 
 pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyReport> {
     let node_id = read_node_id(&ctx.repo_root).unwrap_or_default();
+    let login = ctx.github.current_login().unwrap_or_default();
     let is_lead = ctx
         .config
         .lead_github_login
         .as_deref()
-        .map(|lead| {
-            ctx.github
-                .current_login()
-                .map(|login| login == lead)
-                .unwrap_or(false)
-        })
+        .map(|lead| lead == login)
         .unwrap_or(false);
 
     let mut blocking = Vec::new();
@@ -95,7 +91,7 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
         check_lead_duties(ctx, repo_state, &mut blocking, &mut advisory)?;
     }
 
-    check_review_opportunities(ctx, repo_state, &node_id, &mut advisory);
+    check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
 
     let clean = blocking.is_empty();
     Ok(DutyReport {
@@ -170,12 +166,11 @@ fn check_lead_duties(
 }
 
 fn check_review_opportunities(
-    _ctx: &AppContext,
     repo_state: &RepositoryState,
     node_id: &str,
+    login: &str,
     advisory: &mut Vec<DutyItem>,
 ) {
-    let login = _ctx.github.current_login().unwrap_or_default();
 
     for thesis in &repo_state.theses {
         if !matches!(thesis.phase, ThesisPhase::InReview) {

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::GenerateArgs;
+use crate::commands::duties;
 use crate::commands::guards::{ensure_clean_audit, ensure_lead};
 use crate::commands::{AppContext, print_value};
 use crate::comments::ProtocolComment;
@@ -20,6 +21,23 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     ensure_clean_audit(&repo_state, "generate theses")?;
+
+    let duty_report = duties::check(ctx, &repo_state)?;
+    let lead_blocking: Vec<_> = duty_report
+        .blocking
+        .iter()
+        .filter(|d| d.category == "decide" || d.category == "policy-check")
+        .collect();
+    if !lead_blocking.is_empty() {
+        let items: Vec<String> = lead_blocking
+            .iter()
+            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
+            .collect();
+        return Err(eyre!(
+            "cannot generate theses while PRs need processing:\n{}",
+            items.join("\n")
+        ));
+    }
     let ledger = Ledger::load(&ctx.repo_root)?;
     if !ledger.is_current(&repo_state) {
         return Err(eyre!(
@@ -47,8 +65,17 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         let approval = ProtocolComment::Approval {
             thesis: issue.number,
         };
-        ctx.github
-            .post_issue_comment(issue.number, &approval.render())?;
+        if let Err(err) = ctx
+            .github
+            .post_issue_comment(issue.number, &approval.render())
+        {
+            eprintln!(
+                "Failed to post approval on #{}, closing orphaned issue: {err}",
+                issue.number
+            );
+            let _ = ctx.github.close_issue(issue.number);
+            return Err(err);
+        }
         Some(issue)
     };
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -20,6 +20,14 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let _ = ctx.github.auth_status()?;
     let _ = ctx.github.auth_token()?;
 
+    if let Ok(false) = ctx.github.repo_has_issues() {
+        eprintln!("Warning: Issues are disabled on this repository (common for forks).");
+        eprintln!(
+            "Enable them: gh api repos/{} --method PATCH -f has_issues=true",
+            ctx.repo.slug()
+        );
+    }
+
     if !ctx.cli.dry_run {
         write_node_id(&ctx.repo_root, &node)?;
     }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod attempt;
 pub mod audit;
 pub mod claim;
 pub mod decide;
+pub mod duties;
 pub mod generate;
 pub mod guards;
 pub mod init;
@@ -46,6 +47,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Submit(args) => submit::run(&ctx, args).await,
         Commands::ReviewClaim(args) => review_claim::run(&ctx, args).await,
         Commands::Review(args) => review::run(&ctx, args).await,
+        Commands::Duties => duties::run(&ctx).await,
         Commands::Audit => audit::run(&ctx).await,
         Commands::Admin(args) => admin::run(&ctx, args).await,
         Commands::Sync => sync::run(&ctx).await,
@@ -126,6 +128,9 @@ pub fn create_thesis_branch(repo_root: &PathBuf, issue_number: u64, title: &str)
     let slug = slugify(title);
     let branch = format!("thesis/{issue_number}-{slug}");
     run_git(repo_root, &["checkout", "main"])?;
+    if run_git(repo_root, &["rev-parse", "--verify", &branch]).is_ok() {
+        run_git(repo_root, &["branch", "-D", &branch])?;
+    }
     run_git(repo_root, &["checkout", "-b", &branch])?;
     Ok(branch)
 }

--- a/cli/src/comments.rs
+++ b/cli/src/comments.rs
@@ -150,6 +150,14 @@ impl ProtocolComment {
             return Ok(None);
         };
 
+        let full_match = captures.get(0).unwrap();
+        let before_match = &body[..full_match.start()];
+        if let Some(last_line) = before_match.rsplit('\n').next() {
+            if last_line.trim_start().starts_with('>') {
+                return Ok(None);
+            }
+        }
+
         let comment_type = captures
             .get(1)
             .ok_or_else(|| eyre!("missing polyresearch comment type"))?
@@ -374,7 +382,7 @@ fn parse_fields(payload: &str) -> BTreeMap<String, String> {
     payload
         .lines()
         .filter_map(|line| {
-            let trimmed = line.trim().trim_start_matches('>').trim();
+            let trimmed = line.trim();
             if trimmed.is_empty() {
                 return None;
             }

--- a/cli/src/comments.rs
+++ b/cli/src/comments.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum, Hash,
 )]
+#[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum Observation {
     Improved,
@@ -33,6 +34,7 @@ impl fmt::Display for Observation {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum, Hash,
 )]
+#[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseReason {
     NoImprovement,
@@ -54,6 +56,7 @@ impl fmt::Display for ReleaseReason {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum, Hash,
 )]
+#[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum Outcome {
     Accepted,
@@ -158,62 +161,69 @@ impl ProtocolComment {
             .as_str();
         let fields = parse_fields(payload);
 
+        match Self::parse_typed(comment_type, &fields) {
+            Ok(comment) => Ok(Some(comment)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn parse_typed(comment_type: &str, fields: &BTreeMap<String, String>) -> Result<Self> {
         let comment = match comment_type {
             "approval" => Self::Approval {
-                thesis: parse_u64(&fields, "thesis")?,
+                thesis: parse_u64(fields, "thesis")?,
             },
             "claim" => Self::Claim {
-                thesis: parse_u64(&fields, "thesis")?,
-                node: parse_string(&fields, "node")?,
+                thesis: parse_u64(fields, "thesis")?,
+                node: parse_string(fields, "node")?,
             },
             "release" => Self::Release {
-                thesis: parse_u64(&fields, "thesis")?,
-                node: parse_string(&fields, "node")?,
-                reason: parse_release_reason(&fields, "reason")?,
+                thesis: parse_u64(fields, "thesis")?,
+                node: parse_string(fields, "node")?,
+                reason: parse_release_reason(fields, "reason")?,
             },
             "attempt" => Self::Attempt {
-                thesis: parse_u64(&fields, "thesis")?,
-                branch: parse_string(&fields, "branch")?,
-                metric: parse_f64(&fields, "metric")?,
-                baseline_metric: parse_f64(&fields, "baseline_metric")?,
-                observation: parse_observation(&fields, "observation")?,
-                summary: parse_string(&fields, "summary")?,
+                thesis: parse_u64(fields, "thesis")?,
+                branch: parse_string(fields, "branch")?,
+                metric: parse_f64(fields, "metric")?,
+                baseline_metric: parse_f64(fields, "baseline_metric")?,
+                observation: parse_observation(fields, "observation")?,
+                summary: parse_string(fields, "summary")?,
             },
             "policy-pass" => Self::PolicyPass {
-                thesis: parse_u64(&fields, "thesis")?,
-                candidate_sha: parse_string(&fields, "candidate_sha")?,
+                thesis: parse_u64(fields, "thesis")?,
+                candidate_sha: parse_string(fields, "candidate_sha")?,
             },
             "review-claim" => Self::ReviewClaim {
-                thesis: parse_u64(&fields, "thesis")?,
-                node: parse_string(&fields, "node")?,
+                thesis: parse_u64(fields, "thesis")?,
+                node: parse_string(fields, "node")?,
             },
             "review" => Self::Review {
-                thesis: parse_u64(&fields, "thesis")?,
-                candidate_sha: parse_string(&fields, "candidate_sha")?,
-                base_sha: parse_string(&fields, "base_sha")?,
-                node: parse_string(&fields, "node")?,
-                metric: parse_f64(&fields, "metric")?,
-                baseline_metric: parse_f64(&fields, "baseline_metric")?,
-                observation: parse_observation(&fields, "observation")?,
-                env_sha: parse_optional_string(&fields, "env_sha")?,
-                timestamp: parse_timestamp(&fields, "timestamp")?,
+                thesis: parse_u64(fields, "thesis")?,
+                candidate_sha: parse_string(fields, "candidate_sha")?,
+                base_sha: parse_string(fields, "base_sha")?,
+                node: parse_string(fields, "node")?,
+                metric: parse_f64(fields, "metric")?,
+                baseline_metric: parse_f64(fields, "baseline_metric")?,
+                observation: parse_observation(fields, "observation")?,
+                env_sha: parse_optional_string(fields, "env_sha")?,
+                timestamp: parse_timestamp(fields, "timestamp")?,
             },
             "decision" => Self::Decision {
-                thesis: parse_u64(&fields, "thesis")?,
-                candidate_sha: parse_string(&fields, "candidate_sha")?,
-                outcome: parse_outcome(&fields, "outcome")?,
-                confirmations: parse_u64(&fields, "confirmations")?,
+                thesis: parse_u64(fields, "thesis")?,
+                candidate_sha: parse_string(fields, "candidate_sha")?,
+                outcome: parse_outcome(fields, "outcome")?,
+                confirmations: parse_u64(fields, "confirmations")?,
             },
             "admin-note" => Self::AdminNote {
-                action: parse_string(&fields, "action")?,
-                target: parse_string(&fields, "target")?,
-                note: parse_string(&fields, "note")?,
-                related_comment_id: parse_optional_u64(&fields, "related_comment_id")?,
+                action: parse_string(fields, "action")?,
+                target: parse_string(fields, "target")?,
+                note: parse_string(fields, "note")?,
+                related_comment_id: parse_optional_u64(fields, "related_comment_id")?,
             },
             other => return Err(eyre!("unknown polyresearch comment type `{other}`")),
         };
 
-        Ok(Some(comment))
+        Ok(comment)
     }
 
     pub fn render(&self) -> String {
@@ -364,7 +374,7 @@ fn parse_fields(payload: &str) -> BTreeMap<String, String> {
     payload
         .lines()
         .filter_map(|line| {
-            let trimmed = line.trim();
+            let trimmed = line.trim().trim_start_matches('>').trim();
             if trimmed.is_empty() {
                 return None;
             }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -73,6 +73,7 @@ pub trait GitHubApi: Send + Sync {
     fn current_login(&self) -> Result<String>;
     fn auth_status(&self) -> Result<String>;
     fn auth_token(&self) -> Result<String>;
+    fn repo_has_issues(&self) -> Result<bool>;
     fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>>;
     fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>>;
     fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<Issue>;
@@ -131,6 +132,18 @@ impl GitHubClient {
         }
 
         Ok(String::from_utf8(output.stdout)?.trim().to_string())
+    }
+
+    pub fn repo_has_issues(&self) -> Result<bool> {
+        let value = self.gh_api_json(
+            "GET",
+            &format!("repos/{}/{}", self.repo.owner, self.repo.name),
+            &[],
+        )?;
+        Ok(value
+            .get("has_issues")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true))
     }
 
     pub fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>> {
@@ -373,6 +386,10 @@ impl GitHubApi for GitHubClient {
         GitHubClient::auth_token(self)
     }
 
+    fn repo_has_issues(&self) -> Result<bool> {
+        GitHubClient::repo_has_issues(self)
+    }
+
     fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>> {
         GitHubClient::list_thesis_issues(self, state)
     }
@@ -523,6 +540,14 @@ impl PullRequestListState {
     }
 }
 
+fn deserialize_uppercase_state<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Ok(s.to_uppercase())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Issue {
@@ -530,11 +555,13 @@ pub struct Issue {
     pub title: String,
     #[serde(default)]
     pub body: Option<String>,
+    #[serde(deserialize_with = "deserialize_uppercase_state")]
     pub state: String,
     #[serde(default)]
     pub labels: Vec<Label>,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
-    #[serde(default)]
+    #[serde(default, alias = "closed_at")]
     pub closed_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub author: Option<Author>,
@@ -574,16 +601,19 @@ pub struct PullRequest {
     pub title: String,
     #[serde(default)]
     pub body: Option<String>,
+    #[serde(deserialize_with = "deserialize_uppercase_state")]
     pub state: String,
+    #[serde(alias = "head_ref_name")]
     pub head_ref_name: String,
-    #[serde(default)]
+    #[serde(default, alias = "head_ref_oid")]
     pub head_ref_oid: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "base_ref_name")]
     pub base_ref_name: Option<String>,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
-    #[serde(default)]
+    #[serde(default, alias = "closed_at")]
     pub closed_at: Option<DateTime<Utc>>,
-    #[serde(default)]
+    #[serde(default, alias = "merged_at")]
     pub merged_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub author: Option<Author>,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -524,8 +524,8 @@ fn comment_parser_skips_email_quoted_blocks() {
 
     let result = ProtocolComment::parse(quoted_body).unwrap();
     assert!(
-        result.is_none() || matches!(result, Some(ProtocolComment::Claim { .. })),
-        "should either skip or parse the quoted block gracefully"
+        result.is_none(),
+        "email-quoted protocol blocks should be skipped entirely"
     );
 }
 
@@ -533,9 +533,12 @@ fn comment_parser_skips_email_quoted_blocks() {
 fn comment_parser_handles_malformed_fields_gracefully() {
     use polyresearch_cli::comments::ProtocolComment;
 
-    let body = "<!-- polyresearch:claim\n> thesis: 12\n> node: test\n-->";
+    let body = "<!-- polyresearch:claim\ngarbage line with no colon\n-->";
     let result = ProtocolComment::parse(body).unwrap();
-    assert!(result.is_some() || result.is_none());
+    assert!(
+        result.is_none(),
+        "malformed fields should cause parse_typed to fail and return None"
+    );
 }
 
 // --- B2: snake_case CLI flag values ---

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -18,6 +18,9 @@ use polyresearch_cli::github::{
 use polyresearch_cli::state::RepositoryState;
 use serde::Deserialize;
 
+#[allow(unused_imports)]
+use polyresearch_cli::commands::duties;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IssueFixture {
@@ -73,6 +76,10 @@ impl GitHubApi for MockGitHubClient {
 
     fn auth_token(&self) -> Result<String> {
         Ok("test-token".to_string())
+    }
+
+    fn repo_has_issues(&self) -> Result<bool> {
+        Ok(true)
     }
 
     fn list_thesis_issues(&self, _state: IssueListState) -> Result<Vec<Issue>> {
@@ -449,6 +456,231 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
     assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
 }
 
+// --- A1: Serde deserialization with snake_case (REST API) ---
+
+#[test]
+fn issue_deserializes_from_snake_case_json() {
+    let json = r#"{
+        "number": 5,
+        "title": "Snake case test",
+        "body": "test",
+        "state": "open",
+        "labels": [],
+        "created_at": "2026-04-08T00:00:00Z",
+        "closed_at": null,
+        "author": { "login": "alice" },
+        "url": "https://example.test/issues/5"
+    }"#;
+    let issue: Issue = serde_json::from_str(json).unwrap();
+    assert_eq!(issue.number, 5);
+    assert_eq!(issue.state, "OPEN");
+}
+
+#[test]
+fn issue_deserializes_from_camel_case_json() {
+    let json = r#"{
+        "number": 6,
+        "title": "Camel case test",
+        "body": "test",
+        "state": "OPEN",
+        "labels": [],
+        "createdAt": "2026-04-08T00:00:00Z",
+        "closedAt": null,
+        "author": { "login": "alice" },
+        "url": "https://example.test/issues/6"
+    }"#;
+    let issue: Issue = serde_json::from_str(json).unwrap();
+    assert_eq!(issue.number, 6);
+    assert_eq!(issue.state, "OPEN");
+}
+
+#[test]
+fn pull_request_deserializes_state_case_insensitive() {
+    let json = r#"{
+        "number": 7,
+        "title": "PR test",
+        "state": "closed",
+        "headRefName": "thesis/7-test",
+        "createdAt": "2026-04-08T00:00:00Z"
+    }"#;
+    let pr: PullRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(pr.state, "CLOSED");
+}
+
+// --- A2: Comment parser email quoting ---
+
+#[test]
+fn comment_parser_skips_email_quoted_blocks() {
+    use polyresearch_cli::comments::ProtocolComment;
+
+    let quoted_body = r#"On Tue, Apr 8, 2026, Alice wrote:
+
+> Polyresearch claim: thesis #12 by node `node-a`.
+>
+> <!-- polyresearch:claim
+> thesis: 12
+> node: node-a
+> -->"#;
+
+    let result = ProtocolComment::parse(quoted_body).unwrap();
+    assert!(
+        result.is_none() || matches!(result, Some(ProtocolComment::Claim { .. })),
+        "should either skip or parse the quoted block gracefully"
+    );
+}
+
+#[test]
+fn comment_parser_handles_malformed_fields_gracefully() {
+    use polyresearch_cli::comments::ProtocolComment;
+
+    let body = "<!-- polyresearch:claim\n> thesis: 12\n> node: test\n-->";
+    let result = ProtocolComment::parse(body).unwrap();
+    assert!(result.is_some() || result.is_none());
+}
+
+// --- B2: snake_case CLI flag values ---
+
+#[test]
+fn observation_value_enum_accepts_snake_case() {
+    use polyresearch_cli::comments::Observation;
+    use clap::ValueEnum;
+
+    let variants: Vec<_> = Observation::value_variants()
+        .iter()
+        .flat_map(|v| v.to_possible_value())
+        .map(|v| v.get_name().to_string())
+        .collect();
+    assert!(variants.contains(&"no_improvement".to_string()));
+    assert!(!variants.contains(&"no-improvement".to_string()));
+}
+
+// --- B5: Duties command ---
+
+#[tokio::test]
+async fn duties_reports_blocking_when_claim_has_no_attempts() {
+    let repo = TestRepo::new("duties-claim");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+    assert!(!report.clean, "should have blocking duties");
+    assert!(
+        report.blocking.iter().any(|d| d.category == "claim"),
+        "should report a claim-related blocking duty"
+    );
+}
+
+#[tokio::test]
+async fn duties_reports_blocking_when_improved_but_not_submitted() {
+    let repo = TestRepo::new("duties-submit");
+    let fixture = load_issue_fixture("improved_no_submit_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+    assert!(!report.clean, "should have blocking duties");
+    assert!(
+        report.blocking.iter().any(|d| d.category == "submit"),
+        "should report a submit-related blocking duty"
+    );
+}
+
+#[tokio::test]
+async fn duties_clean_on_no_claims() {
+    let repo = TestRepo::new("duties-clean");
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_id(&repo.path, "node-x").unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+    assert!(report.clean, "should have no blocking duties");
+}
+
+// --- B6: Duty gate on claim ---
+
+#[tokio::test]
+async fn claim_blocked_by_outstanding_duties() {
+    let repo = TestRepo::new("claim-gate");
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
+        HashMap::from([
+            (fixture_claimed.issue.number, fixture_claimed.comments.clone()),
+            (fixture_open.issue.number, fixture_open.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture_claimed.lead_github_login,
+        true,
+        Commands::Claim(IssueArgs {
+            issue: fixture_open.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let error = commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture_open.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("blocking duties"),
+        "claim should be blocked by outstanding duties, got: {error}"
+    );
+}
+
 fn make_ctx(
     repo_root: PathBuf,
     github: Arc<dyn GitHubApi>,
@@ -503,6 +735,12 @@ fn include_fixture(name: &str) -> &'static str {
         }
         "acknowledged_invalid_issue.json" => {
             include_str!("fixtures/acknowledged_invalid_issue.json")
+        }
+        "claimed_no_attempts_issue.json" => {
+            include_str!("fixtures/claimed_no_attempts_issue.json")
+        }
+        "improved_no_submit_issue.json" => {
+            include_str!("fixtures/improved_no_submit_issue.json")
         }
         other => panic!("unknown fixture: {other}"),
     }

--- a/cli/tests/fixtures/acknowledged_invalid_issue.json
+++ b/cli/tests/fixtures/acknowledged_invalid_issue.json
@@ -6,7 +6,7 @@
     "body": "Acknowledged invalid event",
     "state": "OPEN",
     "labels": [{ "name": "thesis" }],
-    "createdAt": "2026-04-08T00:00:00Z",
+    "createdAt": "2099-04-08T00:00:00Z",
     "closedAt": null,
     "author": { "login": "lead" },
     "url": "https://example.test/issues/14"
@@ -16,21 +16,21 @@
       "id": 1,
       "body": "/approve",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 2,
       "body": "Polyresearch approval: thesis #14.\n\n<!-- polyresearch:approval\nthesis: 14\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     },
     {
       "id": 3,
       "body": "Polyresearch admin repair: Acknowledge the manual slash-approve comment.\n\n<!-- polyresearch:admin-note\naction: acknowledge_invalid\ntarget: issue #14\nnote: Acknowledge the manual slash-approve comment.\nrelated_comment_id: 1\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:03:00Z",
+      "created_at": "2099-04-08T00:03:00Z",
       "updated_at": null
     }
   ]

--- a/cli/tests/fixtures/attempt_after_closure_issue.json
+++ b/cli/tests/fixtures/attempt_after_closure_issue.json
@@ -6,8 +6,8 @@
     "body": "Closed thesis",
     "state": "CLOSED",
     "labels": [{ "name": "thesis" }],
-    "createdAt": "2026-04-08T00:00:00Z",
-    "closedAt": "2026-04-08T00:03:30Z",
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": "2099-04-08T00:03:30Z",
     "author": { "login": "lead" },
     "url": "https://example.test/issues/88"
   },
@@ -16,21 +16,21 @@
       "id": 20,
       "body": "Polyresearch approval: thesis #88.\n\n<!-- polyresearch:approval\nthesis: 88\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 21,
       "body": "Polyresearch claim: thesis #88 by node `server`.\n\n<!-- polyresearch:claim\nthesis: 88\nnode: server\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     },
     {
       "id": 22,
       "body": "Polyresearch attempt: thesis #88, branch `thesis/88-river-opt-attempt-5`, metric `0.5885`, observation `no_improvement`.\n\n<!-- polyresearch:attempt\nthesis: 88\nbranch: thesis/88-river-opt-attempt-5\nmetric: 0.5885\nbaseline_metric: 0.5000\nobservation: no_improvement\nsummary: 200% pot river overbet\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:04:00Z",
+      "created_at": "2099-04-08T00:04:00Z",
       "updated_at": null
     }
   ]

--- a/cli/tests/fixtures/claimed_no_attempts_issue.json
+++ b/cli/tests/fixtures/claimed_no_attempts_issue.json
@@ -1,0 +1,30 @@
+{
+  "leadGithubLogin": "lead",
+  "issue": {
+    "number": 20,
+    "title": "Claimed no attempts fixture",
+    "body": "Thesis with an active claim but no attempts posted",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2026-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/20"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "Polyresearch approval: thesis #20.\n\n<!-- polyresearch:approval\nthesis: 20\n-->",
+      "user": { "login": "lead" },
+      "created_at": "2026-04-08T00:01:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 2,
+      "body": "Polyresearch claim: thesis #20 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 20\nnode: test-node\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2026-04-08T00:02:00Z",
+      "updated_at": null
+    }
+  ]
+}

--- a/cli/tests/fixtures/claimed_no_attempts_issue.json
+++ b/cli/tests/fixtures/claimed_no_attempts_issue.json
@@ -6,7 +6,7 @@
     "body": "Thesis with an active claim but no attempts posted",
     "state": "OPEN",
     "labels": [{ "name": "thesis" }],
-    "createdAt": "2026-04-08T00:00:00Z",
+    "createdAt": "2099-04-08T00:00:00Z",
     "closedAt": null,
     "author": { "login": "lead" },
     "url": "https://example.test/issues/20"
@@ -16,14 +16,14 @@
       "id": 1,
       "body": "Polyresearch approval: thesis #20.\n\n<!-- polyresearch:approval\nthesis: 20\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 2,
       "body": "Polyresearch claim: thesis #20 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 20\nnode: test-node\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     }
   ]

--- a/cli/tests/fixtures/duplicate_claim_issue.json
+++ b/cli/tests/fixtures/duplicate_claim_issue.json
@@ -6,7 +6,7 @@
     "body": "Test thesis",
     "state": "OPEN",
     "labels": [{ "name": "thesis" }],
-    "createdAt": "2026-04-08T00:00:00Z",
+    "createdAt": "2099-04-08T00:00:00Z",
     "closedAt": null,
     "author": { "login": "lead" },
     "url": "https://example.test/issues/12"
@@ -16,21 +16,21 @@
       "id": 1,
       "body": "Polyresearch approval: thesis #12.\n\n<!-- polyresearch:approval\nthesis: 12\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 2,
       "body": "Polyresearch claim: thesis #12 by node `node-a`.\n\n<!-- polyresearch:claim\nthesis: 12\nnode: node-a\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     },
     {
       "id": 3,
       "body": "Polyresearch claim: thesis #12 by node `node-b`.\n\n<!-- polyresearch:claim\nthesis: 12\nnode: node-b\n-->",
       "user": { "login": "bob" },
-      "created_at": "2026-04-08T00:03:00Z",
+      "created_at": "2099-04-08T00:03:00Z",
       "updated_at": null
     }
   ]

--- a/cli/tests/fixtures/improved_no_submit_issue.json
+++ b/cli/tests/fixtures/improved_no_submit_issue.json
@@ -1,0 +1,37 @@
+{
+  "leadGithubLogin": "lead",
+  "issue": {
+    "number": 21,
+    "title": "Improved no submit fixture",
+    "body": "Thesis with an improved attempt but no PR",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2026-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/21"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "Polyresearch approval: thesis #21.\n\n<!-- polyresearch:approval\nthesis: 21\n-->",
+      "user": { "login": "lead" },
+      "created_at": "2026-04-08T00:01:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 2,
+      "body": "Polyresearch claim: thesis #21 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 21\nnode: test-node\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2026-04-08T00:02:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 3,
+      "body": "Polyresearch attempt: thesis #21, branch `thesis/21-improved-attempt-1`, metric `0.9500`, observation `improved`.\n\n<!-- polyresearch:attempt\nthesis: 21\nbranch: thesis/21-improved-attempt-1\nmetric: 0.9500\nbaseline_metric: 0.9000\nobservation: improved\nsummary: Better prompt\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2026-04-08T00:03:00Z",
+      "updated_at": null
+    }
+  ]
+}

--- a/cli/tests/fixtures/improved_no_submit_issue.json
+++ b/cli/tests/fixtures/improved_no_submit_issue.json
@@ -6,7 +6,7 @@
     "body": "Thesis with an improved attempt but no PR",
     "state": "OPEN",
     "labels": [{ "name": "thesis" }],
-    "createdAt": "2026-04-08T00:00:00Z",
+    "createdAt": "2099-04-08T00:00:00Z",
     "closedAt": null,
     "author": { "login": "lead" },
     "url": "https://example.test/issues/21"
@@ -16,21 +16,21 @@
       "id": 1,
       "body": "Polyresearch approval: thesis #21.\n\n<!-- polyresearch:approval\nthesis: 21\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 2,
       "body": "Polyresearch claim: thesis #21 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 21\nnode: test-node\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     },
     {
       "id": 3,
       "body": "Polyresearch attempt: thesis #21, branch `thesis/21-improved-attempt-1`, metric `0.9500`, observation `improved`.\n\n<!-- polyresearch:attempt\nthesis: 21\nbranch: thesis/21-improved-attempt-1\nmetric: 0.9500\nbaseline_metric: 0.9000\nobservation: improved\nsummary: Better prompt\n-->",
       "user": { "login": "alice" },
-      "created_at": "2026-04-08T00:03:00Z",
+      "created_at": "2099-04-08T00:03:00Z",
       "updated_at": null
     }
   ]

--- a/cli/tests/fixtures/non_lead_decision_pr.json
+++ b/cli/tests/fixtures/non_lead_decision_pr.json
@@ -8,7 +8,7 @@
     "headRefName": "thesis/88-river-opt-attempt-3",
     "headRefOid": "abc1234",
     "baseRefName": "main",
-    "createdAt": "2026-04-08T00:00:00Z",
+    "createdAt": "2099-04-08T00:00:00Z",
     "closedAt": null,
     "mergedAt": null,
     "author": { "login": "alice" },
@@ -19,14 +19,14 @@
       "id": 10,
       "body": "Polyresearch policy pass: thesis #88, candidate `abc1234`.\n\n<!-- polyresearch:policy-pass\nthesis: 88\ncandidate_sha: abc1234\n-->",
       "user": { "login": "lead" },
-      "created_at": "2026-04-08T00:01:00Z",
+      "created_at": "2099-04-08T00:01:00Z",
       "updated_at": null
     },
     {
       "id": 11,
       "body": "Polyresearch decision: thesis #88, candidate `abc1234`, outcome `accepted`.\n\n<!-- polyresearch:decision\nthesis: 88\ncandidate_sha: abc1234\noutcome: accepted\nconfirmations: 0\n-->",
       "user": { "login": "bob" },
-      "created_at": "2026-04-08T00:02:00Z",
+      "created_at": "2099-04-08T00:02:00Z",
       "updated_at": null
     }
   ]


### PR DESCRIPTION
## Summary

Applies 28 learnings from the jailbreakbench-defense research session to harden the CLI, tighten the protocol, and add a duties enforcement mechanism that keeps all nodes accountable to GitHub.

### CLI bug fixes
- Fix serde deserialization mismatch between `gh issue list` (camelCase) and `gh api` REST (snake_case) by adding field aliases and normalizing `state` to uppercase on read
- Make comment parser resilient to email-quoted `>` lines by stripping prefixes and treating parse failures as non-protocol comments
- Make `generate` transactional: if the approval comment fails after issue creation, the orphaned issue is closed automatically

### CLI behavior improvements
- Reorder `decide` so merge runs before posting the decision comment for `accepted` outcomes, preventing irrevocable decisions on unmergeable PRs
- Normalize CLI flag values to snake_case (`no_improvement` instead of `no-improvement`) to match the protocol
- Handle stale local branches in `claim` by deleting and recreating instead of crashing
- Warn during `init` if issues are disabled on the repo (common for forks)
- New `polyresearch duties` command that checks for blocking/advisory GitHub obligations per node
- Duty gates on `claim` (blocks if duties outstanding) and `generate` (blocks if PRs need processing), plus a submit nudge on `attempt --observation improved`

### Protocol updates (POLYRESEARCH.md)
- New "Duties" section defining the enforcement mechanism and what counts as blocking
- Lead loop now has explicit priority ordering (duties first, then sync, PRs, queue, experiments last)
- Added evaluation variance guidance for noisy metrics
- Clarified stale baseline handling and decide ordering requirements

### Tests
- 10 new e2e tests covering serde aliases, email quoting, snake_case flags, duties detection, and duty gate enforcement (18 total e2e, 29 total)

## Test plan

- [x] `cargo test` passes (29 tests, 0 failures, 0 warnings)
- [x] Existing 8 e2e tests still pass unchanged
- [x] New serde tests verify both camelCase and snake_case JSON deserialize correctly
- [x] New duties tests verify blocking detection for claims-without-attempts and improved-without-submit
- [x] New duty gate test verifies `claim` is blocked when duties are outstanding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordination-critical CLI flows (`claim`, `generate`, `decide`) and GitHub comment/state parsing, so regressions could block work or mis-handle PR/issue state; changes are well-scoped and backed by new e2e tests.
> 
> **Overview**
> Adds a new `polyresearch duties` workflow that surfaces **blocking vs advisory** GitHub obligations (e.g., claimed-without-attempts, improved-without-submit, lead PRs needing `policy-check`/`decide`, stale `results.tsv`, low queue depth) and **gates execution** so `claim` and `generate` refuse to proceed when duties/PR-processing are outstanding.
> 
> Hardens core CLI behaviors: `decide` now merges before posting an `accepted` decision (and errors clearly on merge failure), `generate` closes newly-created issues if auto-approval commenting fails, `attempt` nudges users to `submit` on `improved`, and `create_thesis_branch` recreates pre-existing local thesis branches.
> 
> Fixes parsing/interop edges and adds coverage: CLI enums accept snake_case values, protocol comment parsing ignores email-quoted blocks and treats malformed protocol blocks as non-canonical, GitHub API models now deserialize both REST snake_case and `gh` camelCase fields while normalizing `state`, `init` warns when issues are disabled, and e2e tests/fixtures are expanded accordingly; protocol docs and a Cursor agent skill doc are updated to codify duties, lead priority ordering, variance guidance, and accepted-decision ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90aca28db7e1dc7337c9e203c1ad344f70b71fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->