### PR TITLE
Add maintainer approval gates to polyresearch

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -173,6 +173,7 @@ Complete all of these before opening any new thesis issue:
 Queue depth check:
 
 - Count the number of open theses that are approved and unclaimed, using [Deriving state](#deriving-state).
+- If `auto_approve` is `false`, also count open submitted theses that are waiting on maintainer review. They still occupy queue capacity and should prevent unbounded generation.
 - If `max_queue_depth` is set and that count is already at or above `max_queue_depth`, do not open new theses this iteration.
 - If that count is already at or above `min_queue_depth`, do not open new theses this iteration.
 - If that count is below `min_queue_depth`, open only enough new theses to bring the queue back to `min_queue_depth`.

--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -24,6 +24,8 @@ This table defines the protocol parameters. Put the concrete values for your pro
 | `metric_tolerance`       | Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance.                     |
 | `metric_direction`       | `lower_is_better` or `higher_is_better`.                                                                                                                                    |
 | `lead_github_login`      | GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.                                          |
+| `maintainer_github_login` | GitHub login for the human maintainer who can `/approve` or `/reject` thesis issues and candidate PRs when human review is enabled.                                       |
+| `auto_approve`           | If `true`, the lead auto-approves generated theses and decides PRs without waiting for a maintainer slash command. If `false`, the maintainer must `/approve` first. Default: `true`. |
 | `assignment_timeout`     | Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.                                                                               |
 | `review_timeout`         | Time before an incomplete review claim expires. Default: `12h`.                                                                                                             |
 | `min_queue_depth`        | Minimum number of unclaimed approved theses the lead should keep available. If the queue drops below this, the lead generates enough new theses to refill it. Default: `5`. |
@@ -36,11 +38,13 @@ The parameter definitions live here. Concrete project values live in `PROGRAM.md
 
 ## Roles
 
-**Maintainer.** The human who owns the project. Writes PROGRAM.md and PREPARE.md. Approves theses. Picks the tooling (agent, model, sandbox). Polyresearch does not mandate any specific tooling.
+**Maintainer.** The human who owns the project. Writes PROGRAM.md and PREPARE.md. Approves or rejects theses and PRs when human review is enabled. Picks the tooling (agent, model, sandbox). Polyresearch does not mandate any specific tooling.
 
 **Contributor.** A machine running an agent. Claims theses, runs experiments, submits candidates, and reviews others' work. You are a contributor unless told otherwise.
 
 **Lead.** A contributor with additional responsibilities: generates theses from results history, runs policy checks on candidate PRs, decides PRs (merge or close), and maintains results.tsv as sole writer. One per project. If your instructions say "you are the lead," follow the lead sections in addition to the contributor sections.
+
+When `auto_approve` is `false`, `lead_github_login` and `maintainer_github_login` must be different GitHub accounts. Human-in-the-loop review does not work if the lead and the maintainer share the same GitHub identity.
 
 ---
 
@@ -129,7 +133,7 @@ Everything in the contributor loop, plus these additional responsibilities. Run 
 
 0. `polyresearch duties` — resolve any blocking items (decidable PRs, stale results.tsv, etc.).
 1. `polyresearch sync` (always before other lead actions).
-2. Process open PRs: `policy-check` and `decide` any that are ready.
+2. Process open PRs: `policy-check` and `decide` any that are ready. When `auto_approve` is `false`, assign ready PRs to `maintainer_github_login` and wait for `/approve`.
 3. Check queue depth; `generate` if below `min_queue_depth`.
 4. Only then proceed to local experiments.
 
@@ -180,7 +184,12 @@ Deduplication:
 - If an idea already failed, do not re-propose it unless you can point to a concrete reason the new attempt is materially different. State that reason in the thesis body.
 - If an idea was already merged, do not re-propose it.
 
-Open new GitHub Issues with the `thesis` label by running `polyresearch generate --title "<title>" --body "<body>"`. The CLI auto-approves them by posting a `polyresearch:approval` comment.
+Open new GitHub Issues with the `thesis` label by running `polyresearch generate --title "<title>" --body "<body>"`.
+
+- If `auto_approve` is `true`, the CLI auto-approves the thesis by posting a `polyresearch:approval` comment.
+- If `auto_approve` is `false`, the CLI leaves the thesis in `Submitted`, assigns it to `maintainer_github_login`, and waits for the maintainer to comment `/approve` or `/reject`.
+
+Before opening more theses, the lead must read maintainer `/approve` and `/reject` comments on existing theses and PRs. Treat those comments as directional input: approval reasons suggest promising directions, rejection reasons constrain future generation. This guidance does not override `PROGRAM.md`, `PREPARE.md`, or the measured results history.
 
 Guard against path dependence. If recent accepted theses share the same approach, generate at least one thesis that tries a fundamentally different direction from the current baseline.
 
@@ -192,7 +201,11 @@ If the candidate passes, the CLI posts a `polyresearch:policy-pass` comment. The
 
 ### Decide PRs
 
-When `required_confirmations` review records have been posted on a PR, run `polyresearch decide <pr-number>`:
+When `required_confirmations` review records have been posted on a PR, run `polyresearch decide <pr-number>`.
+
+If `auto_approve` is `false`, the lead assigns the PR to `maintainer_github_login` and waits for a maintainer `/approve` before posting a decision. A maintainer `/reject` means do not accept the current candidate; the lead should close or supersede that PR and use the feedback to guide the next thesis or attempt.
+
+Otherwise apply these rules:
 
 - All reviewers observed `improved` and their metrics agree within `metric_tolerance`: post `outcome: accepted`, **merge** the PR, close the thesis issue.
 - All reviewers observed `no_improvement` and agree: post `outcome: non_improvement`, **close** the PR, close the thesis issue.
@@ -245,6 +258,8 @@ No mutable labels to get out of sync. The comment trail is the truth.
 
 Exhausted theses stay open for history, but they are not claimable and do not count toward queue depth.
 
+When `auto_approve` is `false`, a generated thesis stays in **Submitted** until the maintainer comments `/approve`.
+
 ---
 
 ## Branching
@@ -271,7 +286,7 @@ All protocol state transitions happen through structured comments on GitHub Issu
 
 One label remains: `thesis` on issues, for discovery via `gh issue list --label thesis`. Everything else is a structured comment.
 
-Only structured comments emitted by `polyresearch` are canonical. Raw manual comments that resemble protocol events may still be visible on GitHub, but the lead and the tooling may ignore them if they do not pass validation.
+Structured comments emitted by `polyresearch` are canonical. Maintainer `/approve` and `/reject` slash commands are also canonical. Other raw manual comments that resemble protocol events may still be visible on GitHub, but the lead and the tooling may ignore them if they do not pass validation.
 
 ### Format
 
@@ -286,15 +301,23 @@ key: value
 
 The visible summary line is required so humans can understand the protocol state in GitHub's rendered UI. Agents parse only the HTML block. Keep the summary short and include the comment type and the most important fields.
 
+### Maintainer slash commands (issues and PRs)
+
+```
+/approve Optional reason or guidance.
+```
+
+```
+/reject Optional reason or guidance.
+```
+
+The maintainer writes `/approve` or `/reject` at the start of a comment body on a thesis issue or candidate PR. Any remaining text is free-form feedback for the lead to consider.
+
 ### On thesis issues
 
 **Approval** (maintainer, plain-text slash command):
 
-```
-/approve
-```
-
-The maintainer comments `/approve` on the issue. Agents match on the exact string `/approve` at the start of a comment body.
+`/approve` on the issue is a valid approval signal. `/reject` means the thesis should not be pursued in its current form.
 
 **Approval** (lead auto-approval):
 
@@ -347,6 +370,10 @@ summary: Switched to GeLU activation, regression on val_bpb
 ```
 
 ### On candidate PRs
+
+**Approval or rejection** (maintainer, plain-text slash command):
+
+`/approve` on the PR authorizes the lead to proceed when `auto_approve` is `false`. `/reject` means the current candidate should not be accepted in its current form.
 
 **Policy pass** (lead confirms candidate is within editable surface):
 
@@ -407,6 +434,14 @@ confirmations: 2
 
 ---
 
+## Maintainer feedback
+
+Maintainer `/approve` and `/reject` comments can include free-text guidance. The lead must read this guidance before generating new theses or deciding whether to keep pushing on the same direction.
+
+- Approval reasons indicate what the maintainer wants more of.
+- Rejection reasons indicate constraints, dead ends, or priorities the lead should avoid repeating.
+- This guidance is directional input, not a license to ignore `PROGRAM.md`, `PREPARE.md`, or the measured results in `results.tsv`.
+
 ## Peer review
 
 When `required_confirmations` is greater than 0, candidate PRs go through peer review. The sequence:
@@ -415,7 +450,8 @@ When `required_confirmations` is greater than 0, candidate PRs go through peer r
 2. **Review claiming.** Contributors (who did not author the PR) find PRs with `polyresearch:policy-pass` and no `polyresearch:decision`. They post `polyresearch:review-claim`.
 3. **Evaluation.** The reviewer checks out the candidate SHA, runs the evaluation per PREPARE.md. Then checks out the base SHA, runs the same evaluation. Both metrics are measured independently.
 4. **Review record.** The reviewer posts a `polyresearch:review` comment with both metrics, observation, environment hash, and timestamp.
-5. **Decision.** When `required_confirmations` review records are posted, the lead evaluates and posts `polyresearch:decision`. Merges or closes the PR.
+5. **Maintainer gate.** If `auto_approve` is `false`, the lead waits for a maintainer `/approve` before deciding. The PR should be assigned to `maintainer_github_login` while it is waiting.
+6. **Decision.** When the reviewer requirements are satisfied, and the maintainer gate is satisfied when enabled, the lead evaluates and posts `polyresearch:decision`. Merges or closes the PR.
 
 ---
 

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,6 +14,8 @@ Project-specific coordination values referenced by `POLYRESEARCH.md`. Replace th
 | `metric_tolerance`       | `0.01`             |
 | `metric_direction`       | `higher_is_better` |
 | `lead_github_login`      | `replace-me`       |
+| `maintainer_github_login` | `replace-me`      |
+| `auto_approve`           | `true`             |
 | `assignment_timeout`     | `24h`              |
 | `review_timeout`         | `12h`              |
 | `min_queue_depth`        | `5`                |

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -26,6 +26,25 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     let (thesis, pr_state) = require_decidable_pr(&repo_state, args.pr)?;
 
     let candidate_sha = pr_state.pr.head_ref_oid.clone().unwrap_or_default();
+    if !ctx.config.auto_approve {
+        let maintainer = ctx.config.maintainer_login()?;
+        if !ctx.cli.dry_run && (!pr_state.maintainer_approved || pr_state.maintainer_rejected) {
+            ctx.github.add_assignees(args.pr, &[maintainer])?;
+        }
+        if pr_state.maintainer_rejected {
+            return Err(eyre!(
+                "PR #{} was rejected by the maintainer; do not decide it until a maintainer comments `/approve` or the PR is replaced",
+                args.pr
+            ));
+        }
+        if !pr_state.maintainer_approved {
+            return Err(eyre!(
+                "PR #{} requires maintainer `/approve` before deciding",
+                args.pr
+            ));
+        }
+    }
+
     let outcome = if ctx.config.required_confirmations == 0 {
         decide_without_peer_review(ctx, thesis, pr_state, &ledger)?
     } else {

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -106,6 +106,24 @@ fn check_lead_duties(
 ) -> Result<()> {
     let required = ctx.config.required_confirmations as usize;
 
+    if !ctx.config.auto_approve {
+        for thesis in &repo_state.theses {
+            if thesis.issue.state == "OPEN"
+                && matches!(thesis.phase, ThesisPhase::Submitted)
+                && !thesis.maintainer_rejected
+            {
+                advisory.push(DutyItem {
+                    category: "maintainer-approval".to_string(),
+                    message: format!(
+                        "Thesis #{}: awaiting maintainer `/approve`.",
+                        thesis.issue.number
+                    ),
+                    command: "GitHub comment: /approve OR /reject <reason>".to_string(),
+                });
+            }
+        }
+    }
+
     for thesis in &repo_state.theses {
         for pr_state in &thesis.pull_requests {
             if pr_state.pr.state != "OPEN" || pr_state.decision.is_some() {
@@ -117,6 +135,26 @@ fn check_lead_duties(
                     category: "policy-check".to_string(),
                     message: format!("PR #{}: open without policy-check.", pr_state.pr.number),
                     command: format!("polyresearch policy-check {}", pr_state.pr.number),
+                });
+                continue;
+            }
+
+            if !ctx.config.auto_approve && !pr_state.maintainer_approved {
+                let message = if pr_state.maintainer_rejected {
+                    format!(
+                        "PR #{}: maintainer rejected the candidate; waiting for a new `/approve` or replacement PR.",
+                        pr_state.pr.number
+                    )
+                } else {
+                    format!(
+                        "PR #{}: awaiting maintainer `/approve`.",
+                        pr_state.pr.number
+                    )
+                };
+                advisory.push(DutyItem {
+                    category: "maintainer-approval".to_string(),
+                    message,
+                    command: "GitHub comment: /approve OR /reject <reason>".to_string(),
                 });
                 continue;
             }

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -15,6 +15,7 @@ struct GenerateOutput {
     issue_number: Option<u64>,
     issue_url: Option<String>,
     warned_below_min_queue_depth: bool,
+    awaiting_maintainer_approval: bool,
 }
 
 pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
@@ -56,25 +57,38 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     }
 
     let warned_below_min_queue_depth = repo_state.queue_depth < ctx.config.min_queue_depth;
+    let awaiting_maintainer_approval = !ctx.config.auto_approve;
     let issue = if ctx.cli.dry_run {
         None
     } else {
         let issue = ctx
             .github
             .create_issue(&args.title, &args.body, &["thesis"])?;
-        let approval = ProtocolComment::Approval {
-            thesis: issue.number,
-        };
-        if let Err(err) = ctx
-            .github
-            .post_issue_comment(issue.number, &approval.render())
-        {
-            eprintln!(
-                "Failed to post approval on #{}, closing orphaned issue: {err}",
-                issue.number
-            );
-            let _ = ctx.github.close_issue(issue.number);
-            return Err(err);
+        if ctx.config.auto_approve {
+            let approval = ProtocolComment::Approval {
+                thesis: issue.number,
+            };
+            if let Err(err) = ctx
+                .github
+                .post_issue_comment(issue.number, &approval.render())
+            {
+                eprintln!(
+                    "Failed to post approval on #{}, closing orphaned issue: {err}",
+                    issue.number
+                );
+                let _ = ctx.github.close_issue(issue.number);
+                return Err(err);
+            }
+        } else {
+            let maintainer = ctx.config.maintainer_login()?;
+            if let Err(err) = ctx.github.add_assignees(issue.number, &[maintainer]) {
+                eprintln!(
+                    "Failed to assign maintainer on #{}, closing orphaned issue: {err}",
+                    issue.number
+                );
+                let _ = ctx.github.close_issue(issue.number);
+                return Err(err);
+            }
         }
         Some(issue)
     };
@@ -84,6 +98,7 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         issue_number: issue.as_ref().map(|value| value.number),
         issue_url: issue.and_then(|value| value.url),
         warned_below_min_queue_depth,
+        awaiting_maintainer_approval,
     };
 
     print_value(ctx, &output, |value| {
@@ -92,6 +107,9 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         } else {
             "Would generate a new thesis issue.".to_string()
         };
+        if value.awaiting_maintainer_approval {
+            message.push_str(" Awaiting maintainer /approve.");
+        }
         if value.warned_below_min_queue_depth {
             message.push_str(" Queue depth is below min_queue_depth.");
         }

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -61,6 +61,11 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     let issue = if ctx.cli.dry_run {
         None
     } else {
+        let maintainer = if ctx.config.auto_approve {
+            None
+        } else {
+            Some(ctx.config.maintainer_login()?.to_string())
+        };
         let issue = ctx
             .github
             .create_issue(&args.title, &args.body, &["thesis"])?;
@@ -80,7 +85,9 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
                 return Err(err);
             }
         } else {
-            let maintainer = ctx.config.maintainer_login()?;
+            let maintainer = maintainer
+                .as_deref()
+                .expect("maintainer login validated before issue creation");
             if let Err(err) = ctx.github.add_assignees(issue.number, &[maintainer]) {
                 eprintln!(
                     "Failed to assign maintainer on #{}, closing orphaned issue: {err}",

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -10,12 +10,17 @@ use crate::validation::AuditSeverity;
 #[derive(Debug, Serialize)]
 struct StatusOutput {
     repo: String,
+    auto_approve: bool,
+    maintainer_github_login: Option<String>,
     queue_depth: usize,
     active_nodes: Vec<String>,
     current_best_accepted_metric: Option<f64>,
     ledger_current: bool,
     invalid_count: usize,
     suspicious_count: usize,
+    maintainer_pending_count: usize,
+    maintainer_rejected_count: usize,
+    maintainer_items: Vec<String>,
     audit_findings: Vec<crate::validation::AuditFinding>,
     thesis_count: usize,
     theses: Vec<crate::state::ThesisState>,
@@ -37,15 +42,29 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
         .iter()
         .filter(|finding| matches!(finding.severity, AuditSeverity::Suspicious))
         .count();
+    let maintainer_items = maintainer_items(&repo_state, ctx.config.auto_approve);
+    let maintainer_pending_count = maintainer_items
+        .iter()
+        .filter(|item| item.contains("awaiting"))
+        .count();
+    let maintainer_rejected_count = maintainer_items
+        .iter()
+        .filter(|item| item.contains("rejected"))
+        .count();
 
     let output = StatusOutput {
         repo: ctx.repo.slug(),
+        auto_approve: ctx.config.auto_approve,
+        maintainer_github_login: ctx.config.maintainer_github_login.clone(),
         queue_depth: repo_state.queue_depth,
         active_nodes: repo_state.active_nodes.clone(),
         current_best_accepted_metric: repo_state.current_best_accepted_metric,
         ledger_current: ledger.is_current(&repo_state),
         invalid_count,
         suspicious_count,
+        maintainer_pending_count,
+        maintainer_rejected_count,
+        maintainer_items,
         audit_findings: repo_state.audit_findings.clone(),
         thesis_count: repo_state.theses.len(),
         theses: repo_state.theses,
@@ -56,7 +75,7 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
             .current_best_accepted_metric
             .map(|metric| format!("{metric:.4}"))
             .unwrap_or_else(|| "n/a".to_string());
-        format!(
+        let mut text = format!(
             "Repo: {}\nTheses: {}\nQueue depth: {}\nActive nodes: {}\nBest accepted metric: {}\nresults.tsv current: {}",
             value.repo,
             value.thesis_count,
@@ -71,6 +90,56 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
         ) + &format!(
             "\nAudit findings: {} invalid, {} suspicious",
             value.invalid_count, value.suspicious_count
-        )
+        );
+        if value.auto_approve {
+            text.push_str("\nMaintainer gate: auto-approve enabled");
+        } else {
+            let maintainer = value
+                .maintainer_github_login
+                .as_deref()
+                .unwrap_or("unconfigured");
+            text.push_str(&format!(
+                "\nMaintainer gate: waiting on `{}` ({} awaiting, {} rejected)",
+                maintainer, value.maintainer_pending_count, value.maintainer_rejected_count
+            ));
+            if !value.maintainer_items.is_empty() {
+                text.push_str("\nMaintainer review items:");
+                for item in &value.maintainer_items {
+                    text.push_str(&format!("\n- {item}"));
+                }
+            }
+        }
+        text
     })
+}
+
+fn maintainer_items(repo_state: &RepositoryState, auto_approve: bool) -> Vec<String> {
+    if auto_approve {
+        return Vec::new();
+    }
+
+    let mut items = Vec::new();
+    for thesis in &repo_state.theses {
+        if thesis.issue.state == "OPEN"
+            && matches!(thesis.phase, crate::state::ThesisPhase::Submitted)
+            && !thesis.maintainer_rejected
+        {
+            items.push(format!("thesis #{} awaiting /approve", thesis.issue.number));
+        }
+        if thesis.maintainer_rejected {
+            items.push(format!("thesis #{} rejected", thesis.issue.number));
+        }
+        for pr in thesis
+            .pull_requests
+            .iter()
+            .filter(|pr| pr.pr.state == "OPEN" && pr.decision.is_none())
+        {
+            if pr.maintainer_rejected {
+                items.push(format!("PR #{} rejected", pr.pr.number));
+            } else if !pr.maintainer_approved {
+                items.push(format!("PR #{} awaiting /approve", pr.pr.number));
+            }
+        }
+    }
+    items
 }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -120,6 +120,9 @@ fn maintainer_items(repo_state: &RepositoryState, auto_approve: bool) -> Vec<Str
 
     let mut items = Vec::new();
     for thesis in &repo_state.theses {
+        if thesis.issue.state != "OPEN" {
+            continue;
+        }
         if thesis.issue.state == "OPEN"
             && matches!(thesis.phase, crate::state::ThesisPhase::Submitted)
             && !thesis.maintainer_rejected

--- a/cli/src/comments.rs
+++ b/cli/src/comments.rs
@@ -84,7 +84,12 @@ impl fmt::Display for Outcome {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ProtocolComment {
-    SlashApprove,
+    SlashApprove {
+        reason: Option<String>,
+    },
+    SlashReject {
+        reason: Option<String>,
+    },
     Approval {
         thesis: u64,
     },
@@ -141,8 +146,11 @@ pub enum ProtocolComment {
 impl ProtocolComment {
     pub fn parse(body: &str) -> Result<Option<Self>> {
         let trimmed = body.trim();
-        if trimmed.starts_with("/approve") {
-            return Ok(Some(Self::SlashApprove));
+        if let Some(reason) = parse_slash_command(trimmed, "/approve") {
+            return Ok(Some(Self::SlashApprove { reason }));
+        }
+        if let Some(reason) = parse_slash_command(trimmed, "/reject") {
+            return Ok(Some(Self::SlashReject { reason }));
         }
 
         let regex = comment_block_regex();
@@ -236,7 +244,8 @@ impl ProtocolComment {
 
     pub fn render(&self) -> String {
         match self {
-            Self::SlashApprove => "/approve".to_string(),
+            Self::SlashApprove { reason } => render_slash_command("/approve", reason.as_deref()),
+            Self::SlashReject { reason } => render_slash_command("/reject", reason.as_deref()),
             Self::Approval { thesis } => render_block(
                 format!("Polyresearch approval: thesis #{thesis}."),
                 "approval",
@@ -367,6 +376,27 @@ impl ProtocolComment {
                 )
             }
         }
+    }
+}
+
+fn parse_slash_command(body: &str, command: &str) -> Option<Option<String>> {
+    let remainder = body.strip_prefix(command)?;
+    if remainder
+        .chars()
+        .next()
+        .is_some_and(|character| !character.is_whitespace())
+    {
+        return None;
+    }
+
+    let reason = remainder.trim();
+    Some((!reason.is_empty()).then(|| reason.to_string()))
+}
+
+fn render_slash_command(command: &str, reason: Option<&str>) -> String {
+    match reason {
+        Some(reason) => format!("{command} {reason}"),
+        None => command.to_string(),
     }
 }
 
@@ -525,5 +555,28 @@ summary: RMSNorm instead of LayerNorm
         assert!(rendered.starts_with("Polyresearch claim: thesis #42 by node `node-7f83`."));
         assert!(rendered.contains("<!-- polyresearch:claim"));
         assert!(rendered.contains("node: node-7f83"));
+    }
+
+    #[test]
+    fn parses_slash_commands_with_optional_reasons() {
+        let approve = ProtocolComment::parse("/approve focus on normalization")
+            .unwrap()
+            .unwrap();
+        let reject = ProtocolComment::parse("/reject this is too broad").unwrap().unwrap();
+        let not_a_match = ProtocolComment::parse("/approved").unwrap();
+
+        assert_eq!(
+            approve,
+            ProtocolComment::SlashApprove {
+                reason: Some("focus on normalization".to_string())
+            }
+        );
+        assert_eq!(
+            reject,
+            ProtocolComment::SlashReject {
+                reason: Some("this is too broad".to_string())
+            }
+        );
+        assert!(not_a_match.is_none());
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -19,6 +19,8 @@ pub struct ProtocolConfig {
     pub metric_tolerance: Option<f64>,
     pub metric_direction: MetricDirection,
     pub lead_github_login: Option<String>,
+    pub maintainer_github_login: Option<String>,
+    pub auto_approve: bool,
     pub assignment_timeout: Duration,
     pub review_timeout: Duration,
     pub min_queue_depth: usize,
@@ -32,6 +34,8 @@ impl Default for ProtocolConfig {
             metric_tolerance: None,
             metric_direction: MetricDirection::HigherIsBetter,
             lead_github_login: None,
+            maintainer_github_login: None,
+            auto_approve: true,
             assignment_timeout: Duration::from_secs(24 * 60 * 60),
             review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
@@ -105,6 +109,12 @@ impl ProtocolConfig {
                         config.lead_github_login = Some(value.to_string());
                     }
                 }
+                "maintainer_github_login" => {
+                    if value != "replace-me" && !value.is_empty() {
+                        config.maintainer_github_login = Some(value.to_string());
+                    }
+                }
+                "auto_approve" => config.auto_approve = parse_bool(value)?,
                 "assignment_timeout" => config.assignment_timeout = parse_duration(value)?,
                 "review_timeout" => config.review_timeout = parse_duration(value)?,
                 "min_queue_depth" => {
@@ -134,6 +144,12 @@ impl ProtocolConfig {
         self.lead_github_login
             .as_deref()
             .ok_or_else(|| eyre!("lead_github_login is required in PROGRAM.md"))
+    }
+
+    pub fn maintainer_login(&self) -> Result<&str> {
+        self.maintainer_github_login
+            .as_deref()
+            .ok_or_else(|| eyre!("maintainer_github_login is required in PROGRAM.md"))
     }
 }
 
@@ -232,6 +248,14 @@ fn parse_duration(value: &str) -> Result<Duration> {
     Err(eyre!("unsupported duration format `{trimmed}`"))
 }
 
+fn parse_bool(value: &str) -> Result<bool> {
+    match value.trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(eyre!("invalid boolean value `{other}`")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,5 +285,11 @@ mod tests {
             parse_markdown_list(contents, "## What you CAN modify"),
             vec!["system_prompt.md".to_string(), "tools/**/*.py".to_string()]
         );
+    }
+
+    #[test]
+    fn parses_bool_values() {
+        assert!(parse_bool("true").unwrap());
+        assert!(!parse_bool("false").unwrap());
     }
 }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -78,6 +78,7 @@ pub trait GitHubApi: Send + Sync {
     fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>>;
     fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<Issue>;
     fn post_issue_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment>;
+    fn add_assignees(&self, issue_number: u64, assignees: &[&str]) -> Result<()>;
     fn close_issue(&self, issue_number: u64) -> Result<Issue>;
     fn reopen_issue(&self, issue_number: u64) -> Result<Issue>;
     fn list_pull_requests(&self, state: PullRequestListState) -> Result<Vec<PullRequest>>;
@@ -196,6 +197,23 @@ impl GitHubClient {
             ),
             &[("body", body)],
         )
+    }
+
+    pub fn add_assignees(&self, issue_number: u64, assignees: &[&str]) -> Result<()> {
+        let fields = assignees
+            .iter()
+            .copied()
+            .map(|assignee| ("assignees[]", assignee))
+            .collect::<Vec<_>>();
+        self.gh_api_json(
+            "POST",
+            &format!(
+                "repos/{}/{}/issues/{issue_number}/assignees",
+                self.repo.owner, self.repo.name
+            ),
+            &fields,
+        )?;
+        Ok(())
     }
 
     pub fn close_issue(&self, issue_number: u64) -> Result<Issue> {
@@ -404,6 +422,10 @@ impl GitHubApi for GitHubClient {
 
     fn post_issue_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment> {
         GitHubClient::post_issue_comment(self, issue_number, body)
+    }
+
+    fn add_assignees(&self, issue_number: u64, assignees: &[&str]) -> Result<()> {
+        GitHubClient::add_assignees(self, issue_number, assignees)
     }
 
     fn close_issue(&self, issue_number: u64) -> Result<Issue> {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -25,6 +25,8 @@ pub struct ThesisState {
     pub issue: Issue,
     pub phase: ThesisPhase,
     pub approved: bool,
+    pub maintainer_approved: bool,
+    pub maintainer_rejected: bool,
     pub active_claims: Vec<ClaimRecord>,
     pub releases: Vec<ReleaseRecord>,
     pub attempts: Vec<AttemptRecord>,
@@ -77,6 +79,8 @@ pub struct PullRequestState {
     pub pr: PullRequest,
     pub thesis_number: Option<u64>,
     pub policy_pass: bool,
+    pub maintainer_approved: bool,
+    pub maintainer_rejected: bool,
     pub review_claims: Vec<ReviewClaimRecord>,
     pub reviews: Vec<ReviewRecord>,
     pub decision: Option<DecisionRecord>,
@@ -226,6 +230,8 @@ impl ThesisState {
         let validation = validate_issue(&issue, &comments, config, latest_valid_decision_at);
 
         let approved = validation.approved;
+        let maintainer_approved = validation.maintainer_approved;
+        let maintainer_rejected = validation.maintainer_rejected;
         let attempts = validation
             .attempts
             .iter()
@@ -302,6 +308,8 @@ impl ThesisState {
             issue,
             phase,
             approved,
+            maintainer_approved,
+            maintainer_rejected,
             active_claims,
             releases,
             attempts,
@@ -334,6 +342,24 @@ impl ThesisState {
 
     pub fn is_claimed_by(&self, node: &str) -> bool {
         self.active_claims.iter().any(|claim| claim.node == node)
+    }
+
+    pub fn maintainer_summary(&self, auto_approve: bool) -> String {
+        if auto_approve {
+            return "auto".to_string();
+        }
+
+        if let Some(open_pr) = self.pull_requests.iter().find(|pr| pr.pr.state == "OPEN") {
+            return format!("PR {}", open_pr.maintainer_status(auto_approve));
+        }
+
+        if self.maintainer_rejected {
+            "rejected".to_string()
+        } else if self.approved {
+            "approved".to_string()
+        } else {
+            "waiting".to_string()
+        }
     }
 
     pub fn activity_events(&self) -> Vec<ActivityEvent> {
@@ -422,11 +448,25 @@ impl PullRequestState {
             pr,
             thesis_number: validation.thesis_number,
             policy_pass: validation.policy_pass,
+            maintainer_approved: validation.maintainer_approved,
+            maintainer_rejected: validation.maintainer_rejected,
             review_claims,
             reviews,
             decision,
             findings: validation.findings,
         })
+    }
+
+    pub fn maintainer_status(&self, auto_approve: bool) -> &'static str {
+        if auto_approve {
+            "auto"
+        } else if self.maintainer_rejected {
+            "rejected"
+        } else if self.maintainer_approved {
+            "approved"
+        } else {
+            "waiting"
+        }
     }
 }
 
@@ -465,7 +505,7 @@ pub fn metric_beats(a: f64, b: f64, tolerance: f64, direction: MetricDirection) 
 mod tests {
     use super::*;
     use crate::config::{MetricDirection, ProtocolConfig};
-    use crate::github::{Issue, IssueComment};
+    use crate::github::{Issue, IssueComment, PullRequest};
     use serde::Deserialize;
 
     #[derive(Deserialize)]
@@ -533,6 +573,58 @@ mod tests {
         assert_eq!(count_queue_depth(&[exhausted, approved]), 1);
     }
 
+    #[test]
+    fn maintainer_summary_prefers_open_pr_state() {
+        let thesis = ThesisState {
+            issue: Issue {
+                number: 1,
+                title: "Example".to_string(),
+                body: None,
+                state: "OPEN".to_string(),
+                labels: vec![],
+                created_at: chrono::Utc::now(),
+                closed_at: None,
+                author: None,
+                url: None,
+            },
+            phase: ThesisPhase::InReview,
+            approved: true,
+            maintainer_approved: true,
+            maintainer_rejected: false,
+            active_claims: vec![],
+            releases: vec![],
+            attempts: vec![],
+            pull_requests: vec![PullRequestState {
+                pr: PullRequest {
+                    number: 2,
+                    title: "Candidate".to_string(),
+                    body: None,
+                    state: "OPEN".to_string(),
+                    head_ref_name: "thesis/1-example-attempt-1".to_string(),
+                    head_ref_oid: Some("abc123".to_string()),
+                    base_ref_name: Some("main".to_string()),
+                    created_at: chrono::Utc::now(),
+                    closed_at: None,
+                    merged_at: None,
+                    author: None,
+                    url: None,
+                },
+                thesis_number: Some(1),
+                policy_pass: true,
+                maintainer_approved: false,
+                maintainer_rejected: true,
+                review_claims: vec![],
+                reviews: vec![],
+                decision: None,
+                findings: vec![],
+            }],
+            best_attempt_metric: None,
+            findings: vec![],
+        };
+
+        assert_eq!(thesis.maintainer_summary(false), "PR rejected");
+    }
+
     fn exhausted_fixture() -> IssueFixture {
         serde_json::from_str(include_str!(
             "../tests/fixtures/exhausted_thesis_issue.json"
@@ -546,6 +638,8 @@ mod tests {
             metric_tolerance: Some(0.01),
             metric_direction: MetricDirection::HigherIsBetter,
             lead_github_login: Some(lead_github_login.to_string()),
+            maintainer_github_login: Some("maintainer".to_string()),
+            auto_approve: true,
             assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
             review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -492,7 +492,9 @@ fn count_queue_depth(theses: &[ThesisState], auto_approve: bool) -> usize {
         .filter(|thesis| {
             thesis.issue.state == "OPEN"
                 && (matches!(thesis.phase, ThesisPhase::Approved)
-                    || (!auto_approve && matches!(thesis.phase, ThesisPhase::Submitted)))
+                    || (!auto_approve
+                        && matches!(thesis.phase, ThesisPhase::Submitted)
+                        && !thesis.maintainer_rejected))
         })
         .count()
 }
@@ -585,6 +587,35 @@ mod tests {
 
         assert!(matches!(submitted.phase, ThesisPhase::Submitted));
         assert_eq!(count_queue_depth(&[submitted], false), 1);
+    }
+
+    #[test]
+    fn queue_depth_excludes_rejected_submitted_theses() {
+        let thesis = ThesisState {
+            issue: Issue {
+                number: 3,
+                title: "Rejected thesis".to_string(),
+                body: None,
+                state: "OPEN".to_string(),
+                labels: vec![],
+                created_at: chrono::Utc::now(),
+                closed_at: None,
+                author: None,
+                url: None,
+            },
+            phase: ThesisPhase::Submitted,
+            approved: false,
+            maintainer_approved: false,
+            maintainer_rejected: true,
+            active_claims: vec![],
+            releases: vec![],
+            attempts: vec![],
+            pull_requests: vec![],
+            best_attempt_metric: None,
+            findings: vec![],
+        };
+
+        assert_eq!(count_queue_depth(&[thesis], false), 0);
     }
 
     #[test]

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -152,7 +152,7 @@ impl RepositoryState {
             .into_iter()
             .collect::<Vec<_>>();
 
-        let queue_depth = count_queue_depth(&theses);
+        let queue_depth = count_queue_depth(&theses, config.auto_approve);
 
         let current_best_accepted_metric = theses
             .iter()
@@ -486,11 +486,13 @@ pub fn select_metric(current: Option<f64>, candidate: f64, direction: MetricDire
     }
 }
 
-fn count_queue_depth(theses: &[ThesisState]) -> usize {
+fn count_queue_depth(theses: &[ThesisState], auto_approve: bool) -> usize {
     theses
         .iter()
         .filter(|thesis| {
-            thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
+            thesis.issue.state == "OPEN"
+                && (matches!(thesis.phase, ThesisPhase::Approved)
+                    || (!auto_approve && matches!(thesis.phase, ThesisPhase::Submitted)))
         })
         .count()
 }
@@ -570,7 +572,19 @@ mod tests {
         .unwrap();
 
         assert!(matches!(approved.phase, ThesisPhase::Approved));
-        assert_eq!(count_queue_depth(&[exhausted, approved]), 1);
+        assert_eq!(count_queue_depth(&[exhausted, approved], true), 1);
+    }
+
+    #[test]
+    fn queue_depth_counts_submitted_theses_when_auto_approve_is_disabled() {
+        let fixture = exhausted_fixture();
+        let mut submitted_comments = fixture.comments;
+        submitted_comments.clear();
+        let config = test_config(&fixture.lead_github_login);
+        let submitted = ThesisState::derive(fixture.issue, submitted_comments, &[], &config).unwrap();
+
+        assert!(matches!(submitted.phase, ThesisPhase::Submitted));
+        assert_eq!(count_queue_depth(&[submitted], false), 1);
     }
 
     #[test]

--- a/cli/src/tui/views.rs
+++ b/cli/src/tui/views.rs
@@ -19,9 +19,9 @@ pub fn draw(frame: &mut Frame, app: &DashboardApp, ctx: &AppContext) {
         .split(frame.area());
 
     draw_summary(frame, root[0], app, ctx);
-    draw_thesis_table(frame, root[1], app);
+    draw_thesis_table(frame, root[1], app, ctx);
     if app.show_details {
-        draw_detail(frame, root[2], app);
+        draw_detail(frame, root[2], app, ctx);
     } else {
         draw_activity(frame, root[2], app);
     }
@@ -55,8 +55,46 @@ fn draw_summary(
         .iter()
         .filter(|finding| matches!(finding.severity, AuditSeverity::Suspicious))
         .count();
+    let maintainer_pending = app
+        .repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| {
+            let mut count = 0usize;
+            if thesis.issue.state == "OPEN"
+                && matches!(thesis.phase, crate::state::ThesisPhase::Submitted)
+                && !thesis.maintainer_rejected
+            {
+                count += 1;
+            }
+            count += thesis
+                .pull_requests
+                .iter()
+                .filter(|pr| {
+                    pr.pr.state == "OPEN"
+                        && pr.decision.is_none()
+                        && !pr.maintainer_approved
+                        && !pr.maintainer_rejected
+                })
+                .count();
+            std::iter::once(count)
+        })
+        .sum::<usize>();
+    let maintainer_rejected = app
+        .repo_state
+        .theses
+        .iter()
+        .map(|thesis| {
+            usize::from(thesis.maintainer_rejected)
+                + thesis
+                    .pull_requests
+                    .iter()
+                    .filter(|pr| pr.pr.state == "OPEN" && pr.maintainer_rejected)
+                    .count()
+        })
+        .sum::<usize>();
     let text = format!(
-        "Repo: {} | Theses: {} | Queue: {}/{} | Best: {} | Nodes: {} | results.tsv current: {} | Findings: {} invalid / {} suspicious",
+        "Repo: {} | Theses: {} | Queue: {}/{} | Best: {} | Nodes: {} | results.tsv current: {} | Findings: {} invalid / {} suspicious | Maintainer: {}",
         ctx.repo.slug(),
         app.repo_state.theses.len(),
         app.repo_state.queue_depth,
@@ -73,7 +111,12 @@ fn draw_summary(
             "no"
         },
         invalid_count,
-        suspicious_count
+        suspicious_count,
+        if ctx.config.auto_approve {
+            "auto".to_string()
+        } else {
+            format!("{maintainer_pending} awaiting / {maintainer_rejected} rejected")
+        }
     );
 
     let paragraph =
@@ -81,7 +124,12 @@ fn draw_summary(
     frame.render_widget(paragraph, area);
 }
 
-fn draw_thesis_table(frame: &mut Frame, area: ratatui::layout::Rect, app: &DashboardApp) {
+fn draw_thesis_table(
+    frame: &mut Frame,
+    area: ratatui::layout::Rect,
+    app: &DashboardApp,
+    ctx: &AppContext,
+) {
     let rows = app.repo_state.theses.iter().map(|thesis| {
         let claims = if thesis.active_claims.is_empty() {
             "—".to_string()
@@ -102,6 +150,7 @@ fn draw_thesis_table(frame: &mut Frame, area: ratatui::layout::Rect, app: &Dashb
             Cell::from(format!("#{}", thesis.issue.number)),
             Cell::from(thesis.issue.title.clone()),
             Cell::from(format!("{:?}", thesis.phase)),
+            Cell::from(thesis.maintainer_summary(ctx.config.auto_approve)),
             Cell::from(claims),
             Cell::from(best_metric),
             Cell::from(thesis.attempts.len().to_string()),
@@ -112,6 +161,7 @@ fn draw_thesis_table(frame: &mut Frame, area: ratatui::layout::Rect, app: &Dashb
         Constraint::Length(8),
         Constraint::Percentage(45),
         Constraint::Length(20),
+        Constraint::Length(14),
         Constraint::Length(18),
         Constraint::Length(10),
         Constraint::Length(8),
@@ -122,6 +172,7 @@ fn draw_thesis_table(frame: &mut Frame, area: ratatui::layout::Rect, app: &Dashb
                 "Issue",
                 "Title",
                 "State",
+                "Maintainer",
                 "Claimed By",
                 "Best",
                 "Attempts",
@@ -160,7 +211,12 @@ fn draw_activity(frame: &mut Frame, area: ratatui::layout::Rect, app: &Dashboard
     frame.render_widget(list, area);
 }
 
-fn draw_detail(frame: &mut Frame, area: ratatui::layout::Rect, app: &DashboardApp) {
+fn draw_detail(
+    frame: &mut Frame,
+    area: ratatui::layout::Rect,
+    app: &DashboardApp,
+    ctx: &AppContext,
+) {
     let text = if let Some(thesis) = app.selected_thesis() {
         let attempts = thesis
             .attempts
@@ -173,11 +229,24 @@ fn draw_detail(frame: &mut Frame, area: ratatui::layout::Rect, app: &DashboardAp
             })
             .collect::<Vec<_>>()
             .join("\n");
+        let open_prs = thesis
+            .pull_requests
+            .iter()
+            .filter(|pr| pr.pr.state == "OPEN")
+            .map(|pr| format!("#{} {}", pr.pr.number, pr.maintainer_status(ctx.config.auto_approve)))
+            .collect::<Vec<_>>()
+            .join(", ");
         format!(
-            "Thesis #{}\n{}\n\nState: {:?}\nClaims: {}\nFindings: {}\nAttempts:\n{}",
+            "Thesis #{}\n{}\n\nState: {:?}\nMaintainer: {}\nOpen PRs: {}\nClaims: {}\nFindings: {}\nAttempts:\n{}",
             thesis.issue.number,
             thesis.issue.title,
             thesis.phase,
+            thesis.maintainer_summary(ctx.config.auto_approve),
+            if open_prs.is_empty() {
+                "none".to_string()
+            } else {
+                open_prs
+            },
             if thesis.active_claims.is_empty() {
                 "none".to_string()
             } else {

--- a/cli/src/tui/views.rs
+++ b/cli/src/tui/views.rs
@@ -67,16 +67,18 @@ fn draw_summary(
             {
                 count += 1;
             }
-            count += thesis
-                .pull_requests
-                .iter()
-                .filter(|pr| {
-                    pr.pr.state == "OPEN"
-                        && pr.decision.is_none()
-                        && !pr.maintainer_approved
-                        && !pr.maintainer_rejected
-                })
-                .count();
+            if thesis.issue.state == "OPEN" {
+                count += thesis
+                    .pull_requests
+                    .iter()
+                    .filter(|pr| {
+                        pr.pr.state == "OPEN"
+                            && pr.decision.is_none()
+                            && !pr.maintainer_approved
+                            && !pr.maintainer_rejected
+                    })
+                    .count();
+            }
             std::iter::once(count)
         })
         .sum::<usize>();
@@ -85,12 +87,16 @@ fn draw_summary(
         .theses
         .iter()
         .map(|thesis| {
-            usize::from(thesis.maintainer_rejected)
-                + thesis
-                    .pull_requests
-                    .iter()
-                    .filter(|pr| pr.pr.state == "OPEN" && pr.maintainer_rejected)
-                    .count()
+            if thesis.issue.state != "OPEN" {
+                0
+            } else {
+                usize::from(thesis.maintainer_rejected)
+                    + thesis
+                        .pull_requests
+                        .iter()
+                        .filter(|pr| pr.pr.state == "OPEN" && pr.maintainer_rejected)
+                        .count()
+            }
         })
         .sum::<usize>();
     let text = format!(

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -97,10 +97,27 @@ pub struct ValidDecisionRecord {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaintainerVerdict {
+    Approve,
+    Reject,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MaintainerFeedback {
+    pub verdict: MaintainerVerdict,
+    pub reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone)]
 pub struct PullRequestValidation {
     pub thesis_number: Option<u64>,
     pub policy_pass: bool,
+    pub maintainer_approved: bool,
+    pub maintainer_rejected: bool,
+    pub maintainer_feedback: Vec<MaintainerFeedback>,
     pub review_claims: Vec<ValidReviewClaimRecord>,
     pub reviews: Vec<ValidReviewRecord>,
     pub decision: Option<ValidDecisionRecord>,
@@ -110,6 +127,9 @@ pub struct PullRequestValidation {
 #[derive(Debug, Clone)]
 pub struct IssueValidation {
     pub approved: bool,
+    pub maintainer_approved: bool,
+    pub maintainer_rejected: bool,
+    pub maintainer_feedback: Vec<MaintainerFeedback>,
     pub active_claims: Vec<ValidClaimRecord>,
     pub releases: Vec<ValidReleaseRecord>,
     pub attempts: Vec<ValidAttemptRecord>,
@@ -137,6 +157,9 @@ pub fn validate_pull_request(
     sorted_comments.sort_by_key(|comment| (comment.created_at, comment.id));
 
     let mut policy_pass = false;
+    let mut maintainer_approved = false;
+    let mut maintainer_rejected = false;
+    let mut maintainer_feedback = Vec::new();
     let mut review_claims = Vec::new();
     let mut claimed_nodes = BTreeSet::new();
     let mut reviews = Vec::new();
@@ -149,6 +172,40 @@ pub fn validate_pull_request(
 
     for comment in sorted_comments {
         match &comment.protocol {
+            Some(ProtocolComment::SlashApprove { reason }) => {
+                if !is_maintainer_actor(&comment.author, config) {
+                    findings.push(invalid_issue_like(
+                        AuditScope::PullRequest { number: pr.number },
+                        &comment,
+                        "slash approve comment from non-maintainer actor",
+                    ));
+                } else {
+                    maintainer_approved = true;
+                    maintainer_rejected = false;
+                    maintainer_feedback.push(MaintainerFeedback {
+                        verdict: MaintainerVerdict::Approve,
+                        reason: reason.clone(),
+                        created_at: comment.created_at,
+                    });
+                }
+            }
+            Some(ProtocolComment::SlashReject { reason }) => {
+                if !is_maintainer_actor(&comment.author, config) {
+                    findings.push(invalid_issue_like(
+                        AuditScope::PullRequest { number: pr.number },
+                        &comment,
+                        "slash reject comment from non-maintainer actor",
+                    ));
+                } else {
+                    maintainer_approved = false;
+                    maintainer_rejected = true;
+                    maintainer_feedback.push(MaintainerFeedback {
+                        verdict: MaintainerVerdict::Reject,
+                        reason: reason.clone(),
+                        created_at: comment.created_at,
+                    });
+                }
+            }
             Some(ProtocolComment::AdminNote {
                 action,
                 related_comment_id,
@@ -330,6 +387,9 @@ pub fn validate_pull_request(
     PullRequestValidation {
         thesis_number,
         policy_pass,
+        maintainer_approved,
+        maintainer_rejected,
+        maintainer_feedback,
         review_claims,
         reviews,
         decision,
@@ -347,6 +407,9 @@ pub fn validate_issue(
     sorted_comments.sort_by_key(|comment| (comment.created_at, comment.id));
 
     let mut approved = false;
+    let mut maintainer_approved = false;
+    let mut maintainer_rejected = false;
+    let mut maintainer_feedback = Vec::new();
     let mut findings = Vec::new();
     let mut acknowledged_comment_ids = BTreeSet::new();
     let mut active_claims = HashMap::<String, ValidClaimRecord>::new();
@@ -358,6 +421,46 @@ pub fn validate_issue(
 
     for comment in sorted_comments {
         match &comment.protocol {
+            Some(ProtocolComment::SlashApprove { reason }) => {
+                if !is_maintainer_actor(&comment.author, config) {
+                    findings.push(invalid_issue_like(
+                        AuditScope::Issue {
+                            number: issue.number,
+                        },
+                        &comment,
+                        "slash approve comment from non-maintainer actor",
+                    ));
+                } else {
+                    approved = true;
+                    maintainer_approved = true;
+                    maintainer_rejected = false;
+                    maintainer_feedback.push(MaintainerFeedback {
+                        verdict: MaintainerVerdict::Approve,
+                        reason: reason.clone(),
+                        created_at: comment.created_at,
+                    });
+                }
+            }
+            Some(ProtocolComment::SlashReject { reason }) => {
+                if !is_maintainer_actor(&comment.author, config) {
+                    findings.push(invalid_issue_like(
+                        AuditScope::Issue {
+                            number: issue.number,
+                        },
+                        &comment,
+                        "slash reject comment from non-maintainer actor",
+                    ));
+                } else {
+                    approved = false;
+                    maintainer_approved = false;
+                    maintainer_rejected = true;
+                    maintainer_feedback.push(MaintainerFeedback {
+                        verdict: MaintainerVerdict::Reject,
+                        reason: reason.clone(),
+                        created_at: comment.created_at,
+                    });
+                }
+            }
             Some(ProtocolComment::AdminNote {
                 action,
                 related_comment_id,
@@ -376,15 +479,6 @@ pub fn validate_issue(
                         acknowledged_comment_ids.insert(*related_comment_id);
                     }
                 }
-            }
-            Some(ProtocolComment::SlashApprove) => {
-                findings.push(suspicious_issue_like(
-                    AuditScope::Issue {
-                        number: issue.number,
-                    },
-                    &comment,
-                    "manual `/approve` comment is non-canonical; use `polyresearch generate` or an admin command",
-                ));
             }
             Some(ProtocolComment::Approval { thesis }) => {
                 if *thesis != issue.number {
@@ -600,6 +694,9 @@ pub fn validate_issue(
 
     IssueValidation {
         approved,
+        maintainer_approved,
+        maintainer_rejected,
+        maintainer_feedback,
         active_claims,
         releases,
         attempts,
@@ -612,6 +709,14 @@ fn is_lead_actor(author: &str, config: &ProtocolConfig) -> bool {
         .lead_github_login
         .as_deref()
         .map(|lead| lead == author)
+        .unwrap_or(false)
+}
+
+fn is_maintainer_actor(author: &str, config: &ProtocolConfig) -> bool {
+    config
+        .maintainer_github_login
+        .as_deref()
+        .map(|maintainer| maintainer == author)
         .unwrap_or(false)
 }
 
@@ -670,6 +775,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct IssueFixture {
         lead_github_login: String,
+        maintainer_github_login: Option<String>,
         issue: Issue,
         comments: Vec<IssueComment>,
     }
@@ -678,6 +784,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct PullRequestFixture {
         lead_github_login: String,
+        maintainer_github_login: Option<String>,
         pr: PullRequest,
         comments: Vec<IssueComment>,
     }
@@ -687,7 +794,10 @@ mod tests {
         let fixture: IssueFixture =
             serde_json::from_str(include_str!("../tests/fixtures/duplicate_claim_issue.json"))
                 .unwrap();
-        let config = test_config(&fixture.lead_github_login);
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
         let comments = envelopes(fixture.comments);
         let validation = validate_issue(&fixture.issue, &comments, &config, None);
 
@@ -706,7 +816,10 @@ mod tests {
         let fixture: PullRequestFixture =
             serde_json::from_str(include_str!("../tests/fixtures/non_lead_decision_pr.json"))
                 .unwrap();
-        let config = test_config(&fixture.lead_github_login);
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
         let comments = envelopes(fixture.comments);
         let validation = validate_pull_request(&fixture.pr, &comments, &config);
 
@@ -726,7 +839,10 @@ mod tests {
             "../tests/fixtures/attempt_after_closure_issue.json"
         ))
         .unwrap();
-        let config = test_config(&fixture.lead_github_login);
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
         let comments = envelopes(fixture.comments);
         let validation = validate_issue(&fixture.issue, &comments, &config, None);
 
@@ -745,12 +861,74 @@ mod tests {
             "../tests/fixtures/acknowledged_invalid_issue.json"
         ))
         .unwrap();
-        let config = test_config(&fixture.lead_github_login);
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
         let comments = envelopes(fixture.comments);
         let validation = validate_issue(&fixture.issue, &comments, &config, None);
 
         assert!(validation.approved);
         assert!(validation.findings.is_empty());
+    }
+
+    #[test]
+    fn maintainer_slash_approve_marks_issue_as_approved() {
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/maintainer_approve_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
+        let comments = envelopes(fixture.comments);
+        let validation = validate_issue(&fixture.issue, &comments, &config, None);
+
+        assert!(validation.approved);
+        assert!(validation.maintainer_approved);
+        assert!(!validation.maintainer_rejected);
+        assert_eq!(validation.maintainer_feedback.len(), 1);
+        assert!(validation.findings.is_empty());
+    }
+
+    #[test]
+    fn maintainer_slash_reject_marks_issue_as_rejected() {
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/maintainer_reject_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(
+            &fixture.lead_github_login,
+            fixture.maintainer_github_login.as_deref(),
+        );
+        let comments = envelopes(fixture.comments);
+        let validation = validate_issue(&fixture.issue, &comments, &config, None);
+
+        assert!(!validation.approved);
+        assert!(!validation.maintainer_approved);
+        assert!(validation.maintainer_rejected);
+        assert_eq!(validation.maintainer_feedback.len(), 1);
+        assert!(validation.findings.is_empty());
+    }
+
+    #[test]
+    fn non_maintainer_slash_approve_is_invalid() {
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/maintainer_approve_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(&fixture.lead_github_login, Some("someone-else"));
+        let comments = envelopes(fixture.comments);
+        let validation = validate_issue(&fixture.issue, &comments, &config, None);
+
+        assert!(!validation.approved);
+        assert_eq!(validation.findings.len(), 1);
+        assert!(
+            validation.findings[0]
+                .message
+                .contains("slash approve comment from non-maintainer actor")
+        );
     }
 
     fn envelopes(comments: Vec<IssueComment>) -> Vec<ProtocolEnvelope> {
@@ -761,12 +939,17 @@ mod tests {
             .unwrap()
     }
 
-    fn test_config(lead_github_login: &str) -> ProtocolConfig {
+    fn test_config(
+        lead_github_login: &str,
+        maintainer_github_login: Option<&str>,
+    ) -> ProtocolConfig {
         ProtocolConfig {
             required_confirmations: 0,
             metric_tolerance: Some(0.01),
             metric_direction: MetricDirection::HigherIsBetter,
             lead_github_login: Some(lead_github_login.to_string()),
+            maintainer_github_login: maintainer_github_login.map(ToString::to_string),
+            auto_approve: true,
             assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
             review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -114,6 +114,10 @@ impl GitHubApi for MockGitHubClient {
         })
     }
 
+    fn add_assignees(&self, _issue_number: u64, _assignees: &[&str]) -> Result<()> {
+        Ok(())
+    }
+
     fn close_issue(&self, _issue_number: u64) -> Result<Issue> {
         Err(eyre!("unexpected close_issue call in test"))
     }
@@ -718,6 +722,8 @@ fn make_ctx(
             metric_tolerance: Some(0.01),
             metric_direction: MetricDirection::HigherIsBetter,
             lead_github_login: Some(lead_github_login.to_string()),
+            maintainer_github_login: Some("maintainer".to_string()),
+            auto_approve: true,
             assignment_timeout: Duration::from_secs(24 * 60 * 60),
             review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,

--- a/cli/tests/fixtures/maintainer_approve_issue.json
+++ b/cli/tests/fixtures/maintainer_approve_issue.json
@@ -1,0 +1,24 @@
+{
+  "leadGithubLogin": "lead",
+  "maintainerGithubLogin": "maintainer",
+  "issue": {
+    "number": 21,
+    "title": "Maintainer approve fixture",
+    "body": "Test thesis",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/21"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "/approve focus on normalization layers",
+      "user": { "login": "maintainer" },
+      "created_at": "2099-04-08T00:01:00Z",
+      "updated_at": null
+    }
+  ]
+}

--- a/cli/tests/fixtures/maintainer_reject_issue.json
+++ b/cli/tests/fixtures/maintainer_reject_issue.json
@@ -1,0 +1,24 @@
+{
+  "leadGithubLogin": "lead",
+  "maintainerGithubLogin": "maintainer",
+  "issue": {
+    "number": 22,
+    "title": "Maintainer reject fixture",
+    "body": "Test thesis",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/22"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "/reject too broad for the current project",
+      "user": { "login": "maintainer" },
+      "created_at": "2099-04-08T00:01:00Z",
+      "updated_at": null
+    }
+  ]
+}

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -91,12 +91,18 @@ Each iteration, before any experiments:
      - For each PR without policy-check:
        polyresearch policy-check <pr>
      - For each PR with enough reviews and no decision:
+       - If `auto_approve` is `false`, wait for the maintainer to comment `/approve`.
+         The lead should assign the PR to `maintainer_github_login` while it waits.
        polyresearch decide <pr>
 
   4. Check queue depth:
      - If below min_queue_depth:
        polyresearch generate --title "<title>" --body "<body>"
+     - If `auto_approve` is `false`, generated theses are not auto-approved.
+       They stay queued for the maintainer to `/approve` or `/reject`.
      - Read results.tsv and all thesis history before generating.
+     - Read maintainer `/approve` and `/reject` comments and use them as
+       directional input for future thesis generation.
      - Deduplicate against existing open and closed theses.
 
   5. Now proceed with contributor loop (experiments, etc.)


### PR DESCRIPTION
## Summary
- add a shared `auto_approve` switch plus `maintainer_github_login` so generated theses and candidate PRs can wait on a human `/approve` or `/reject`
- treat maintainer slash commands as canonical state in the CLI, assign waiting issues and PRs to the maintainer, and stop `generate` and `decide` until approval lands
- show waiting and rejected maintainer state in `polyresearch status`, the TUI, the protocol docs, the repo skill, and the test suite

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new human-in-the-loop gate that changes how thesis/PR state is derived and blocks `generate`/`decide` without maintainer input, which could stall automation if misconfigured or if comment parsing/assignment behavior is wrong.
> 
> **Overview**
> Adds a **maintainer approval gate** to the polyresearch protocol via new config keys `maintainer_github_login` and `auto_approve`, allowing projects to require a human `/approve` or `/reject` before theses progress and before the lead can decide candidate PRs.
> 
> Updates the CLI to parse maintainer slash commands (with optional reasons) as canonical state, assign waiting issues/PRs to the maintainer, include *submitted-but-waiting* items in queue depth when gated, and surface pending/rejected maintainer items in `polyresearch duties`, `status`, and the TUI; docs/skills and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629ea33803d884ec2dc8df09a1f1b19e42b9b621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->