### PR TITLE
Use composite node IDs to prevent cross-user collisions

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -57,7 +57,7 @@ When you start, before doing anything else:
 3. Run `git log --oneline -20` on `main` to see recent state.
 4. If `.polyresearch/` exists, run its setup. Otherwise follow PREPARE.md setup instructions.
 5. Check your GitHub identity. Run `gh api user --jq '.login'` to see which GitHub account you are operating as. If your instructions specify a particular GitHub user (for example, "contribute as user X"), verify the result matches. If it does not, stop and report the mismatch before proceeding. If your instructions do not specify a user, proceed with whatever account `gh` is currently authenticated as.
-6. Generate your node identifier if you don't have one. Run `polyresearch init`. The CLI generates a composite identifier in the form `{github_login}/{hostname}` (e.g. `alice/mac.lan`). This prevents collisions when multiple GitHub users share the same machine hostname. Override the machine part with `polyresearch init --node <id>`.
+6. Generate your node identifier if you don't have one. Run `polyresearch init`. The CLI generates a composite identifier in the form `{github_login}/{hostname}-{suffix}` (e.g. `alice/mac.lan-a3f2`). This prevents collisions across users and across multiple machines with the same hostname. Override the machine part with `polyresearch init --node <id>`.
 7. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
 
 ---

--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -57,7 +57,7 @@ When you start, before doing anything else:
 3. Run `git log --oneline -20` on `main` to see recent state.
 4. If `.polyresearch/` exists, run its setup. Otherwise follow PREPARE.md setup instructions.
 5. Check your GitHub identity. Run `gh api user --jq '.login'` to see which GitHub account you are operating as. If your instructions specify a particular GitHub user (for example, "contribute as user X"), verify the result matches. If it does not, stop and report the mismatch before proceeding. If your instructions do not specify a user, proceed with whatever account `gh` is currently authenticated as.
-6. Generate your node identifier if you don't have one. Use your machine's hostname or a short ID (e.g. `node-7f83`). Keep it consistent across sessions.
+6. Generate your node identifier if you don't have one. Run `polyresearch init`. The CLI generates a composite identifier in the form `{github_login}/{hostname}` (e.g. `alice/mac.lan`). This prevents collisions when multiple GitHub users share the same machine hostname. Override the machine part with `polyresearch init --node <id>`.
 7. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
 
 ---
@@ -335,22 +335,22 @@ Both forms are valid approval signals. The protocol recognizes either.
 **Claim** (contributor claims a thesis):
 
 ```
-Polyresearch claim: thesis #12 by node `node-7f83`.
+Polyresearch claim: thesis #12 by node `alice/node-7f83`.
 
 <!-- polyresearch:claim
 thesis: 12
-node: node-7f83
+node: alice/node-7f83
 -->
 ```
 
 **Release** (contributor releases a claim without submitting a candidate):
 
 ```
-Polyresearch release: thesis #12 by node `node-7f83` (`reason: no_improvement`).
+Polyresearch release: thesis #12 by node `alice/node-7f83` (`reason: no_improvement`).
 
 <!-- polyresearch:release
 thesis: 12
-node: node-7f83
+node: alice/node-7f83
 reason: no_improvement | timeout | infra_failure
 -->
 ```
