### PR TITLE
Give each agent session its own node ID

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -59,8 +59,16 @@ When you start, before doing anything else:
 3. Run `git log --oneline -20` on `main` to see recent state.
 4. If `.polyresearch/` exists, run its setup. Otherwise follow PREPARE.md setup instructions.
 5. Check your GitHub identity. Run `gh api user --jq '.login'` to see which GitHub account you are operating as. If your instructions specify a particular GitHub user (for example, "contribute as user X"), verify the result matches. If it does not, stop and report the mismatch before proceeding. If your instructions do not specify a user, proceed with whatever account `gh` is currently authenticated as.
-6. Run `polyresearch init` if `.polyresearch-node.toml` does not exist yet. The CLI generates a composite identifier in the form `{github_login}/{hostname}-{suffix}` (e.g. `alice/mac.lan-a3f2`) to prevent collisions across users and machines. Override the machine part with `polyresearch init --node <id>`. This also records your optional node-specific `resource_policy`.
-7. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
+6. Create a distinct node ID for this session before running other `polyresearch` commands. This is required when multiple agents share the same checkout or when one GitHub login runs several workers in parallel:
+
+   ```bash
+   LOGIN=$(gh api user --jq '.login')
+   MACHINE_ID="$(hostname -s)-$(xxd -l2 -p /dev/urandom)"
+   export POLYRESEARCH_NODE_ID="${LOGIN}/${MACHINE_ID}"
+   ```
+
+7. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"`. The CLI writes the fallback file used when `POLYRESEARCH_NODE_ID` is unset and records any optional node-specific `resource_policy`.
+8. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
 
 ---
 
@@ -69,13 +77,15 @@ When you start, before doing anything else:
 Each node keeps a local `.polyresearch-node.toml` file at the repo root:
 
 ```toml
-node_id = "node-7f83"
+node_id = "alice/mac.lan-a3f2"
 resource_policy = "8-core machine with 2 GPUs. Run up to 4 parallel evaluations. Keep GPUs saturated. Stay under 50 API calls/min."
 ```
 
-- `node_id` identifies the machine or worker. Keep it stable across sessions.
+- `node_id` identifies the machine or worker. Keep it stable for the lifetime of that worker or agent session.
 - `resource_policy` is optional natural language guidance for that node only. It is not project state.
 - Set or update it with `polyresearch init --resource-policy "..."`.
