### PR TITLE
Make the lead a pure role and move thesis claims into worktrees

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -42,9 +42,11 @@ The parameter definitions live here. Concrete project values live in `PROGRAM.md
 
 **Contributor.** A machine running an agent. Claims theses, runs experiments, submits candidates, and reviews others' work. You are a contributor unless told otherwise.
 
-**Lead.** A contributor with additional responsibilities: generates theses from results history, runs policy checks on candidate PRs, decides PRs (merge or close), and maintains results.tsv as sole writer. One per project. If your instructions say "you are the lead," follow the lead sections in addition to the contributor sections.
+**Lead.** A machine running an agent dedicated to project management. The lead generates theses from results history, runs policy checks on candidate PRs, decides PRs (merge or close), and maintains `results.tsv` as sole writer. One per project. The lead does not claim theses, run experiments, submit candidates, or participate in peer review. If your instructions say "you are the lead," follow the lead loop only.
 
 When `auto_approve` is `false`, `lead_github_login` and `maintainer_github_login` must be different GitHub accounts. Human-in-the-loop review does not work if the lead and the maintainer share the same GitHub identity.
+
+In practice, the maintainer usually runs the lead and at least one contributor as separate agent instances. Contributors may share the lead's GitHub login because the protocol uses node IDs for attribution, but the lead and maintainer still must be different GitHub accounts when `auto_approve` is `false`. The lead may spend many iterations idle between duty cycles; that is expected and preferable to blocking contributors behind GitHub-visible work.
 
 ---
 
@@ -93,9 +95,9 @@ LOOP FOREVER:
 1. **Check for theses.** Run `polyresearch status` and look for theses that are **approved and unclaimed**. The CLI derives canonical state from the comment trail and ignores invalid raw events.
 2. **If a claimable thesis exists:**
   a. Run `polyresearch claim <issue-number>`.
-   b. The CLI posts the `polyresearch:claim` comment and creates the thesis branch from `main`: `thesis/<issue-number>-<slug>`.
+   b. The CLI posts the `polyresearch:claim` comment and creates a git worktree from `main` at `.worktrees/<issue-number>-<slug>/` on branch `thesis/<issue-number>-<slug>`. Change into that worktree before editing.
    c. Read PROGRAM.md for direction and constraints.
-   d. Run experiments. Each attempt on its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`.
+   d. Run experiments from inside that thesis worktree. Each attempt uses its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`. If you run attempts in parallel, use one worktree per active attempt.
    e. For each attempt:
       - Make your changes within the editable surface defined in PROGRAM.md.
       - Commit your changes.
@@ -104,6 +106,7 @@ LOOP FOREVER:
       - Run `polyresearch attempt <issue-number> --metric <value> --baseline <value> --observation <observation> --summary "<summary>"`.
    f. **If you find an improvement:** run `polyresearch submit <issue-number>`. The CLI pushes the best attempt branch and opens the candidate PR to `main`.
    g. **If no improvement after exhausting ideas:** run `polyresearch release <issue-number> --reason <reason>`. The thesis returns to the queue for another contributor.
+   h. When the thesis is released or later resolved, remove its worktree with `git worktree remove` and return to the main worktree before claiming again.
 3. **Check for review work.** Run `polyresearch status` and look for PRs with a `polyresearch:policy-pass` comment and **no** `polyresearch:decision` comment. These need peer review. Skip PRs you authored.
 4. **If a reviewable PR exists:**
   a. Run `polyresearch review-claim <pr-number>`.
@@ -127,7 +130,7 @@ If there are no theses to claim and no PRs to review, wait briefly and check aga
 
 ## The lead loop
 
-Everything in the contributor loop, plus these additional responsibilities. Run them as part of the same loop.
+The lead runs a separate management loop from the repository root worktree, which stays on `main`.
 
 **Priority order within each iteration.** GitHub-visible duties run first, in this order:
 
@@ -135,9 +138,9 @@ Everything in the contributor loop, plus these additional responsibilities. Run 
 1. `polyresearch sync` (always before other lead actions).
 2. Process open PRs: `policy-check` and `decide` any that are ready. When `auto_approve` is `false`, assign ready PRs to `maintainer_github_login` and wait for `/approve`.
 3. Check queue depth; `generate` if below `min_queue_depth`.
-4. Only then proceed to local experiments.
+4. If there is no immediate GitHub-visible work, wait briefly and repeat from step 0.
 
-Between experiment batches (or while waiting for evaluations), re-run steps 0–3. The lead must never have GitHub stale while the server is working. Post `polyresearch attempt` results immediately after each evaluation completes, not in batches.
+The lead never claims theses or runs experiments. Keeping `main` current is the lead's full-time job.
 
 ### Maintain results.tsv
 
@@ -266,18 +269,22 @@ When `auto_approve` is `false`, a generated thesis stays in **Submitted** until 
 ## Branching
 
 ```
