### PR TITLE
Add per-node resource policy and polyresearch pace command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 .env
 .venv/
 node_modules/
-.polyresearch-node
+.polyresearch-node.toml
 target/
 cli/target/
 *.log

--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -57,8 +57,29 @@ When you start, before doing anything else:
 3. Run `git log --oneline -20` on `main` to see recent state.
 4. If `.polyresearch/` exists, run its setup. Otherwise follow PREPARE.md setup instructions.
 5. Check your GitHub identity. Run `gh api user --jq '.login'` to see which GitHub account you are operating as. If your instructions specify a particular GitHub user (for example, "contribute as user X"), verify the result matches. If it does not, stop and report the mismatch before proceeding. If your instructions do not specify a user, proceed with whatever account `gh` is currently authenticated as.
-6. Generate your node identifier if you don't have one. Run `polyresearch init`. The CLI generates a composite identifier in the form `{github_login}/{hostname}-{suffix}` (e.g. `alice/mac.lan-a3f2`). This prevents collisions across users and across multiple machines with the same hostname. Override the machine part with `polyresearch init --node <id>`.
+6. Run `polyresearch init` if `.polyresearch-node.toml` does not exist yet. The CLI generates a composite identifier in the form `{github_login}/{hostname}-{suffix}` (e.g. `alice/mac.lan-a3f2`) to prevent collisions across users and machines. Override the machine part with `polyresearch init --node <id>`. This also records your optional node-specific `resource_policy`.
 7. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
+
+---
+
+## Node configuration
+
+Each node keeps a local `.polyresearch-node.toml` file at the repo root:
+
+```toml
+node_id = "node-7f83"
+resource_policy = "8-core machine with 2 GPUs. Run up to 4 parallel evaluations. Keep GPUs saturated. Stay under 50 API calls/min."
+```
+
+- `node_id` identifies the machine or worker. Keep it stable across sessions.
+- `resource_policy` is optional natural language guidance for that node only. It is not project state.
+- Set or update it with `polyresearch init --resource-policy "..."`.
+
+If `resource_policy` is absent, the default policy applies:
+
+> Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.
+
+Run `polyresearch pace` regularly. It prints the effective resource policy alongside recent node activity so the agent can compare expectation vs reality and adjust parallelism or claim rate.
 
 ---
 
@@ -90,8 +111,9 @@ This mechanism exists because GitHub visibility is a shared resource. Other cont
 LOOP FOREVER:
 
 0. **Check duties.** Run `polyresearch duties`. If any blocking items are reported, resolve each one before continuing. The CLI will also block `claim` if duties are outstanding.
-1. **Check for theses.** Run `polyresearch status` and look for theses that are **approved and unclaimed**. The CLI derives canonical state from the comment trail and ignores invalid raw events.
-2. **If a claimable thesis exists:**
+1. **Check pace.** Run `polyresearch pace`. Compare the effective resource policy against recent throughput and adjust how many experiments you run in parallel.
+2. **Check for theses.** Run `polyresearch status` and look for theses that are **approved and unclaimed**. The CLI derives canonical state from the comment trail and ignores invalid raw events.
+3. **If a claimable thesis exists:**
   a. Run `polyresearch claim <issue-number>`.
    b. The CLI posts the `polyresearch:claim` comment and creates the thesis branch from `main`: `thesis/<issue-number>-<slug>`.
    c. Read PROGRAM.md for direction and constraints.
@@ -104,8 +126,8 @@ LOOP FOREVER:
       - Run `polyresearch attempt <issue-number> --metric <value> --baseline <value> --observation <observation> --summary "<summary>"`.
    f. **If you find an improvement:** run `polyresearch submit <issue-number>`. The CLI pushes the best attempt branch and opens the candidate PR to `main`.
    g. **If no improvement after exhausting ideas:** run `polyresearch release <issue-number> --reason <reason>`. The thesis returns to the queue for another contributor.
-3. **Check for review work.** Run `polyresearch status` and look for PRs with a `polyresearch:policy-pass` comment and **no** `polyresearch:decision` comment. These need peer review. Skip PRs you authored.
-4. **If a reviewable PR exists:**
+4. **Check for review work.** Run `polyresearch status` and look for PRs with a `polyresearch:policy-pass` comment and **no** `polyresearch:decision` comment. These need peer review. Skip PRs you authored.
+5. **If a reviewable PR exists:**
   a. Run `polyresearch review-claim <pr-number>`.
    b. Check out the **candidate SHA** (the PR head).
    c. Run the evaluation per PREPARE.md. Record the candidate metric.
