### PR TITLE
Document maintainer approval gates in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ results.tsv         -- lab notebook of every experiment (lead-maintained)
 
 ## Roles
 
-**Maintainer.** Writes `PROGRAM.md` and `PREPARE.md`. Approves theses. Picks the tooling.
+**Maintainer.** Writes `PROGRAM.md` and `PREPARE.md`. Picks the tooling. When `auto_approve` is `false`, reviews generated theses and candidate PRs with `/approve` or `/reject` before agents can proceed.
 
 **Contributor.** A machine running an agent. Runs experiments and reviews others' results. Many contributors per project.
 
@@ -84,6 +84,7 @@ results.tsv         -- lab notebook of every experiment (lead-maintained)
 - **Structured comments as the state mechanism.** Agents coordinate through structured HTML comments on GitHub Issues and PRs. State is derived from the comment trail, not from mutable labels. Every transition is append-only, attributed, and auditable.
 - **Mandatory CLI, familiar GitHub activity.** Agents and humans use `polyresearch` for protocol mutations, but GitHub still shows the same readable issue comments, PR comments, and branch structure as before.
 - **Independent peer review.** Multiple contributors rerun the evaluation, measuring the baseline themselves. Results must agree within tolerance. No single contributor decides the outcome.
+- **Human-in-the-loop when you want it.** Set `auto_approve` to `false` and the lead waits for the maintainer to `/approve` or `/reject` each thesis and PR before proceeding. The maintainer's feedback steers future thesis generation. Flip it back to `true` when you're comfortable with the trajectory.
 - **The evaluation is the trust boundary.** `PREPARE.md` defines how results are judged. The evaluation code is outside the editable surface. Agents cannot grade their own homework.
 - **Failed experiments are data.** Every attempt stays as an unmerged branch with a row in `results.tsv` and a structured attempt comment on the thesis issue. No `git reset`, no lost code. The lead reads the full history to generate new theses and avoid dead ends.
 - **The environment is the maintainer's choice.** `.polyresearch/` is the standard location for the reproducible environment. Polyresearch standardizes where it lives, not what goes in it.

--- a/cli/README.md
+++ b/cli/README.md
@@ -111,10 +111,20 @@ Lead flow:
 
 ```bash
 polyresearch sync
+polyresearch duties
 polyresearch generate --title "New thesis" --body "Hypothesis and rationale"
 polyresearch policy-check 93
 polyresearch decide 93
 polyresearch admin reconcile-ledger
+```
+
+Maintainer approval (when `auto_approve` is `false` in `PROGRAM.md`):
+
+The maintainer comments `/approve` or `/reject` directly on thesis issues and candidate PRs in GitHub. Both commands accept an optional reason that the lead reads as directional input for future thesis generation.
+
+```
+/approve focus on normalization layers
+/reject this direction already failed for architectural reasons
 ```
 
 ## Output modes
@@ -135,9 +145,10 @@ polyresearch admin reconcile-ledger
 - `polyresearch review-claim` -- claim a PR for review
 - `polyresearch review` -- post a structured review record with env hash
 - `polyresearch sync` -- reconcile `results.tsv` from the comment trail
-- `polyresearch generate` -- open and auto-approve a thesis issue
+- `polyresearch generate` -- open a thesis issue (auto-approves when `auto_approve` is `true`, otherwise assigns to maintainer)
 - `polyresearch policy-check` -- validate PR files against the editable surface
-- `polyresearch decide` -- post the lead decision and merge/close accordingly
+- `polyresearch decide` -- post the lead decision and merge/close accordingly (waits for maintainer `/approve` when `auto_approve` is `false`)
+- `polyresearch duties` -- list blocking and advisory work items for the current node
 - `polyresearch admin ...` -- lead-only repair commands for exceptional recovery
 
 ## Notes


### PR DESCRIPTION
## Summary
- main README: updated Maintainer role description and added human-in-the-loop as a design choice
- CLI README: added `duties` to the command summary, documented `/approve` and `/reject` workflow, and noted `auto_approve` behavior on `generate` and `decide`

Follows up on PR #21 which added the feature but missed the README updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates clarifying `auto_approve`/maintainer `/approve`/`/reject` gating and the `duties` command; no runtime or protocol logic changes.
> 
> **Overview**
> Documents the optional *human-in-the-loop* approval gate when `auto_approve` is `false`, clarifying that maintainers can block/steer progress by commenting `/approve` or `/reject` on thesis issues and candidate PRs.
> 
> Updates the CLI workflow docs to include `polyresearch duties`, and refines `generate`/`decide` command descriptions to note their behavior under `auto_approve`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a96aafb28e7d1d7c876bd8dd4c6e8c839cb8e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->