-main
-  └── thesis/12-rmsnorm                    (thesis branch)
-        ├── thesis/12-rmsnorm-attempt-1    (discarded, unmerged)
-        ├── thesis/12-rmsnorm-attempt-2    (discarded, unmerged)
-        └── thesis/12-rmsnorm-attempt-3    (candidate PR → merged to main)
+repo-root/                                 (main worktree on `main`)
+  ├── .git
+  ├── .worktrees/                          (gitignored)
+  │     ├── 12-rmsnorm/                    (worktree on `thesis/12-rmsnorm`)
+  │     └── 12-rmsnorm-attempt-2/          (optional parallel attempt worktree)
+  └── ...                                  (lead stays here)
 ```
 
+- The repository root is the main worktree. The lead stays here on `main`.
 - `main` is the accepted ledger. Only verified improvements land here.
-- Each thesis gets a branch: `thesis/<issue-number>-<slug>`.
+- Each claim creates a thesis worktree under `.worktrees/<issue-number>-<slug>/` on branch `thesis/<issue-number>-<slug>`.
 - Each attempt gets its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`, forked from the thesis branch.
+- When running attempts in parallel, create one worktree per active attempt.
 - The candidate PR merges the best attempt's sub-branch into `main`.
 - Discarded attempts stay as unmerged branches. They are data, not waste.
+- Remove thesis worktrees with `git worktree remove` once the thesis is released or resolved.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repo has three files and an optional directory that matter:
 - `PREPARE.md` -- the evaluation setup. Describes how results are measured: what commands to run, how to parse the metric, what the ground truth is. The evaluation code is outside the editable surface, so agents cannot change how they are judged. **Edited by the maintainer.**
 - `.polyresearch/` -- the reproducible environment. Contains whatever the project needs to run experiments and evaluate results consistently across machines. Polyresearch standardizes the location, not the contents. **Provided by the maintainer, optional.**
 
-A contributor picks up a thesis from the Issues queue through the `polyresearch` CLI, which posts the same human-readable structured comments to GitHub and manages the protocol state transitions. Other contributors independently rerun the evaluation and post structured review records through the CLI. If enough reviewers agree the result beats the baseline, the lead merges it. Failed experiments stay as unmerged branches with rows in `results.tsv`. Nothing is discarded.
+A contributor picks up a thesis from the Issues queue through the `polyresearch` CLI, which posts the same human-readable structured comments to GitHub and manages the protocol state transitions. By default, `polyresearch claim` creates a dedicated git worktree for that thesis under `.worktrees/`, so contributors can run multiple branches in parallel without disturbing the repo root. Other contributors independently rerun the evaluation and post structured review records through the CLI. If enough reviewers agree the result beats the baseline, the lead merges it. Failed experiments stay as unmerged branches with rows in `results.tsv`. Nothing is discarded.
 
 ## Quick start
 
@@ -38,13 +38,17 @@ $EDITOR PREPARE.md
 # 5. (Optional) Add a reproducible environment
 mkdir .polyresearch/
 