+- `POLYRESEARCH_NODE_ID` overrides `node_id` for the current process. Use it when multiple agents share one checkout or when one GitHub login needs several concurrent nodes.
+- If `POLYRESEARCH_NODE_ID` is unset, the CLI falls back to `.polyresearch-node.toml`.
 
 If `resource_policy` is absent, the default policy applies:
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -7,6 +8,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
+pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -32,21 +34,35 @@ impl NodeConfig {
 
     pub fn load(repo_root: &Path) -> Result<Self> {
         let path = node_config_path(repo_root);
-        if !path.exists() {
-            return Err(eyre!(
-                "node identity is not configured yet; run `polyresearch init` first"
-            ));
-        }
+        let env_node_id = node_id_override();
+        let file_config = match path.exists() {
+            true => match load_node_config_from_file(&path) {
+                Ok(config) => Some(config),
+                Err(_error) if env_node_id.is_some() => None,
+                Err(error) => return Err(error),
+            },
+            false => None,
+        };
 
-        let contents = fs::read_to_string(&path)
-            .wrap_err_with(|| format!("failed to read {}", path.display()))?;
-        let config: Self = toml::from_str(&contents)
-            .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
-        if config.node_id.trim().is_empty() {
-            return Err(eyre!("node_id in {} cannot be empty", path.display()));
-        }
+        let node_id = match env_node_id {
+            Some(node_id) => node_id,
+            None => {
+                let Some(config) = file_config.as_ref() else {
+                    return Err(eyre!(
+                        "node identity is not configured yet; run `polyresearch init` first"
+                    ));
+                };
+                if config.node_id.trim().is_empty() {
+                    return Err(eyre!("node_id in {} cannot be empty", path.display()));
+                }
+                config.node_id.clone()
+            }
+        };
 
-        Ok(Self::new(config.node_id, config.resource_policy))
+        Ok(Self::new(
+            node_id,
+            file_config.and_then(|config| config.resource_policy),
+        ))
     }
 
     pub fn save(&self, repo_root: &Path) -> Result<()> {
@@ -74,6 +90,19 @@ impl NodeConfig {
 
 pub fn node_config_path(repo_root: &Path) -> PathBuf {
     repo_root.join(".polyresearch-node.toml")
+}
+
+fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
+    let contents =
+        fs::read_to_string(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&contents).wrap_err_with(|| format!("failed to parse {}", path.display()))
+}
+
+fn node_id_override() -> Option<String> {
+    env::var(NODE_ID_ENV_VAR).ok().and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -322,6 +351,24 @@ fn parse_bool(value: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn set_node_id_env(value: &str) {
+        unsafe {
+            env::set_var(NODE_ID_ENV_VAR, value);
+        }
+    }
+
+    fn clear_node_id_env() {
+        unsafe {
+            env::remove_var(NODE_ID_ENV_VAR);
+        }
+    }
 
     #[test]
     fn parses_duration_suffixes() {
@@ -375,6 +422,61 @@ resource_policy = "Run 4 evals in parallel."
             Some("Run 4 evals in parallel.")
         );
 
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn env_override_wins_over_file_node_id() {
+        let _guard = env_lock().lock().unwrap();
+        let repo_root = unique_temp_dir("node-config-env-override");
+        let path = node_config_path(&repo_root);
+        fs::write(
+            &path,
+            r#"node_id = "file-node"
+resource_policy = "Run 4 evals in parallel."
+"#,
+        )
+        .unwrap();
+        set_node_id_env("env-node");
+
+        let config = NodeConfig::load(&repo_root).unwrap();
+        assert_eq!(config.node_id, "env-node");
+        assert_eq!(
+            config.resource_policy.as_deref(),
+            Some("Run 4 evals in parallel.")
+        );
+
+        clear_node_id_env();
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn env_override_allows_loading_without_file() {
+        let _guard = env_lock().lock().unwrap();
+        let repo_root = unique_temp_dir("node-config-env-only");
+        set_node_id_env("env-node");
+
+        let config = NodeConfig::load(&repo_root).unwrap();
+        assert_eq!(config.node_id, "env-node");
+        assert_eq!(config.resource_policy, None);
+
+        clear_node_id_env();
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn env_override_ignores_invalid_file_contents() {
+        let _guard = env_lock().lock().unwrap();
+        let repo_root = unique_temp_dir("node-config-env-invalid");
+        let path = node_config_path(&repo_root);
+        fs::write(&path, "this is not valid toml").unwrap();
+        set_node_id_env("env-node");
+
+        let config = NodeConfig::load(&repo_root).unwrap();
+        assert_eq!(config.node_id, "env-node");
+        assert_eq!(config.resource_policy, None);
+
+        clear_node_id_env();
         fs::remove_dir_all(repo_root).unwrap();
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -351,11 +351,29 @@ fn parse_bool(value: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct NodeIdEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl NodeIdEnvGuard {
+        fn lock_clean() -> Self {
+            let guard = env_lock().lock().unwrap();
+            clear_node_id_env();
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for NodeIdEnvGuard {
+        fn drop(&mut self) {
+            clear_node_id_env();
+        }
     }
 
     fn set_node_id_env(value: &str) {
@@ -405,6 +423,7 @@ mod tests {
 
     #[test]
     fn loads_node_config_from_toml() {
+        let _guard = NodeIdEnvGuard::lock_clean();
         let repo_root = unique_temp_dir("node-config");
         let path = node_config_path(&repo_root);
         fs::write(
@@ -427,7 +446,7 @@ resource_policy = "Run 4 evals in parallel."
 
     #[test]
     fn env_override_wins_over_file_node_id() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = NodeIdEnvGuard::lock_clean();
         let repo_root = unique_temp_dir("node-config-env-override");
         let path = node_config_path(&repo_root);
         fs::write(
@@ -446,13 +465,12 @@ resource_policy = "Run 4 evals in parallel."
             Some("Run 4 evals in parallel.")
         );
 
-        clear_node_id_env();
         fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
     fn env_override_allows_loading_without_file() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = NodeIdEnvGuard::lock_clean();
         let repo_root = unique_temp_dir("node-config-env-only");
         set_node_id_env("env-node");
 
@@ -460,13 +478,12 @@ resource_policy = "Run 4 evals in parallel."
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
 
-        clear_node_id_env();
         fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
     fn env_override_ignores_invalid_file_contents() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = NodeIdEnvGuard::lock_clean();
         let repo_root = unique_temp_dir("node-config-env-invalid");
         let path = node_config_path(&repo_root);
         fs::write(&path, "this is not valid toml").unwrap();
@@ -476,7 +493,6 @@ resource_policy = "Run 4 evals in parallel."
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
 
-        clear_node_id_env();
         fs::remove_dir_all(repo_root).unwrap();
     }
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
@@ -222,6 +222,24 @@ fn env_lock() -> &'static Mutex<()> {
     ENV_LOCK.get_or_init(|| Mutex::new(()))
 }
 
+struct NodeIdEnvGuard {
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl NodeIdEnvGuard {
+    fn lock_clean() -> Self {
+        let guard = env_lock().lock().unwrap();
+        clear_node_id_env();
+        Self { _guard: guard }
+    }
+}
+
+impl Drop for NodeIdEnvGuard {
+    fn drop(&mut self) {
+        clear_node_id_env();
+    }
+}
+
 fn set_node_id_env(value: &str) {
     unsafe {
         env::set_var(polyresearch_cli::config::NODE_ID_ENV_VAR, value);
@@ -236,6 +254,7 @@ fn clear_node_id_env() {
 
 #[tokio::test]
 async fn init_writes_node_identity() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("init");
     let mock = Arc::new(MockGitHubClient::new(
         "lead",
@@ -276,7 +295,7 @@ async fn init_writes_node_identity() {
 
 #[tokio::test]
 async fn env_override_uses_session_node_id() {
-    let _guard = env_lock().lock().unwrap();
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("env-node-override");
     let mock = Arc::new(MockGitHubClient::new(
         "lead",
@@ -300,11 +319,11 @@ async fn env_override_uses_session_node_id() {
     assert_eq!(output.resource_policy, "Keep CPUs saturated.");
     assert!(!output.is_default_policy);
 
-    clear_node_id_env();
 }
 
 #[tokio::test]
 async fn pace_reports_default_policy_and_node_metrics() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("pace");
     let approved_fixture = load_issue_fixture("acknowledged_invalid_issue.json");
     let claimed_fixture = load_issue_fixture("claimed_no_attempts_issue.json");
@@ -359,6 +378,7 @@ async fn pace_reports_default_policy_and_node_metrics() {
 
 #[tokio::test]
 async fn status_and_audit_succeed_on_fixture_snapshot() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("status-audit");
     let issue_fixture = load_issue_fixture("duplicate_claim_issue.json");
     let pr_fixture = load_pr_fixture("non_lead_decision_pr.json");
@@ -400,6 +420,7 @@ async fn status_and_audit_succeed_on_fixture_snapshot() {
 
 #[tokio::test]
 async fn claim_rejects_already_claimed_thesis() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-reject");
     let fixture = load_issue_fixture("duplicate_claim_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -435,6 +456,7 @@ async fn claim_rejects_already_claimed_thesis() {
 
 #[tokio::test]
 async fn claim_rejects_closed_thesis() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-closed");
     let fixture = load_issue_fixture("attempt_after_closure_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -470,6 +492,7 @@ async fn claim_rejects_closed_thesis() {
 
 #[tokio::test]
 async fn attempt_rejects_node_without_canonical_claim() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("attempt-reject");
     let fixture = load_issue_fixture("duplicate_claim_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -511,6 +534,7 @@ async fn attempt_rejects_node_without_canonical_claim() {
 
 #[tokio::test]
 async fn generate_is_blocked_by_dirty_audit() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("generate-dirty");
     let fixture = load_issue_fixture("duplicate_claim_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -549,6 +573,7 @@ async fn generate_is_blocked_by_dirty_audit() {
 
 #[tokio::test]
 async fn lead_only_command_rejects_non_lead_login() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("non-lead");
     let mock = Arc::new(MockGitHubClient::new(
         "alice",
@@ -565,6 +590,7 @@ async fn lead_only_command_rejects_non_lead_login() {
 
 #[tokio::test]
 async fn valid_claim_succeeds_in_dry_run_without_writing() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("valid-claim");
     let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -601,6 +627,7 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
 
 #[tokio::test]
 async fn claim_creates_worktree_by_default() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-worktree");
     init_git_repo(&repo.path);
     let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
@@ -659,6 +686,7 @@ async fn claim_creates_worktree_by_default() {
 
 #[tokio::test]
 async fn prune_removes_empty_stale_worktree_directories() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("prune-worktrees");
     init_git_repo(&repo.path);
     let mock = Arc::new(MockGitHubClient::new(
@@ -785,6 +813,7 @@ fn observation_value_enum_accepts_snake_case() {
 
 #[tokio::test]
 async fn duties_reports_blocking_when_claim_has_no_attempts() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-claim");
     let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -816,6 +845,7 @@ async fn duties_reports_blocking_when_claim_has_no_attempts() {
 
 #[tokio::test]
 async fn duties_reports_blocking_when_improved_but_not_submitted() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-submit");
     let fixture = load_issue_fixture("improved_no_submit_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -847,6 +877,7 @@ async fn duties_reports_blocking_when_improved_but_not_submitted() {
 
 #[tokio::test]
 async fn duties_clean_on_no_claims() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-clean");
     let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -876,6 +907,7 @@ async fn duties_clean_on_no_claims() {
 
 #[tokio::test]
 async fn claim_blocked_by_outstanding_duties() {
+    let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-gate");
     let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
     let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
@@ -216,6 +217,23 @@ fn run_git(path: &PathBuf, args: &[&str]) {
     );
 }
 
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn set_node_id_env(value: &str) {
+    unsafe {
+        env::set_var(polyresearch_cli::config::NODE_ID_ENV_VAR, value);
+    }
+}
+
+fn clear_node_id_env() {
+    unsafe {
+        env::remove_var(polyresearch_cli::config::NODE_ID_ENV_VAR);
+    }
+}
+
 #[tokio::test]
 async fn init_writes_node_identity() {
     let repo = TestRepo::new("init");
@@ -254,6 +272,35 @@ async fn init_writes_node_identity() {
         config.resource_policy.as_deref(),
         Some("Use 2 GPUs and keep them busy.")
     );
+}
+
+#[tokio::test]
+async fn env_override_uses_session_node_id() {
+    let _guard = env_lock().lock().unwrap();
+    let repo = TestRepo::new("env-node-override");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
+    commands::write_node_config(&repo.path, "lead/file-node", Some("Keep CPUs saturated."))
+        .unwrap();
+    set_node_id_env("lead/env-node");
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let output = commands::pace::build_output(ctx.repo.slug(), &node_config, &repo_state);
+
+    assert_eq!(output.node_id, "lead/env-node");
+    assert_eq!(output.resource_policy, "Keep CPUs saturated.");
+    assert!(!output.is_default_policy);
+
+    clear_node_id_env();
 }
 
 #[tokio::test]

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -15,15 +15,23 @@ description: >-
 
 1. Read these files in order: `POLYRESEARCH.md`, `PROGRAM.md`, `PREPARE.md`, `results.tsv`.
 2. Run `git log --oneline -20` on `main` to see recent state.
-3. Run `polyresearch init` if `.polyresearch-node.toml` does not exist.
-4. If `.polyresearch/` exists, run its setup. Otherwise follow `PREPARE.md`.
-5. Check your GitHub identity: `gh api user --jq '.login'`
-6. Identify your role from your instructions or `PROGRAM.md`:
+3. Create a distinct node ID for this session before running other `polyresearch` commands:
+   ```bash
+   LOGIN=$(gh api user --jq '.login')
+   MACHINE_ID="$(hostname -s)-$(xxd -l2 -p /dev/urandom)"
+   export POLYRESEARCH_NODE_ID="${LOGIN}/${MACHINE_ID}"
+   ```
+4. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"` to create the fallback file.
+5. If `.polyresearch/` exists, run its setup. Otherwise follow `PREPARE.md`.
+6. Check your GitHub identity: the `LOGIN` above must match the GitHub user you were asked to operate as.
+7. Identify your role from your instructions or `PROGRAM.md`:
    - If told "you are the lead," follow the lead loop.
    - Otherwise, follow the contributor loop.
-7. If the repo is a fork and issues are disabled:
+8. If the repo is a fork and issues are disabled:
    `gh api repos/{owner}/{name} --method PATCH -f has_issues=true`
-8. For any CLI command details: `polyresearch <command> --help`
+9. For any CLI command details: `polyresearch <command> --help`
+
+`POLYRESEARCH_NODE_ID` takes precedence over `.polyresearch-node.toml` for the current session. This is required when multiple agents share one checkout or when one GitHub login runs several workers in parallel.
 
 ## Core principle
 


### PR DESCRIPTION
## Summary
- let `POLYRESEARCH_NODE_ID` override the repo node file so agents sharing one checkout do not collapse onto the same identity
- keep `resource_policy` from `.polyresearch-node.toml` when it exists and add coverage for env override behavior
- update the protocol docs and repo skill so agents export a per-session node ID before running the CLI

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI derives node identity by introducing an environment-variable override and new fallback behavior, which could affect attribution/locking semantics across all commands. Risk is moderated by added unit/e2e coverage for precedence and error-handling cases.
> 
> **Overview**
> Enables **per-process node identities** by letting `POLYRESEARCH_NODE_ID` override `.polyresearch-node.toml` when loading `NodeConfig`, while still reusing `resource_policy` from the file when present.
> 
> When the env var is set, the CLI can now run even if the node config file is missing or invalid, and new tests add env isolation plus coverage for override precedence.
> 
> Updates `POLYRESEARCH.md` and `skills/polyresearch/SKILL.md` to instruct agents to export a unique per-session `POLYRESEARCH_NODE_ID` (and use `polyresearch init` only as a fallback file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a3b25936ac9434f356eae825a04dca127684da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->