@@ -113,7 +135,7 @@ LOOP FOREVER:
    e. Run the same evaluation. Record the baseline metric.
    f. If `.polyresearch/` exists, compute its content hash: `find .polyresearch/ -type f | sort | xargs sha256sum | sha256sum`.
    g. Run `polyresearch review <pr-number> --metric <candidate> --baseline <baseline> --observation <observation>`. Your `baseline_metric` is your own measurement. Do not copy it from results.tsv or the candidate's self-report.
-5. Repeat from step 1.
+6. Repeat from step 1.
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
 
@@ -132,12 +154,13 @@ Everything in the contributor loop, plus these additional responsibilities. Run 
 **Priority order within each iteration.** GitHub-visible duties run first, in this order:
 
 0. `polyresearch duties` — resolve any blocking items (decidable PRs, stale results.tsv, etc.).
-1. `polyresearch sync` (always before other lead actions).
-2. Process open PRs: `policy-check` and `decide` any that are ready. When `auto_approve` is `false`, assign ready PRs to `maintainer_github_login` and wait for `/approve`.
-3. Check queue depth; `generate` if below `min_queue_depth`.
-4. Only then proceed to local experiments.
+1. `polyresearch pace` — compare your effective resource policy against recent node throughput.
+2. `polyresearch sync` (always before other lead actions).
+3. Process open PRs: `policy-check` and `decide` any that are ready. When `auto_approve` is `false`, assign ready PRs to `maintainer_github_login` and wait for `/approve`.
+4. Check queue depth; `generate` if below `min_queue_depth`.
+5. Only then proceed to local experiments.
 
-Between experiment batches (or while waiting for evaluations), re-run steps 0–3. The lead must never have GitHub stale while the server is working. Post `polyresearch attempt` results immediately after each evaluation completes, not in batches.
+Between experiment batches (or while waiting for evaluations), re-run steps 0–4. The lead must never have GitHub stale while the server is working. Post `polyresearch attempt` results immediately after each evaluation completes, not in batches.
 
 ### Maintain results.tsv
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ What you need:
 - If the repo has a `.polyresearch/` directory, use it for setup and execution
 - Otherwise, follow the setup instructions in `PREPARE.md`
 
+Initialize each machine or clone once with `polyresearch init`. This writes a local `.polyresearch-node.toml` file with the node ID and an optional natural-language `resource_policy`. If you do not set one, the protocol default is to maximize throughput. Agents can inspect the effective policy and recent node activity with `polyresearch pace`.
+
 Polyresearch does not mandate a specific agent, model, or sandbox. It does mandate the `polyresearch` CLI as the canonical path for protocol state changes. Bring your own agent and tooling around that boundary.
 
 ## Project structure

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2030,6 +2030,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tokio",
+ "toml",
  "walkdir",
 ]
 
@@ -2548,6 +2549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3013,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3599,6 +3648,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
 tokio = { version = "1.51.0", features = ["full"] }
+toml = "1.1.2"
 walkdir = "2.5.0"
 
 # The profile that 'dist' will build with

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,13 +80,18 @@ Initialize the local node identity once per repo:
 
 ```bash
 polyresearch init
+polyresearch init --resource-policy "2 GPUs, run up to 4 evals in parallel, stay under 50 API calls/min"
 ```
+
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` plus an optional natural-language `resource_policy`. If no policy is set, the protocol default is to maximize throughput.
 
 Inspect the current state:
 
 ```bash
+polyresearch pace
 polyresearch status
 polyresearch audit