@@ -390,24 +390,24 @@ candidate_sha: a1b2c3d
 **Review claim** (reviewer signals they are starting evaluation):
 
 ```
-Polyresearch review claim: thesis #12 by node `node-3e91`.
+Polyresearch review claim: thesis #12 by node `bob/node-3e91`.
 
 <!-- polyresearch:review-claim
 thesis: 12
-node: node-3e91
+node: bob/node-3e91
 -->
 ```
 
 **Review record** (reviewer posts evaluation results):
 
 ```
-Polyresearch review: thesis #12 by node `node-3e91`, candidate `0.9934`, baseline `0.9979`, observation `improved`.
+Polyresearch review: thesis #12 by node `bob/node-3e91`, candidate `0.9934`, baseline `0.9979`, observation `improved`.
 
 <!-- polyresearch:review
 thesis: 12
 candidate_sha: a1b2c3d
 base_sha: c0d1e2f
-node: node-3e91
+node: bob/node-3e91
 metric: 0.9934
 baseline_metric: 0.9979
 observation: improved | no_improvement | crashed | infra_failure

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -309,6 +309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -743,7 +754,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -800,7 +811,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -999,6 +1010,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1029,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1436,7 +1448,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -1642,7 +1654,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1929,7 +1941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2011,6 +2023,7 @@ dependencies = [
  "crossterm",
  "globset",
  "octocrab",
+ "rand 0.10.1",
  "ratatui",
  "regex",
  "serde",
@@ -2107,7 +2120,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2117,7 +2141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2128,6 +2152,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "ratatui"
@@ -2289,7 +2319,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2604,7 +2634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ color-eyre = "0.6.5"
 crossterm = "0.29.0"
 globset = "0.4.18"
 octocrab = "0.49.7"
+rand = "0.10.1"
 ratatui = "0.30.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::process::Command;
 
 use color_eyre::eyre::Result;
+use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::InitArgs;
@@ -48,6 +49,12 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
 }
 
 fn default_machine_id() -> String {
+    let hostname = resolve_hostname();
+    let suffix: u16 = rand::rng().random();
+    format!("{hostname}-{suffix:04x}")
+}
+
+fn resolve_hostname() -> String {
     if let Ok(hostname) = env::var("HOSTNAME") {
         if !hostname.trim().is_empty() {
             return hostname;

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -15,10 +15,11 @@ struct InitOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
-    let node = args.node.clone().unwrap_or_else(default_node_id);
     let login = ctx.github.current_login()?;
     let _ = ctx.github.auth_status()?;
     let _ = ctx.github.auth_token()?;
+    let machine_id = args.node.clone().unwrap_or_else(default_machine_id);
+    let node = format!("{login}/{machine_id}");
 
     if let Ok(false) = ctx.github.repo_has_issues() {
         eprintln!("Warning: Issues are disabled on this repository (common for forks).");
@@ -46,7 +47,7 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     })
 }
 
-fn default_node_id() -> String {
+fn default_machine_id() -> String {
     if let Ok(hostname) = env::var("HOSTNAME") {
         if !hostname.trim().is_empty() {
             return hostname;

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -221,7 +221,7 @@ async fn init_writes_node_identity() {
     .unwrap();
 
     let node_file = repo.path.join(".polyresearch-node");
-    assert_eq!(fs::read_to_string(node_file).unwrap(), "test-node\n");
+    assert_eq!(fs::read_to_string(node_file).unwrap(), "lead/test-node\n");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Node IDs are now `{github_login}/{hostname}` (e.g. `alice/mac.lan`) instead of bare hostnames
- Prevents the collision that occurred when two different GitHub users on Macs both got node name `mac.lan`, causing one user's duties/claims to bleed into the other's
- Updates POLYRESEARCH.md structured comment examples to use composite format

## Context

Closes #24. In the `alanzabihi/eslint` project, contributor `homanp` ran `polyresearch init` on a Mac and got node `mac.lan` -- the same node name as existing contributor `samadin-123`. This caused `polyresearch duties` to show `samadin-123`'s claims as `homanp`'s blocking duties, and led to a fraudulent release comment that required lead intervention.

## Test plan

- [x] All 39 existing tests pass (21 unit + 18 e2e)
- [x] `init_writes_node_identity` test updated to expect composite format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the node identity format written by `polyresearch init`, which can affect how claims/duties match existing GitHub comments and existing `.polyresearch-node` files. Risk is mitigated by being localized to initialization and covered by updated e2e expectations, but may require migration for existing users.
> 
> **Overview**
> `polyresearch init` now writes a **composite node identifier** of the form `{github_login}/{hostname}-{suffix}` (or `{github_login}/{--node}`) instead of a bare machine name, preventing cross-user/machine collisions in protocol state.
> 
> This adds `rand` to generate the suffix, updates tests to expect the new `.polyresearch-node` contents, and updates `POLYRESEARCH.md` structured comment examples/documentation to use the composite node format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25198313d236829ccb7331c2215f2f5f19109289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->