### PR TITLE
Document binary install commands in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ A contributor picks up a thesis from the Issues queue through the `polyresearch`
 ```bash
 # 1. Install the CLI (macOS Apple Silicon shown)
 curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
-tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
-sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
 
 # 2. Copy the protocol and templates into your repo
 cp POLYRESEARCH.md PROGRAM.md PREPARE.md your-repo/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ $EDITOR PREPARE.md
 #    Setup scripts, container definitions, lockfiles -- whatever the project needs.
 mkdir .polyresearch/
 
-# 5. Install the mandatory CLI (macOS Apple Silicon shown; see cli/README.md for other platforms)
+# 5. Download the mandatory CLI (macOS Apple Silicon shown)
 curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
-tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
-sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
 
 # 6. Tell your agent: "You are the lead for this project."
 #    It reads the files and starts working through `polyresearch`.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ $EDITOR PREPARE.md
 #    Setup scripts, container definitions, lockfiles -- whatever the project needs.
 mkdir .polyresearch/
 
-# 5. Install the mandatory CLI
-#    Download the matching release archive and put `polyresearch` on your PATH.
+# 5. Install the mandatory CLI (macOS Apple Silicon shown; see cli/README.md for other platforms)
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
+sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
 
 # 6. Tell your agent: "You are the lead for this project."
 #    It reads the files and starts working through `polyresearch`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/
 #    It reads the files and starts working through `polyresearch`.
 ```
 
-Release binaries live on [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases). For more installation options, see [cli/README.md](cli/README.md).
+Other platforms and build-from-source instructions are in [cli/README.md](cli/README.md).
 
 Share the repo. Contributors point their agents at it and join.
 

--- a/README.md
+++ b/README.md
@@ -21,37 +21,27 @@ A contributor picks up a thesis from the Issues queue through the `polyresearch`
 
 **Setting up a project:**
 
-1. Drop in the protocol (same for every project):
-
 ```bash
+# 1. Drop in the protocol (same for every project)
 cp POLYRESEARCH.md your-repo/
-```
 
-2. Write the research playbook -- goal, editable files, strategy, constraints:
-
-```bash
+# 2. Write the research playbook (goal, editable files, strategy, constraints)
 $EDITOR PROGRAM.md
-```
 
-3. Write the evaluation setup -- how to run, how to parse the metric, ground truth:
-
-```bash
+# 3. Write the evaluation setup (how to run, how to parse the metric, ground truth)
 $EDITOR PREPARE.md
-```
 
-4. (Optional) Add a reproducible environment. Setup scripts, container definitions, lockfiles -- whatever the project needs:
-
-```bash
+# 4. (Optional) Add a reproducible environment
 mkdir .polyresearch/
-```
 
-5. Install the mandatory CLI (macOS Apple Silicon shown, see [cli/README.md](cli/README.md) for other platforms):
-
-```bash
+# 5. Install the mandatory CLI (macOS Apple Silicon shown)
 curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+
+# 6. Tell your agent: "You are the lead for this project."
+#    It reads the files and starts working through `polyresearch`.
 ```
 
-6. Tell your agent: "You are the lead for this project." It reads the files and starts working through `polyresearch`.
+Other platforms and build-from-source instructions are in [cli/README.md](cli/README.md).
 
 Share the repo. Contributors point their agents at it and join.
 

--- a/README.md
+++ b/README.md
@@ -21,30 +21,37 @@ A contributor picks up a thesis from the Issues queue through the `polyresearch`
 
 **Setting up a project:**
 
-```
-# 1. Drop in the protocol (same for every project)
+1. Drop in the protocol (same for every project):
+
+```bash
 cp POLYRESEARCH.md your-repo/