+polyresearch pace --json
 polyresearch status --json
 polyresearch status --tui
 ```
@@ -135,7 +140,8 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 ## Command summary
 
-- `polyresearch init` -- set node identity, verify GitHub auth, detect repo
+- `polyresearch init` -- set node identity, optional resource policy, verify GitHub auth, detect repo
+- `polyresearch pace` -- show the effective resource policy alongside recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
 - `polyresearch claim` -- atomically claim a thesis and create the thesis branch

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -22,6 +22,7 @@ pub struct Cli {
 #[derive(Debug, Subcommand, Clone)]
 pub enum Commands {
     Init(InitArgs),
+    Pace,
     Status(StatusArgs),
     Claim(IssueArgs),
     Attempt(AttemptArgs),
@@ -42,6 +43,9 @@ pub enum Commands {
 pub struct InitArgs {
     #[arg(long)]
     pub node: Option<String>,
+
+    #[arg(long)]
+    pub resource_policy: Option<String>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -6,16 +6,26 @@ use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::InitArgs;
-use crate::commands::{AppContext, print_value, write_node_id};
+use crate::commands::{AppContext, print_value, write_node_config};
+use crate::config::DEFAULT_RESOURCE_POLICY;
 
 #[derive(Debug, Serialize)]
 struct InitOutput {
     repo: String,
     node: String,
     github_login: String,
+    resource_policy: Option<String>,
+    effective_resource_policy: String,
+    is_default_policy: bool,
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
+    let resource_policy = args
+        .resource_policy
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
     let login = ctx.github.current_login()?;
     let _ = ctx.github.auth_status()?;
     let _ = ctx.github.auth_token()?;
@@ -31,20 +41,34 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     }
 
     if !ctx.cli.dry_run {
-        write_node_id(&ctx.repo_root, &node)?;
+        write_node_config(&ctx.repo_root, &node, resource_policy.as_deref())?;
     }
+
+    let (effective_resource_policy, is_default_policy) = match &resource_policy {
+        Some(policy) => (policy.clone(), false),
+        None => (DEFAULT_RESOURCE_POLICY.to_string(), true),
+    };
 
     let output = InitOutput {
         repo: ctx.repo.slug(),
         node,
         github_login: login,
+        resource_policy,
+        effective_resource_policy,
+        is_default_policy,
     };
 
     print_value(ctx, &output, |value| {
-        format!(
+        let mut text = format!(
             "Initialized polyresearch for {} as node `{}` (GitHub: {}).",
             value.repo, value.node, value.github_login
-        )
+        );
+        if value.is_default_policy {
+            text.push_str(" Using the default resource policy.");
+        } else {
+            text.push_str(" Saved the custom resource policy.");
+        }
+        text
     })
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod duties;
 pub mod generate;
 pub mod guards;
 pub mod init;
+pub mod pace;
 pub mod policy_check;
 pub mod release;
 pub mod review;
@@ -15,7 +16,6 @@ pub mod status;
 pub mod submit;
 pub mod sync;
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -24,7 +24,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{ProgramSpec, ProtocolConfig};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig, node_config_path};
 use crate::github::{GitHubApi, RepoRef};
 
 #[derive(Clone)]
@@ -40,6 +40,7 @@ pub struct AppContext {
 pub async fn run(ctx: AppContext) -> Result<()> {
     match &ctx.cli.command {
         Commands::Init(args) => init::run(&ctx, args).await,
+        Commands::Pace => pace::run(&ctx).await,
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,
@@ -70,23 +71,27 @@ where
 }
 
 pub fn node_file(repo_root: &PathBuf) -> PathBuf {
-    repo_root.join(".polyresearch-node")
+    node_config_path(repo_root)
+}
+
+pub fn read_node_config(repo_root: &PathBuf) -> Result<NodeConfig> {
+    NodeConfig::load(repo_root)
 }
 
 pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
-    let path = node_file(repo_root);
-    if !path.exists() {
-        return Err(eyre!(
-            "node identity is not configured yet; run `polyresearch init` first"
-        ));
-    }
-
-    Ok(fs::read_to_string(path)?.trim().to_string())
+    Ok(read_node_config(repo_root)?.node_id)
 }
 
 pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
-    fs::write(node_file(repo_root), format!("{node}\n"))?;
-    Ok(())
+    write_node_config(repo_root, node, None)
+}
+
+pub fn write_node_config(
+    repo_root: &PathBuf,
+    node: &str,
+    resource_policy: Option<&str>,
+) -> Result<()> {
+    NodeConfig::new(node.to_string(), resource_policy.map(ToString::to_string)).save(repo_root)
 }
 
 pub fn current_branch(repo_root: &PathBuf) -> Result<String> {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -24,7 +24,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig, node_config_path};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 
 #[derive(Clone)]
@@ -68,10 +68,6 @@ where
         println!("{}", plain(value));
     }
     Ok(())
-}
-
-pub fn node_file(repo_root: &PathBuf) -> PathBuf {
-    node_config_path(repo_root)
 }
 
 pub fn read_node_config(repo_root: &PathBuf) -> Result<NodeConfig> {

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -1,0 +1,188 @@
+use chrono::{DateTime, Duration, Utc};
+use color_eyre::eyre::Result;
+use serde::Serialize;
+
+use crate::commands::{AppContext, print_value, read_node_config};
+use crate::config::NodeConfig;
+use crate::state::{RepositoryState, ThesisPhase};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PaceOutput {
+    pub repo: String,
+    pub node_id: String,
+    pub resource_policy: String,
+    pub is_default_policy: bool,
+    pub attempts_last_hour: usize,
+    pub attempts_last_4_hours: usize,
+    pub idle_minutes: Option<i64>,
+    pub claimable_theses: usize,
+    pub active_claims: usize,
+}
+
+pub async fn run(ctx: &AppContext) -> Result<()> {
+    let node_config = read_node_config(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let output = build_output(ctx.repo.slug(), &node_config, &repo_state);
+
+    print_value(ctx, &output, |value| {
+        let resource_label = if value.is_default_policy {
+            "Resource policy (default)"
+        } else {
+            "Resource policy"
+        };
+        let mut rendered = format_wrapped_policy(resource_label, &value.resource_policy);
+        let idle = value
+            .idle_minutes
+            .map(|minutes| minutes.to_string())
+            .unwrap_or_else(|| "n/a".to_string());
+        rendered.push_str(&format!(
+            "\n\nThroughput ({}):\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}\n  Active claims:               {}",
+            value.node_id,
+            value.attempts_last_hour,
+            value.attempts_last_4_hours,
+            idle,
+            value.claimable_theses,
+            value.active_claims
+        ));
+        rendered
+    })
+}
+
+pub fn build_output(
+    repo: String,
+    node_config: &NodeConfig,
+    repo_state: &RepositoryState,
+) -> PaceOutput {
+    let now = Utc::now();
+    let one_hour_ago = now - Duration::hours(1);
+    let four_hours_ago = now - Duration::hours(4);
+    let node_id = node_config.node_id.clone();
+    let (resource_policy, is_default_policy) = node_config.effective_resource_policy();
+
+    let attempts = repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| thesis.attempts.iter())
+        .filter(|attempt| attempt.node == node_id)
+        .collect::<Vec<_>>();
+    let attempts_last_hour = attempts
+        .iter()
+        .filter(|attempt| attempt.created_at >= one_hour_ago)
+        .count();
+    let attempts_last_4_hours = attempts
+        .iter()
+        .filter(|attempt| attempt.created_at >= four_hours_ago)
+        .count();
+    let claimable_theses = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| {
+            thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
+        })
+        .count();
+    let active_claims = repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| thesis.active_claims.iter())
+        .filter(|claim| claim.node == node_id)
+        .count();
+    let idle_minutes = last_activity(repo_state, &node_id)
+        .map(|timestamp| now.signed_duration_since(timestamp).num_minutes().max(0));
+
+    PaceOutput {
+        repo,
+        node_id,
+        resource_policy: resource_policy.to_string(),
+        is_default_policy,
+        attempts_last_hour,
+        attempts_last_4_hours,
+        idle_minutes,
+        claimable_theses,
+        active_claims,
+    }
+}
+
+fn last_activity(repo_state: &RepositoryState, node_id: &str) -> Option<DateTime<Utc>> {
+    let mut timestamps = Vec::new();
+
+    for thesis in &repo_state.theses {
+        timestamps.extend(
+            thesis
+                .active_claims
+                .iter()
+                .filter(|claim| claim.node == node_id)
+                .map(|claim| claim.created_at),
+        );
+        timestamps.extend(
+            thesis
+                .releases
+                .iter()
+                .filter(|release| release.node == node_id)
+                .map(|release| release.created_at),
+        );
+        timestamps.extend(
+            thesis
+                .attempts
+                .iter()
+                .filter(|attempt| attempt.node == node_id)
+                .map(|attempt| attempt.created_at),
+        );
+
+        for pr in &thesis.pull_requests {
+            timestamps.extend(
+                pr.review_claims
+                    .iter()
+                    .filter(|claim| claim.node == node_id)
+                    .map(|claim| claim.created_at),
+            );
+            timestamps.extend(
+                pr.reviews
+                    .iter()
+                    .filter(|review| review.node == node_id)
+                    .map(|review| review.created_at),
+            );
+        }
+    }
+
+    timestamps.into_iter().max()
+}
+
+fn format_wrapped_policy(label: &str, policy: &str) -> String {
+    let lines = wrap_text(policy, 72);
+    let mut rendered = String::new();
+    if let Some((first, rest)) = lines.split_first() {
+        rendered.push_str(&format!("{label}: {first}"));
+        for line in rest {
+            rendered.push_str(&format!("\n  {line}"));
+        }
+    } else {
+        rendered.push_str(&format!("{label}:"));
+    }
+    rendered
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+            continue;
+        }
+
+        if current.len() + 1 + word.len() > width {
+            lines.push(current);
+            current = word.to_string();
+        } else {
+            current.push(' ');
+            current.push_str(word);
+        }
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    lines
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,16 +1,79 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result, eyre};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
+pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricDirection {
     HigherIsBetter,
     LowerIsBetter,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeConfig {
+    pub node_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_policy: Option<String>,
+}
+
+impl NodeConfig {
+    pub fn new(node_id: impl Into<String>, resource_policy: Option<String>) -> Self {
+        Self {
+            node_id: node_id.into(),
+            resource_policy: normalize_resource_policy(resource_policy),
+        }
+    }
+
+    pub fn load(repo_root: &Path) -> Result<Self> {
+        let path = node_config_path(repo_root);
+        if !path.exists() {
+            return Err(eyre!(
+                "node identity is not configured yet; run `polyresearch init` first"
+            ));
+        }
+
+        let contents = fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+        let config: Self = toml::from_str(&contents)
+            .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
+        if config.node_id.trim().is_empty() {
+            return Err(eyre!("node_id in {} cannot be empty", path.display()));
+        }
+
+        Ok(Self::new(config.node_id, config.resource_policy))
+    }
+
+    pub fn save(&self, repo_root: &Path) -> Result<()> {
+        let path = node_config_path(repo_root);
+        let rendered = toml::to_string_pretty(self)
+            .wrap_err_with(|| format!("failed to serialize {}", path.display()))?;
+        fs::write(&path, rendered)
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn resource_policy(&self) -> Option<&str> {
+        self.resource_policy
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    pub fn effective_resource_policy(&self) -> (&str, bool) {
+        match self.resource_policy() {
+            Some(policy) => (policy, false),
+            None => (DEFAULT_RESOURCE_POLICY, true),
+        }
+    }
+}
+
+pub fn node_config_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(".polyresearch-node.toml")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -292,4 +355,51 @@ mod tests {
         assert!(parse_bool("true").unwrap());
         assert!(!parse_bool("false").unwrap());
     }
+
+    #[test]
+    fn loads_node_config_from_toml() {
+        let repo_root = unique_temp_dir("node-config");
+        let path = node_config_path(&repo_root);
+        fs::write(
+            &path,
+            r#"node_id = "node-7f83"
+resource_policy = "Run 4 evals in parallel."
+"#,
+        )
+        .unwrap();
+
+        let config = NodeConfig::load(&repo_root).unwrap();
+        assert_eq!(config.node_id, "node-7f83");
+        assert_eq!(
+            config.resource_policy.as_deref(),
+            Some("Run 4 evals in parallel.")
+        );
+
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn defaults_resource_policy_when_missing() {
+        let config = NodeConfig::new("node-7f83", None);
+        let (policy, is_default) = config.effective_resource_policy();
+        assert!(is_default);
+        assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("polyresearch-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+}
+
+fn normalize_resource_policy(resource_policy: Option<String>) -> Option<String> {
+    resource_policy.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
 }

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -65,6 +65,7 @@ pub struct ReleaseRecord {
 #[derive(Debug, Clone, Serialize)]
 pub struct AttemptRecord {
     pub thesis: u64,
+    pub node: String,
     pub branch: String,
     pub metric: f64,
     pub baseline_metric: f64,
@@ -237,6 +238,7 @@ impl ThesisState {
             .iter()
             .map(|attempt| AttemptRecord {
                 thesis: attempt.thesis,
+                node: attempt.node.clone(),
                 branch: attempt.branch.clone(),
                 metric: attempt.metric,
                 baseline_metric: attempt.baseline_metric,
@@ -583,7 +585,8 @@ mod tests {
         let mut submitted_comments = fixture.comments;
         submitted_comments.clear();
         let config = test_config(&fixture.lead_github_login);
-        let submitted = ThesisState::derive(fixture.issue, submitted_comments, &[], &config).unwrap();
+        let submitted =
+            ThesisState::derive(fixture.issue, submitted_comments, &[], &config).unwrap();
 
         assert!(matches!(submitted.phase, ThesisPhase::Submitted));
         assert_eq!(count_queue_depth(&[submitted], false), 1);

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -60,6 +60,7 @@ pub struct ValidReleaseRecord {
 #[derive(Debug, Clone)]
 pub struct ValidAttemptRecord {
     pub thesis: u64,
+    pub node: String,
     pub branch: String,
     pub metric: f64,
     pub baseline_metric: f64,
@@ -664,8 +665,13 @@ pub fn validate_issue(
                         "duplicate attempt branch recorded more than once",
                     ));
                 } else {
+                    let claim = active_claims
+                        .values()
+                        .find(|claim| claim.author_login == comment.author)
+                        .expect("validated attempt should have a matching active claim");
                     attempts.push(ValidAttemptRecord {
                         thesis: *thesis,
+                        node: claim.node.clone(),
                         branch: branch.clone(),
                         metric: *metric,
                         baseline_metric: *baseline_metric,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -10,7 +10,7 @@ use polyresearch_cli::cli::{
 };
 use polyresearch_cli::commands;
 use polyresearch_cli::comments::Observation;
-use polyresearch_cli::config::{MetricDirection, ProgramSpec, ProtocolConfig};
+use polyresearch_cli::config::{MetricDirection, NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch_cli::github::{
     CommentUser, GitHubApi, Issue, IssueComment, IssueListState, PullRequest, PullRequestFile,
     PullRequestListState, RepoRef,
@@ -208,6 +208,7 @@ async fn init_writes_node_identity() {
         false,
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
+            resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
         }),
     );
 
@@ -215,13 +216,74 @@ async fn init_writes_node_identity() {
         &ctx,
         &InitArgs {
             node: Some("test-node".to_string()),
+            resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
         },
     )
     .await
     .unwrap();
 
-    let node_file = repo.path.join(".polyresearch-node");
-    assert_eq!(fs::read_to_string(node_file).unwrap(), "lead/test-node\n");
+    let node_file = repo.path.join(".polyresearch-node.toml");
+    let config: NodeConfig = toml::from_str(&fs::read_to_string(node_file).unwrap()).unwrap();
+    assert_eq!(config.node_id, "lead/test-node");
+    assert_eq!(
+        config.resource_policy.as_deref(),
+        Some("Use 2 GPUs and keep them busy.")
+    );
+}
+
+#[tokio::test]
+async fn pace_reports_default_policy_and_node_metrics() {
+    let repo = TestRepo::new("pace");
+    let approved_fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let claimed_fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let attempt_fixture = load_issue_fixture("improved_no_submit_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![
+            approved_fixture.issue.clone(),
+            claimed_fixture.issue.clone(),
+            attempt_fixture.issue.clone(),
+        ],
+        HashMap::from([
+            (
+                approved_fixture.issue.number,
+                approved_fixture.comments.clone(),
+            ),
+            (
+                claimed_fixture.issue.number,
+                claimed_fixture.comments.clone(),
+            ),
+            (
+                attempt_fixture.issue.number,
+                attempt_fixture.comments.clone(),
+            ),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &approved_fixture.lead_github_login,
+        false,
+        Commands::Pace,
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let output = commands::pace::build_output(ctx.repo.slug(), &node_config, &repo_state);
+
+    assert_eq!(output.node_id, "test-node");
+    assert!(output.is_default_policy);
+    assert_eq!(output.attempts_last_hour, 1);
+    assert_eq!(output.attempts_last_4_hours, 1);
+    assert_eq!(output.claimable_theses, 1);
+    assert_eq!(output.active_claims, 2);
+    assert_eq!(output.idle_minutes, Some(0));
+>>>>>>> 788dc56 (Add per-node resource policy and `polyresearch pace` command for enforced resource utilization (closes #23).)
 }
 
 #[tokio::test]

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 
 1. Read these files in order: `POLYRESEARCH.md`, `PROGRAM.md`, `PREPARE.md`, `results.tsv`.
 2. Run `git log --oneline -20` on `main` to see recent state.
-3. Run `polyresearch init` if `.polyresearch-node` does not exist.
+3. Run `polyresearch init` if `.polyresearch-node.toml` does not exist.
 4. If `.polyresearch/` exists, run its setup. Otherwise follow `PREPARE.md`.
 5. Check your GitHub identity: `gh api user --jq '.login'`
 6. Identify your role from your instructions or `PROGRAM.md`:
@@ -41,10 +41,15 @@ LOOP FOREVER:
   0. polyresearch duties
      If BLOCKING items exist, resolve each one before continuing.
 
-  1. polyresearch status
+  1. polyresearch pace
+     Compare your effective resource policy against recent node throughput.
+     If the policy says to push harder, increase parallelism or claim rate.
+     If the policy says to stay under a hardware or API ceiling, back off.
+
+  2. polyresearch status
      Look for approved, unclaimed theses.
 
-  2. If a claimable thesis exists:
+  3. If a claimable thesis exists:
      a. polyresearch claim <issue>
      b. Read PROGRAM.md for direction and constraints.
      c. For each experiment:
@@ -61,14 +66,14 @@ LOOP FOREVER:
      e. If no improvement after exhausting ideas:
         polyresearch release <issue> --reason <reason>
 
-  3. Check for review work (PRs with policy-pass, no decision,
+  4. Check for review work (PRs with policy-pass, no decision,
      not authored by you):
      a. polyresearch review-claim <pr>
      b. Evaluate candidate SHA and base SHA per PREPARE.md.
      c. polyresearch review <pr> --metric <candidate> --baseline <base> \
           --observation <obs>
 
-  4. Repeat from step 0.
+  5. Repeat from step 0.
 ```
 
 ## The lead loop
