### PR TITLE
Fix zombie theses inflating queue depth after no_improvement release

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -223,8 +223,8 @@ Submitted → Approved → Claimed → Experimenting ─┬→ CandidateSubmitte
      │                                           │                                  ├→ ClosedDisagreement
      │                                           │                                  └→ ClosedStale
      │                                           │
-     │                                           ├→ Released (returns to Approved)
-     │                                           └→ TimedOut (returns to Approved)
+     │                                           ├→ ReleasedNoImprovement → Exhausted
+     │                                           └→ ReleasedTimeoutOrInfra (returns to Approved)
      │
      └→ Rejected (maintainer closes issue)
 ```
@@ -236,11 +236,14 @@ Scan the comment trail on the issue to reconstruct the current state:
 - Issue exists with `thesis` label → **Submitted**
 - Has a `/approve` comment or a `polyresearch:approval` comment → **Approved**
 - Has a `polyresearch:claim` with no subsequent `polyresearch:release` for the same node → **Claimed**
+- Is approved, has no active claim or open PR, and has a `polyresearch:release` with `reason: no_improvement` → **Exhausted**
 - Claimed and has an open PR from a thesis branch → **CandidateSubmitted**
 - PR has a `polyresearch:policy-pass` comment → **InReview**
 - PR has a `polyresearch:decision` comment → **Resolved** (check `outcome` for terminal state)
 
 No mutable labels to get out of sync. The comment trail is the truth.
+
+Exhausted theses stay open for history, but they are not claimable and do not count toward queue depth.
 
 ---
 

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -71,10 +71,7 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
         let has_improved = my_attempts
             .iter()
             .any(|a| a.observation == Observation::Improved);
-        let has_open_pr = thesis
-            .pull_requests
-            .iter()
-            .any(|pr| pr.pr.state == "OPEN");
+        let has_open_pr = thesis.pull_requests.iter().any(|pr| pr.pr.state == "OPEN");
         if has_improved && !has_open_pr {
             blocking.push(DutyItem {
                 category: "submit".to_string(),
@@ -118,10 +115,7 @@ fn check_lead_duties(
             if !pr_state.policy_pass {
                 blocking.push(DutyItem {
                     category: "policy-check".to_string(),
-                    message: format!(
-                        "PR #{}: open without policy-check.",
-                        pr_state.pr.number
-                    ),
+                    message: format!("PR #{}: open without policy-check.", pr_state.pr.number),
                     command: format!("polyresearch policy-check {}", pr_state.pr.number),
                 });
                 continue;
@@ -171,15 +165,13 @@ fn check_review_opportunities(
     login: &str,
     advisory: &mut Vec<DutyItem>,
 ) {
-
     for thesis in &repo_state.theses {
         if !matches!(thesis.phase, ThesisPhase::InReview) {
             continue;
         }
 
         for pr_state in &thesis.pull_requests {
-            if pr_state.pr.state != "OPEN" || !pr_state.policy_pass || pr_state.decision.is_some()
-            {
+            if pr_state.pr.state != "OPEN" || !pr_state.policy_pass || pr_state.decision.is_some() {
                 continue;
             }
 
@@ -193,10 +185,7 @@ fn check_review_opportunities(
                 continue;
             }
 
-            let already_claimed = pr_state
-                .review_claims
-                .iter()
-                .any(|rc| rc.node == node_id);
+            let already_claimed = pr_state.review_claims.iter().any(|rc| rc.node == node_id);
             if already_claimed {
                 continue;
             }

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -38,6 +38,7 @@ pub struct ThesisState {
 pub enum ThesisPhase {
     Submitted,
     Approved,
+    Exhausted,
     Claimed,
     CandidateSubmitted,
     InReview,
@@ -147,12 +148,7 @@ impl RepositoryState {
             .into_iter()
             .collect::<Vec<_>>();
 
-        let queue_depth = theses
-            .iter()
-            .filter(|thesis| {
-                thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
-            })
-            .count();
+        let queue_depth = count_queue_depth(&theses);
 
         let current_best_accepted_metric = theses
             .iter()
@@ -280,6 +276,12 @@ impl ThesisState {
             ThesisPhase::CandidateSubmitted
         } else if !active_claims.is_empty() {
             ThesisPhase::Claimed
+        } else if approved
+            && releases
+                .iter()
+                .any(|release| release.reason == ReleaseReason::NoImprovement)
+        {
+            ThesisPhase::Exhausted
         } else if approved {
             ThesisPhase::Approved
         } else if issue.state == "CLOSED" {
@@ -444,6 +446,15 @@ pub fn select_metric(current: Option<f64>, candidate: f64, direction: MetricDire
     }
 }
 
+fn count_queue_depth(theses: &[ThesisState]) -> usize {
+    theses
+        .iter()
+        .filter(|thesis| {
+            thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
+        })
+        .count()
+}
+
 pub fn metric_beats(a: f64, b: f64, tolerance: f64, direction: MetricDirection) -> bool {
     match direction {
         MetricDirection::HigherIsBetter => a > b + tolerance,
@@ -453,6 +464,17 @@ pub fn metric_beats(a: f64, b: f64, tolerance: f64, direction: MetricDirection) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{MetricDirection, ProtocolConfig};
+    use crate::github::{Issue, IssueComment};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct IssueFixture {
+        lead_github_login: String,
+        issue: Issue,
+        comments: Vec<IssueComment>,
+    }
 
     #[test]
     fn parses_thesis_number_from_branch_name() {
@@ -477,5 +499,57 @@ mod tests {
             0.01,
             MetricDirection::HigherIsBetter
         ));
+    }
+
+    #[test]
+    fn marks_no_improvement_releases_as_exhausted() {
+        let fixture = exhausted_fixture();
+        let config = test_config(&fixture.lead_github_login);
+        let thesis = ThesisState::derive(fixture.issue, fixture.comments, &[], &config).unwrap();
+
+        assert!(matches!(thesis.phase, ThesisPhase::Exhausted));
+    }
+
+    #[test]
+    fn queue_depth_excludes_exhausted_theses() {
+        let fixture = exhausted_fixture();
+        let config = test_config(&fixture.lead_github_login);
+        let exhausted = ThesisState::derive(
+            fixture.issue.clone(),
+            fixture.comments.clone(),
+            &[],
+            &config,
+        )
+        .unwrap();
+        let approved = ThesisState::derive(
+            fixture.issue,
+            fixture.comments.into_iter().take(1).collect(),
+            &[],
+            &config,
+        )
+        .unwrap();
+
+        assert!(matches!(approved.phase, ThesisPhase::Approved));
+        assert_eq!(count_queue_depth(&[exhausted, approved]), 1);
+    }
+
+    fn exhausted_fixture() -> IssueFixture {
+        serde_json::from_str(include_str!(
+            "../tests/fixtures/exhausted_thesis_issue.json"
+        ))
+        .unwrap()
+    }
+
+    fn test_config(lead_github_login: &str) -> ProtocolConfig {
+        ProtocolConfig {
+            required_confirmations: 0,
+            metric_tolerance: Some(0.01),
+            metric_direction: MetricDirection::HigherIsBetter,
+            lead_github_login: Some(lead_github_login.to_string()),
+            assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
+            review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
+            min_queue_depth: 5,
+            max_queue_depth: Some(10),
+        }
     }
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -545,8 +545,8 @@ fn comment_parser_handles_malformed_fields_gracefully() {
 
 #[test]
 fn observation_value_enum_accepts_snake_case() {
-    use polyresearch_cli::comments::Observation;
     use clap::ValueEnum;
+    use polyresearch_cli::comments::Observation;
 
     let variants: Vec<_> = Observation::value_variants()
         .iter()
@@ -579,7 +579,9 @@ async fn duties_reports_blocking_when_claim_has_no_attempts() {
     );
     commands::write_node_id(&repo.path, "test-node").unwrap();
 
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
     assert!(!report.clean, "should have blocking duties");
     assert!(
@@ -608,7 +610,9 @@ async fn duties_reports_blocking_when_improved_but_not_submitted() {
     );
     commands::write_node_id(&repo.path, "test-node").unwrap();
 
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
     assert!(!report.clean, "should have blocking duties");
     assert!(
@@ -637,7 +641,9 @@ async fn duties_clean_on_no_claims() {
     );
     commands::write_node_id(&repo.path, "node-x").unwrap();
 
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await.unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
     assert!(report.clean, "should have no blocking duties");
 }
@@ -653,7 +659,10 @@ async fn claim_blocked_by_outstanding_duties() {
         "alice",
         vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
         HashMap::from([
-            (fixture_claimed.issue.number, fixture_claimed.comments.clone()),
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
             (fixture_open.issue.number, fixture_open.comments.clone()),
         ]),
         vec![],

--- a/cli/tests/fixtures/exhausted_thesis_issue.json
+++ b/cli/tests/fixtures/exhausted_thesis_issue.json
@@ -1,0 +1,37 @@
+{
+  "leadGithubLogin": "lead",
+  "issue": {
+    "number": 28,
+    "title": "Exhausted thesis fixture",
+    "body": "Thesis that should become exhausted after a no_improvement release",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/28"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "Polyresearch approval: thesis #28.\n\n<!-- polyresearch:approval\nthesis: 28\n-->",
+      "user": { "login": "lead" },
+      "created_at": "2099-04-08T00:01:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 2,
+      "body": "Polyresearch claim: thesis #28 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 28\nnode: test-node\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:02:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 3,
+      "body": "Polyresearch release: thesis #28 by node `test-node` (`reason: no_improvement`).\n\n<!-- polyresearch:release\nthesis: 28\nnode: test-node\nreason: no_improvement\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:03:00Z",
+      "updated_at": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- After `polyresearch release <issue> --reason no_improvement`, the thesis dropped back to `Approved` and still counted toward `queue_depth`. With enough of these zombies in the queue, the lead's generate gate thought the queue was full and stopped producing new theses.
- Adds a `ThesisPhase::Exhausted` variant. A thesis is exhausted when it's approved, unclaimed, has no open PR, and has at least one `no_improvement` release in its comment history. Exhausted theses are excluded from `queue_depth` and can't be claimed.
- No new config, no new labels, no changes to the `release` command. The existing `queue_depth` filter, claimability guard, and serde serialization all handle the new phase without additional code.

## Test plan

- [x] New unit test: `marks_no_improvement_releases_as_exhausted` -- derives phase from fixture, asserts `Exhausted`.
- [x] New unit test: `queue_depth_excludes_exhausted_theses` -- builds one exhausted and one approved thesis, asserts count is 1.
- [x] Full test suite passes (13 unit + 18 e2e).
- [ ] Manual: run `polyresearch status` on a repo with zombie theses and confirm they show `exhausted` and queue depth drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thesis state derivation and queue depth calculation, which can affect lead `generate` gating and claimability decisions. Logic is straightforward and covered by new fixture-based unit tests, but misclassification would impact workflow correctness.
> 
> **Overview**
> Prevents “zombie” theses (released with `reason: no_improvement`) from returning to the `Approved` queue by introducing a new `ThesisPhase::Exhausted` state derived from issue comment history.
> 
> Updates `RepositoryState` queue depth computation to count only `Approved` theses (excluding `Exhausted`), adds unit tests + a JSON fixture to lock in the behavior, and documents the new lifecycle branch in `POLYRESEARCH.md` (plus minor formatting-only tidy-ups in CLI code/tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767bae0d8e6e41db38cc5162d8536c0ef8244402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->