-# 6. Tell your agent: "You are the lead for this project."
-#    It reads the files and starts working through `polyresearch`.
+# 6. Launch one lead agent from the repo root:
+#    "You are the lead for this project."
+#
+# 7. Launch one or more contributor agents:
+#    "Do polyresearch on this project."
+#    If you do not explicitly say "you are the lead", the agent defaults to contributor.
 ```
 
 Other platforms and build-from-source instructions are in [cli/README.md](cli/README.md).
 
-Share the repo. Contributors point their agents at it and join.
+Share the repo. Contributors point their agents at it and join. The lead stays in the repo root on `main`; contributors work from the worktree path returned by `polyresearch claim`.
 
 **Contributing to a project:**
 
@@ -76,7 +80,7 @@ results.tsv         -- lab notebook of every experiment (lead-maintained)
 
 **Contributor.** A machine running an agent. Runs experiments and reviews others' results. Many contributors per project.
 
-**Lead.** A contributor that also generates theses from results history, runs policy checks, decides PRs, and maintains results.tsv as sole writer. One per project.
+**Lead.** A machine running an agent dedicated to project management. The lead generates theses from results history, runs policy checks, decides PRs, and maintains results.tsv as sole writer. It does not claim theses, run experiments, submit candidates, or review PRs. One per project.
 
 ## Design choices
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -100,6 +100,8 @@ polyresearch submit 88
 polyresearch release 88 --reason no_improvement
 ```
 
+By default, `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. Pass `--no-worktree` only if you intentionally want the legacy single-working-tree checkout flow.
+
 Review flow:
 
 ```bash
@@ -114,8 +116,11 @@ polyresearch sync
 polyresearch generate --title "New thesis" --body "Hypothesis and rationale"
 polyresearch policy-check 93
 polyresearch decide 93