@@ -84,10 +89,11 @@ Each iteration, before any experiments:
      - Open PRs without policy-check
      - Stale results.tsv
 
-  1. polyresearch sync          # on main branch, always first
-  2. polyresearch audit         # check for inconsistencies
+  1. polyresearch pace          # compare actual throughput vs effective policy
+  2. polyresearch sync          # on main branch, always first
+  3. polyresearch audit         # check for inconsistencies
 
-  3. Process open PRs:
+  4. Process open PRs:
      - For each PR without policy-check:
        polyresearch policy-check <pr>
      - For each PR with enough reviews and no decision:
@@ -95,7 +101,7 @@ Each iteration, before any experiments:
          The lead should assign the PR to `maintainer_github_login` while it waits.
        polyresearch decide <pr>
 
-  4. Check queue depth:
+  5. Check queue depth:
      - If below min_queue_depth:
        polyresearch generate --title "<title>" --body "<body>"
      - If `auto_approve` is `false`, generated theses are not auto-approved.
@@ -105,39 +111,32 @@ Each iteration, before any experiments:
        directional input for future thesis generation.
      - Deduplicate against existing open and closed theses.
 
-  5. Now proceed with contributor loop (experiments, etc.)
+  6. Now proceed with contributor loop (experiments, etc.)
 