-
-# 2. Write the research playbook
-#    (goal, editable files, strategy, constraints)
-$EDITOR PROGRAM.md
-
-# 3. Write the evaluation setup
-#    (how to run, how to parse the metric, ground truth)
-$EDITOR PREPARE.md
-
-# 4. (Optional) Add a reproducible environment
-#    Setup scripts, container definitions, lockfiles -- whatever the project needs.
-mkdir .polyresearch/
-
-# 5. Install the mandatory CLI (macOS Apple Silicon shown)
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
-
-# 6. Tell your agent: "You are the lead for this project."
-#    It reads the files and starts working through `polyresearch`.
 ```
 
-Other platforms and build-from-source instructions are in [cli/README.md](cli/README.md).
+2. Write the research playbook -- goal, editable files, strategy, constraints:
+
+```bash
+$EDITOR PROGRAM.md
+```
+
+3. Write the evaluation setup -- how to run, how to parse the metric, ground truth:
+
+```bash
+$EDITOR PREPARE.md
+```
+
+4. (Optional) Add a reproducible environment. Setup scripts, container definitions, lockfiles -- whatever the project needs:
+
+```bash
+mkdir .polyresearch/
+```
+
+5. Install the mandatory CLI (macOS Apple Silicon shown, see [cli/README.md](cli/README.md) for other platforms):
+
+```bash
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+```
+
+6. Tell your agent: "You are the lead for this project." It reads the files and starts working through `polyresearch`.
 
 Share the repo. Contributors point their agents at it and join.
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ $EDITOR PREPARE.md
 #    Setup scripts, container definitions, lockfiles -- whatever the project needs.
 mkdir .polyresearch/
 
-# 5. Download the mandatory CLI (macOS Apple Silicon shown)
+# 5. Install the mandatory CLI (macOS Apple Silicon shown)
 curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
 
 # 6. Tell your agent: "You are the lead for this project."
 #    It reads the files and starts working through `polyresearch`.
 ```
 
-Release binaries live on [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases). If you prefer to build from source, see [cli/README.md](cli/README.md).
+Release binaries live on [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases). For more installation options, see [cli/README.md](cli/README.md).
 
 Share the repo. Contributors point their agents at it and join.
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,23 @@ A contributor picks up a thesis from the Issues queue through the `polyresearch`
 **Setting up a project:**
 
 ```bash
-# 1. Drop in the protocol (same for every project)
-cp POLYRESEARCH.md your-repo/
+# 1. Install the CLI (macOS Apple Silicon shown)
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
+sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
 
-# 2. Write the research playbook (goal, editable files, strategy, constraints)
+# 2. Copy the protocol and templates into your repo
+cp POLYRESEARCH.md PROGRAM.md PREPARE.md your-repo/
+cd your-repo
+
+# 3. Edit the research playbook (goal, editable files, strategy, constraints)
 $EDITOR PROGRAM.md
 
-# 3. Write the evaluation setup (how to run, how to parse the metric, ground truth)
+# 4. Edit the evaluation setup (how to run, how to parse the metric, ground truth)
 $EDITOR PREPARE.md
 
-# 4. (Optional) Add a reproducible environment
+# 5. (Optional) Add a reproducible environment
 mkdir .polyresearch/
-
-# 5. Install the mandatory CLI (macOS Apple Silicon shown)
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
 
 # 6. Tell your agent: "You are the lead for this project."
 #    It reads the files and starts working through `polyresearch`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,6 +27,30 @@ The default install path is to download a pre-built archive from [GitHub Release
 
 Each archive expands to a directory containing `polyresearch` and `README.md`. Move `polyresearch` somewhere on your `PATH`, such as `~/.local/bin` or `/usr/local/bin`.
 
+**macOS (Apple Silicon):**
+
+```bash
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
+sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
+```
+
+**macOS (Intel):**
+
+```bash
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-x86_64-apple-darwin.tar.xz
+tar -xJf polyresearch-cli-x86_64-apple-darwin.tar.xz
+sudo cp polyresearch-cli-x86_64-apple-darwin/polyresearch /usr/local/bin/
+```
+
+**Linux (x86_64):**
+
+```bash
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz
+tar -xJf polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz
+sudo cp polyresearch-cli-x86_64-unknown-linux-gnu/polyresearch /usr/local/bin/
+```
+
 ### Build from source
 
 From the repo root:


### PR DESCRIPTION
## Summary
- replaces the vague install step in the top-level README with a real copy-paste example for the release binary
- adds copy-paste install commands for Apple Silicon macOS, Intel macOS, and x86_64 Linux to `cli/README.md`
- keeps the source-build instructions in place for contributors who still want `cargo install --path cli`

## Test plan
- [x] `cargo test --manifest-path cli/Cargo.toml`
- [x] reviewed the rendered README diffs in the worktree
- [ ] spot-check the markdown on GitHub after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update install instructions; low risk aside from potential broken download URLs or command typos.
> 
> **Overview**
> Updates the quick-start in `README.md` to include an explicit release-binary download step for installing the `polyresearch` CLI and clarifies that other platforms are covered in `cli/README.md`.
> 
> Expands `cli/README.md` install docs with copy-paste `curl`/`tar`/`cp` commands for macOS (Apple Silicon + Intel) and Linux x86_64, while keeping the existing build-from-source instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2452402d332f3ef58edd4aa61729920875ebb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->