### PR TITLE
Ship pre-built polyresearch binaries via GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,193 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+env:
+  DIST_VERSION: "0.31.0"
+
+jobs:
+  plan:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-v${DIST_VERSION}-installer.sh" | sh
+
+      - name: Validate dist config and release tag
+        run: dist plan --tag "${GITHUB_REF_NAME}"
+
+  build-local-artifacts:
+    name: Build ${{ matrix.target }}
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target: aarch64-apple-darwin
+          - runner: macos-13
+            target: x86_64-apple-darwin
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cargo-dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-v${DIST_VERSION}-installer.sh" | sh
+
+      - name: Build local archive
+        run: dist build --artifacts local --target "${{ matrix.target }}" --tag "${GITHUB_REF_NAME}"
+
+      - name: Smoke test extracted binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz"
+          tmpdir="$(mktemp -d)"
+          tar -xJf "$archive" -C "$tmpdir"
+          archive_root="$tmpdir/polyresearch-cli-${{ matrix.target }}"
+
+          "$archive_root/polyresearch" --help >/dev/null
+
+          mkdir -p "$tmpdir/fake-bin"
+          cat > "$tmpdir/fake-bin/gh" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [ "$#" -ge 2 ] && [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+            printf '[]'
+          elif [ "$#" -ge 2 ] && [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+            printf '[]'
+          else
+            echo "unexpected gh invocation: $*" >&2
+            exit 1
+          fi
+          EOF
+          chmod +x "$tmpdir/fake-bin/gh"
+
+          PATH="$tmpdir/fake-bin:$PATH" \
+            "$archive_root/polyresearch" --repo superagent-ai/polyresearch status --json > "$tmpdir/status.json"
+
+          python3 - "$tmpdir/status.json" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+
+          assert data["queue_depth"] == 0, data
+          assert data["thesis_count"] == 0, data
+          assert data["invalid_count"] == 0, data
+          assert data["suspicious_count"] == 0, data
+          PY
+
+      - name: Stage release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist-artifacts
+          cp "target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz" dist-artifacts/
+          cp "target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz.sha256" dist-artifacts/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist-artifacts/
+
+  build-global-artifacts:
+    name: Build global artifacts
+    needs: plan
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-v${DIST_VERSION}-installer.sh" | sh
+
+      - name: Build source bundle and checksums
+        run: dist build --artifacts global --tag "${GITHUB_REF_NAME}"
+
+      - name: Stage release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist-artifacts
+          cp target/distrib/source.tar.gz dist-artifacts/
+          cp target/distrib/source.tar.gz.sha256 dist-artifacts/
+          cp target/distrib/sha256.sum dist-artifacts/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-global
+          path: dist-artifacts/
+
+  release:
+    name: Publish GitHub Release
+    needs:
+      - build-local-artifacts
+      - build-global-artifacts
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: target/distrib
+          merge-multiple: true
+
+      - name: Show release payload
+        run: ls -al target/distrib
+
+      - name: Publish release artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          prerelease_flag=()
+          case "${GITHUB_REF_NAME}" in
+            *-*) prerelease_flag+=(--prerelease) ;;
+          esac
+
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" target/distrib/* --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" target/distrib/* \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes \
+              "${prerelease_flag[@]}"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .venv/
 node_modules/
 .polyresearch-node
+target/
 cli/target/
 *.log

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ $EDITOR PREPARE.md
 mkdir .polyresearch/
 
 # 5. Install the mandatory CLI
-cargo install --path cli
+#    Download the matching release archive and put `polyresearch` on your PATH.
 
 # 6. Tell your agent: "You are the lead for this project."
 #    It reads the files and starts working through `polyresearch`.
 ```
+
+Release binaries live on [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases). If you prefer to build from source, see [cli/README.md](cli/README.md).
 
 Share the repo. Contributors point their agents at it and join.
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polyresearch-cli"
 version = "0.1.0"
 edition = "2024"
+repository = "https://github.com/superagent-ai/polyresearch"
 
 [[bin]]
 name = "polyresearch"
@@ -21,3 +22,8 @@ serde_json = "1.0.149"
 sha2 = "0.11.0"
 tokio = { version = "1.51.0", features = ["full"] }
 walkdir = "2.5.0"
+
+# The profile that 'dist' will build with
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,6 +17,18 @@ This CLI centralizes that logic so every machine uses the same implementation an
 
 ## Install
 
+The default install path is to download a pre-built archive from [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
+
+| OS | Architecture | Archive |
+| --- | --- | --- |
+| macOS | Apple Silicon | `polyresearch-cli-aarch64-apple-darwin.tar.xz` |
+| macOS | Intel | `polyresearch-cli-x86_64-apple-darwin.tar.xz` |
+| Linux | x86_64 (glibc) | `polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz` |
+
+Each archive expands to a directory containing `polyresearch` and `README.md`. Move `polyresearch` somewhere on your `PATH`, such as `~/.local/bin` or `/usr/local/bin`.
+
+### Build from source
+
 From the repo root:
 
 ```bash
@@ -33,6 +45,10 @@ That installs the `polyresearch` binary from [cli/Cargo.toml](cli/Cargo.toml).
 - GitHub authentication through `gh auth login`
 
 The CLI can read `GITHUB_TOKEN`, but by default it uses the existing `gh` authentication on the machine.
+
+## Releasing
+
+Release tags follow `vX.Y.Z` and must match the version in [cli/Cargo.toml](cli/Cargo.toml). Bump the crate version, push the matching tag, and GitHub Actions publishes the archives and checksums to [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
 
 ## Basic workflow
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,0 +1,18 @@
+[workspace]
+members = ["cargo:cli"]
+
+# Config for 'dist'
+[dist]
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.31.0"
+# CI backends to support
+ci = "github"
+# Keep release builds valid even though this repo uses a hand-trimmed workflow
+# instead of cargo-dist's generated release.yml.
+allow-dirty = ["ci"]
+# The installers to generate for each app
+installers = []
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+# Where to host releases
+hosting = "github"


### PR DESCRIPTION
## Summary

- Adds a tag-triggered GitHub Actions workflow (`.github/workflows/release.yml`) that builds `polyresearch` binaries for macOS (arm64, x86_64) and Linux (x86_64), smoke-tests each one offline, and publishes archives + checksums to GitHub Releases.
- Adds `dist-workspace.toml` and `cli/Cargo.toml` metadata so `cargo-dist` handles artifact naming, archive layout, and source tarballs.
- Updates `README.md` and `cli/README.md` so the default install path is "download a release binary" with source builds as a fallback.

## How to test

After merging, bump the version in `cli/Cargo.toml` if needed, then push a tag:

```bash
git tag v0.1.0
git push origin v0.1.0
```

The workflow runs on any `v*.*.*` tag. Watch the Actions tab for a successful Release job, then check the [Releases page](https://github.com/superagent-ai/polyresearch/releases) for the archives and checksums.

To do a safe dry run first, use a prerelease tag like `v0.1.0-rc.1` (set the crate version to match). The workflow marks it as a prerelease automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tag-triggered release workflow that builds and publishes binaries/checksums; risk is mainly around CI/release correctness and artifact integrity, not runtime behavior.
> 
> **Overview**
> Adds a tag-triggered GitHub Actions release pipeline that uses `cargo-dist` to build macOS/Linux archives, smoke-test extracted binaries, and publish the resulting archives plus checksums (and a source bundle) to GitHub Releases.
> 
> Introduces `dist-workspace.toml` and `cli/Cargo.toml` `cargo-dist` metadata (`repository`, `profile.dist`) to standardize artifact naming/layout, updates `.gitignore` to ignore `target/`, and revises docs (`README.md`, `cli/README.md`) to make “download a release binary” the default install path with source builds as fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bce4a7a9c8f486dd896944f0a2d6e1d841b781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->