-  Between experiment batches, re-run steps 0-4.
+  Between experiment batches, re-run steps 0-5.
 ```
 
-## Maximizing resource utilization
+## Resource pacing
 
-Do not leave compute idle while doing GitHub duties.
+The protocol has a default resource policy: maximize throughput. Never leave
+claimable theses idle while experiments could be running. Run evaluations in
+parallel when the evaluator supports it. Interleave duties with long-running
+evaluations.
 
-**Interleave duties with running experiments.** If an evaluation takes 30+
-minutes, launch it in the background. While it runs, execute the full duty
-cycle: `duties` > `sync` > process PRs > check queue > `generate`. Return to
-check experiment progress after.
+If `.polyresearch-node.toml` sets a `resource_policy`, that node-specific
+policy overrides the default. Treat it as a real operating constraint.
 
-**Parallel evaluations.** API latency per call (5-10s) is the bottleneck, not
-rate limits. When the evaluator supports it, run multiple evaluations
-concurrently. Each process runs sequential API calls; parallelism comes from
-running N processes.
+Use `polyresearch pace` as the feedback loop:
 
-**Parallel experiment setup.** When running N experiments in parallel:
+1. Read the effective resource policy shown by `pace`.
+2. Compare it against the throughput metrics for your node.
+3. If the policy allows more throughput than you are getting, increase
+   parallelism or claim rate.
+4. If the policy imposes a ceiling (hardware, RAM, API rate limits), stay
+   below it.
 
-1. Create N working directories. Copy evaluator files; do not symlink
-   (relative paths break).
-2. Write the prompt/config variant into each directory.
-3. Launch all N as background processes.
-4. As each completes, IMMEDIATELY post `polyresearch attempt`.
-   Do not wait for the batch.
-5. Between batches, run `polyresearch duties` to handle accumulated
-   obligations.
-
-**Never serialize what can overlap.** If you are waiting on I/O (API calls,
-evaluation runs), do GitHub work. If GitHub is current and no duties are
-blocking, start more experiments.
+Do not leave resource usage on autopilot. Re-run `pace` regularly and correct
+drift.
 
 ## Critical rules
 


### PR DESCRIPTION
## Summary

- Adds `.polyresearch-node.toml` as the node identity file, replacing the old plain-text `.polyresearch-node`. The TOML file stores `node_id` and an optional natural-language `resource_policy` that describes how hard the node should push (hardware, API limits, parallelism).
- Adds `polyresearch pace`, a new command that prints the effective resource policy alongside recent node-scoped throughput metrics (attempts/hour, idle time, claimable theses sitting untouched, active claims). Agents compare the two and self-correct when they drift into under- or over-utilization.
- When no custom policy is set, the protocol default applies: maximize throughput, never leave claimable theses idle, parallelize evaluations, interleave duties with long-running experiments.
- Updates both loops in `POLYRESEARCH.md` and `SKILL.md` to include `pace` as a regular step after `duties`.

Closes #23.

## Test plan

- [x] `cargo test` passes (42 tests, 0 failures)
- [x] New unit test `loads_node_config_from_toml` validates TOML round-trip
- [x] New unit test `defaults_resource_policy_when_missing` validates fallback
- [x] New e2e test `pace_reports_default_policy_and_node_metrics` validates node-scoped throughput calculation against fixture data
- [x] Existing `init_writes_node_identity` test updated to verify new TOML format and `--resource-policy` flag
- [ ] Manual: run `polyresearch init --resource-policy "..."` and verify `.polyresearch-node.toml` contents
- [ ] Manual: run `polyresearch pace` and `polyresearch pace --json` against a live repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new persisted node config format and adds a new CLI command that derives node-scoped throughput from GitHub state; it also appears to leave a merge-conflict marker in `cli/tests/e2e.rs`, which would break compilation/tests if not resolved.
> 
> **Overview**
> Adds per-node configuration via a new repo-root `.polyresearch-node.toml` (replacing the old plain-text `.polyresearch-node`) that stores `node_id` plus an optional natural-language `resource_policy`, and extends `polyresearch init` with `--resource-policy` to write it.
> 
> Introduces `polyresearch pace`, which reads the node config and prints/JSON-exports the *effective* resource policy along with recent node throughput metrics (attempt counts, idle time, claimable thesis count, active claims), requiring attempts to carry node attribution in derived state.
> 
> Updates docs/protocol (`POLYRESEARCH.md`, `README.md`, `skills/polyresearch/SKILL.md`, `cli/README.md`) to incorporate `pace` into the contributor/lead loops, adds `toml` dependency + NodeConfig tests/e2e coverage, and updates `.gitignore` accordingly. **Note:** `cli/tests/e2e.rs` contains a leftover `>>>>>>>` merge-conflict marker in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b0275d07648f14f08be872a05e5bb22613eada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->