+polyresearch prune
 polyresearch admin reconcile-ledger
 ```
+
+Run the lead from the repository root on `main`. Launch contributors as separate agents in their own thesis worktrees.
 
 ## Output modes
 
@@ -128,7 +133,7 @@ polyresearch admin reconcile-ledger
 - `polyresearch init` -- set node identity, verify GitHub auth, detect repo
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
-- `polyresearch claim` -- atomically claim a thesis and create the thesis branch
+- `polyresearch claim` -- atomically claim a thesis and create the thesis worktree (or a branch with `--no-worktree`)
 - `polyresearch attempt` -- post a structured attempt comment from the current branch
 - `polyresearch release` -- release a claim with a structured reason
 - `polyresearch submit` -- push the branch and open a candidate PR
@@ -138,6 +143,7 @@ polyresearch admin reconcile-ledger
 - `polyresearch generate` -- open and auto-approve a thesis issue
 - `polyresearch policy-check` -- validate PR files against the editable surface
 - `polyresearch decide` -- post the lead decision and merge/close accordingly
+- `polyresearch prune` -- prune git worktree metadata and remove empty stale directories under `.worktrees`
 - `polyresearch admin ...` -- lead-only repair commands for exceptional recovery
 
 ## Notes

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -36,6 +36,7 @@ pub enum Commands {
     Generate(GenerateArgs),
     PolicyCheck(PrArgs),
     Decide(PrArgs),
+    Prune,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -53,6 +54,9 @@ pub struct StatusArgs {
 #[derive(Debug, Args, Clone)]
 pub struct IssueArgs {
     pub issue: u64,
+
+    #[arg(long)]
+    pub no_worktree: bool,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -4,7 +4,10 @@ use serde::Serialize;
 use crate::cli::IssueArgs;
 use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
-use crate::commands::{AppContext, create_thesis_branch, print_value, read_node_id, slugify};
+use crate::commands::{
+    AppContext, create_thesis_branch, create_thesis_worktree, print_value, read_node_id, slugify,
+    thesis_worktree_path,
+};
 use crate::comments::ProtocolComment;
 use crate::state::RepositoryState;
 
@@ -13,6 +16,7 @@ struct ClaimOutput {
     issue: u64,
     node: String,
     branch: String,
+    worktree_path: Option<String>,
 }
 
 pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
@@ -46,14 +50,30 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
 
-    let branch = if ctx.cli.dry_run {
-        format!(
+    let (branch, worktree_path) = if ctx.cli.dry_run {
+        let branch = format!(
             "thesis/{}-{}",
             thesis.issue.number,
             slugify(&thesis.issue.title)
+        );
+        let worktree_path = (!args.no_worktree).then(|| {
+            thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)
+                .display()
+                .to_string()
+        });
+        (branch, worktree_path)
+    } else if args.no_worktree {
+        (
+            create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?,
+            None,
         )
     } else {
-        create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?
+        let workspace =
+            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
+        (
+            workspace.branch,
+            Some(workspace.worktree_path.display().to_string()),
+        )
     };
 
     let comment = ProtocolComment::Claim {
@@ -69,12 +89,27 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         issue: thesis.issue.number,
         node,
         branch,
+        worktree_path,
     };
 
     print_value(ctx, &output, |value| {
-        format!(
-            "Claimed thesis #{} as node `{}` on branch `{}`.",
-            value.issue, value.node, value.branch
-        )
+        match (&value.worktree_path, ctx.cli.dry_run) {
+            (Some(path), true) => format!(
+                "Would claim thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
+                value.issue, value.node, value.branch, path
+            ),
+            (Some(path), false) => format!(
+                "Claimed thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
+                value.issue, value.node, value.branch, path
+            ),
+            (None, true) => format!(
+                "Would claim thesis #{} as node `{}` on branch `{}`.",
+                value.issue, value.node, value.branch
+            ),
+            (None, false) => format!(
+                "Claimed thesis #{} as node `{}` on branch `{}`.",
+                value.issue, value.node, value.branch
+            ),
+        }
     })
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod generate;
 pub mod guards;
 pub mod init;
 pub mod policy_check;
+pub mod prune;
 pub mod release;
 pub mod review;
 pub mod review_claim;
@@ -54,6 +55,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Generate(args) => generate::run(&ctx, args).await,
         Commands::PolicyCheck(args) => policy_check::run(&ctx, args).await,
         Commands::Decide(args) => decide::run(&ctx, args).await,
+        Commands::Prune => prune::run(&ctx).await,
     }
 }
 
@@ -124,6 +126,12 @@ pub fn run_git(repo_root: &PathBuf, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }
 
+#[derive(Debug, Clone)]
+pub struct ThesisWorkspace {
+    pub branch: String,
+    pub worktree_path: PathBuf,
+}
+
 pub fn create_thesis_branch(repo_root: &PathBuf, issue_number: u64, title: &str) -> Result<String> {
     let slug = slugify(title);
     let branch = format!("thesis/{issue_number}-{slug}");
@@ -133,6 +141,53 @@ pub fn create_thesis_branch(repo_root: &PathBuf, issue_number: u64, title: &str)
     }
     run_git(repo_root, &["checkout", "-b", &branch])?;
     Ok(branch)
+}
+
+pub fn thesis_worktree_path(repo_root: &PathBuf, issue_number: u64, title: &str) -> PathBuf {
+    let slug = slugify(title);
+    repo_root
+        .join(".worktrees")
+        .join(format!("{issue_number}-{slug}"))
+}
+
+pub fn create_thesis_worktree(
+    repo_root: &PathBuf,
+    issue_number: u64,
+    title: &str,
+) -> Result<ThesisWorkspace> {
+    let slug = slugify(title);
+    let branch = format!("thesis/{issue_number}-{slug}");
+    let worktree_root = repo_root.join(".worktrees");
+    let worktree_path = thesis_worktree_path(repo_root, issue_number, title);
+
+    fs::create_dir_all(&worktree_root)
+        .wrap_err_with(|| format!("failed to create {}", worktree_root.display()))?;
+
+    if worktree_path.exists() {
+        return Err(eyre!(
+            "worktree path `{}` already exists; remove it with `git worktree remove` before reclaiming thesis #{}",
+            worktree_path.display(),
+            issue_number
+        ));
+    }
+
+    if run_git(repo_root, &["rev-parse", "--verify", &branch]).is_ok() {
+        return Err(eyre!(
+            "branch `{branch}` already exists; delete or rename it before reclaiming thesis #{}",
+            issue_number
+        ));
+    }
+
+    let worktree_path_arg = worktree_path.to_string_lossy().into_owned();
+    run_git(
+        repo_root,
+        &["worktree", "add", "-b", &branch, &worktree_path_arg, "main"],
+    )?;
+
+    Ok(ThesisWorkspace {
+        branch,
+        worktree_path,
+    })
 }
 
 pub fn push_current_branch(repo_root: &PathBuf) -> Result<String> {

--- a/cli/src/commands/prune.rs
+++ b/cli/src/commands/prune.rs
@@ -1,0 +1,80 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+
+use crate::commands::{AppContext, print_value, run_git};
+
+#[derive(Debug, Serialize)]
+struct PruneOutput {
+    removed_directories: Vec<String>,
+    skipped_directories: Vec<String>,
+}
+
+pub async fn run(ctx: &AppContext) -> Result<()> {
+    run_git(&ctx.repo_root, &["worktree", "prune"])?;
+
+    let worktree_root = ctx.repo_root.join(".worktrees");
+    let registered = registered_worktree_paths(&ctx.repo_root)?;
+    let mut removed_directories = Vec::new();
+    let mut skipped_directories = Vec::new();
+
+    if worktree_root.exists() {
+        for entry in fs::read_dir(&worktree_root)
+            .wrap_err_with(|| format!("failed to read {}", worktree_root.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() || registered.contains(&path) {
+                continue;
+            }
+
+            let mut contents = fs::read_dir(&path)
+                .wrap_err_with(|| format!("failed to inspect {}", path.display()))?;
+            if contents.next().is_none() {
+                fs::remove_dir(&path)
+                    .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
+                removed_directories.push(path.display().to_string());
+            } else {
+                skipped_directories.push(path.display().to_string());
+            }
+        }
+    }
+
+    let output = PruneOutput {
+        removed_directories,
+        skipped_directories,
+    };
+
+    print_value(ctx, &output, |value| {
+        if value.removed_directories.is_empty() && value.skipped_directories.is_empty() {
+            "Pruned git worktree metadata. No stale worktree directories found.".to_string()
+        } else if value.skipped_directories.is_empty() {
+            format!(
+                "Pruned git worktree metadata and removed {} stale worktree directories.",
+                value.removed_directories.len()
+            )
+        } else {
+            format!(
+                "Pruned git worktree metadata, removed {} stale worktree directories, and skipped {} non-empty directories.",
+                value.removed_directories.len(),
+                value.skipped_directories.len()
+            )
+        }
+    })
+}
+
+fn registered_worktree_paths(repo_root: &PathBuf) -> Result<HashSet<PathBuf>> {
+    let output = run_git(repo_root, &["worktree", "list", "--porcelain"])?;
+    let mut paths = HashSet::new();
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            paths.insert(PathBuf::from(path));
+        }
+    }
+
+    Ok(paths)
+}

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -191,6 +192,30 @@ impl Drop for TestRepo {
     }
 }
 
+fn init_git_repo(path: &PathBuf) {
+    run_git(path, &["init"]);
+    run_git(path, &["config", "user.name", "Test User"]);
+    run_git(path, &["config", "user.email", "test@example.com"]);
+    fs::write(path.join("README.md"), "test\n").unwrap();
+    run_git(path, &["add", "README.md"]);
+    run_git(path, &["commit", "-m", "Initial commit"]);
+    run_git(path, &["branch", "-M", "main"]);
+}
+
+fn run_git(path: &PathBuf, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[tokio::test]
 async fn init_writes_node_identity() {
     let repo = TestRepo::new("init");
@@ -283,6 +308,7 @@ async fn claim_rejects_already_claimed_thesis() {
         false,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "node-b").unwrap();
@@ -291,6 +317,7 @@ async fn claim_rejects_already_claimed_thesis() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         },
     )
     .await
@@ -316,6 +343,7 @@ async fn claim_rejects_closed_thesis() {
         false,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "server").unwrap();
@@ -324,6 +352,7 @@ async fn claim_rejects_closed_thesis() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         },
     )
     .await
@@ -444,6 +473,7 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
         true,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "node-a").unwrap();
@@ -452,12 +482,94 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
+            no_worktree: false,
         },
     )
     .await
     .unwrap();
 
     assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn claim_creates_worktree_by_default() {
+    let repo = TestRepo::new("claim-worktree");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_id(&repo.path, "node-a").unwrap();
+
+    commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let expected_branch = format!(
+        "thesis/{}-{}",
+        fixture.issue.number,
+        commands::slugify(&fixture.issue.title)
+    );
+    let worktree_path = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture.issue.number,
+        commands::slugify(&fixture.issue.title)
+    ));
+
+    assert!(
+        worktree_path.exists(),
+        "expected worktree at {}",
+        worktree_path.display()
+    );
+    assert_eq!(commands::current_branch(&repo.path).unwrap(), "main");
+    assert_eq!(
+        commands::current_branch(&worktree_path).unwrap(),
+        expected_branch
+    );
+    assert_eq!(mock.posted_issue_comments.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn prune_removes_empty_stale_worktree_directories() {
+    let repo = TestRepo::new("prune-worktrees");
+    init_git_repo(&repo.path);
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let stale = repo.path.join(".worktrees").join("stale");
+    fs::create_dir_all(&stale).unwrap();
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Prune);
+
+    commands::prune::run(&ctx).await.unwrap();
+
+    assert!(
+        !stale.exists(),
+        "expected stale worktree directory to be removed"
+    );
 }
 
 // --- A1: Serde deserialization with snake_case (REST API) ---
@@ -679,6 +791,7 @@ async fn claim_blocked_by_outstanding_duties() {
         true,
         Commands::Claim(IssueArgs {
             issue: fixture_open.issue.number,
+            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "test-node").unwrap();
@@ -687,6 +800,7 @@ async fn claim_blocked_by_outstanding_duties() {
         &ctx,
         &IssueArgs {
             issue: fixture_open.issue.number,
+            no_worktree: false,
         },
     )
     .await


### PR DESCRIPTION
## Summary
- split the protocol so the lead is a pure management role and contributors handle experiments and reviews
- make `polyresearch claim` create a thesis worktree by default, keep `--no-worktree` as a fallback, and add `polyresearch prune` for cleanup
- update the main docs and CLI docs to show the new lead/contributor launch pattern and worktree flow

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because `polyresearch claim` now mutates the local repo via `git worktree add` by default and introduces new cleanup behavior; mis-handling existing branches/worktrees could disrupt contributor workflows.
> 
> **Overview**
> Updates the protocol/docs to make the **lead a pure management role** (no claiming/experiments/reviews) and to standardize a new launch pattern: lead stays on repo-root `main` while contributors work in per-thesis worktrees.
> 
> Changes `polyresearch claim` to **create a thesis worktree under `.worktrees/` by default**, returning the worktree path in output/JSON, with `--no-worktree` preserving the legacy branch-only flow. Adds `polyresearch prune` to run `git worktree prune` and remove empty unregistered directories under `.worktrees/`, and extends e2e tests to cover the new worktree and prune behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb03c929489a611fea97818ff98f2bf084c908a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->