### PR TITLE
Add CLI loop guidance for idle and stale polyresearch sessions

### DIFF
--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -277,6 +277,41 @@ fn check_contributor_idle_state(
         return Ok(());
     }
 
+    let approved_claimable_count = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| {
+            thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
+        })
+        .count();
+    if approved_claimable_count == 0 {
+        let pending_approval_count = repo_state
+            .theses
+            .iter()
+            .filter(|thesis| {
+                thesis.issue.state == "OPEN"
+                    && matches!(thesis.phase, ThesisPhase::Submitted)
+                    && !thesis.maintainer_rejected
+            })
+            .count();
+
+        if pending_approval_count > 0 {
+            let noun = if pending_approval_count == 1 {
+                "thesis is"
+            } else {
+                "theses are"
+            };
+            advisory.push(DutyItem {
+                category: "awaiting-approval".to_string(),
+                message: format!(
+                    "No approved theses are currently claimable. {pending_approval_count} {noun} still awaiting maintainer `/approve`."
+                ),
+                command: "sleep 60 && polyresearch duties".to_string(),
+            });
+        }
+        return Ok(());
+    }
+
     if let Some((best, tolerance)) = metric_floor_info(ctx, repo_state) {
         advisory.push(DutyItem {
             category: "no-claimable-work".to_string(),

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::Result;
 use serde::Serialize;
 
 use crate::commands::{AppContext, print_value, read_node_id};
-use crate::comments::Observation;
+use crate::comments::{Observation, ReleaseReason};
 use crate::ledger::Ledger;
 use crate::state::{RepositoryState, ThesisPhase};
 
@@ -197,6 +197,17 @@ fn check_lead_duties(
         });
     }
 
+    let stale_claimable_count = stale_claimable_queue_count(repo_state);
+    if let Some(stale_count) = stale_claimable_count {
+        advisory.push(DutyItem {
+            category: "stale-queue".to_string(),
+            message: format!(
+                "All {stale_count} claimable theses have already been released with `no_improvement`. Generate fresh theses."
+            ),
+            command: "polyresearch generate --title \"...\" --body \"...\"".to_string(),
+        });
+    }
+
     if let Some((best, tolerance)) = metric_floor_info(ctx, repo_state) {
         advisory.push(DutyItem {
             category: "metric-floor".to_string(),
@@ -206,7 +217,10 @@ fn check_lead_duties(
             command: "Consider adjusting metric_tolerance or concluding the program.".to_string(),
         });
 
-        if repo_state.queue_depth >= ctx.config.min_queue_depth && repo_state.queue_depth > 0 {
+        if stale_claimable_count.is_none()
+            && repo_state.queue_depth >= ctx.config.min_queue_depth
+            && repo_state.queue_depth > 0
+        {
             advisory.push(DutyItem {
                 category: "stale-queue".to_string(),
                 message: format!(
@@ -320,12 +334,31 @@ fn metric_floor_info(ctx: &AppContext, repo_state: &RepositoryState) -> Option<(
     let tolerance = ctx.config.metric_tolerance?;
     let best = repo_state.current_best_accepted_metric?;
 
+    // Lower-is-better metrics have a generic floor at zero, so once the best score is
+    // below the required tolerance there is no room left for another meaningful win.
     matches!(
         ctx.config.metric_direction,
         crate::config::MetricDirection::LowerIsBetter
     )
     .then_some((best, tolerance))
     .filter(|(best, tolerance)| *best < *tolerance)
+}
+
+fn stale_claimable_queue_count(repo_state: &RepositoryState) -> Option<usize> {
+    let stale_count = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| {
+            thesis.issue.state == "OPEN"
+                && matches!(thesis.phase, ThesisPhase::Approved)
+                && thesis
+                    .releases
+                    .iter()
+                    .any(|release| release.reason == ReleaseReason::NoImprovement)
+        })
+        .count();
+
+    (stale_count > 0 && stale_count == repo_state.queue_depth).then_some(stale_count)
 }
 
 fn render_report(value: &DutyReport) -> String {

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -88,7 +88,10 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
         check_lead_duties(ctx, repo_state, &mut blocking, &mut advisory)?;
     }
 
-    check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
+    let has_review_work = check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
+    if !is_lead {
+        check_contributor_idle_state(ctx, repo_state, &node_id, has_review_work, &mut advisory)?;
+    }
 
     let clean = blocking.is_empty();
     Ok(DutyReport {
@@ -194,6 +197,27 @@ fn check_lead_duties(
         });
     }
 
+    if let Some((best, tolerance)) = metric_floor_info(ctx, repo_state) {
+        advisory.push(DutyItem {
+            category: "metric-floor".to_string(),
+            message: format!(
+                "Best metric ({best:.1}ms) is below metric_tolerance ({tolerance:.1}ms). Further improvement within the current tolerance is impossible."
+            ),
+            command: "Consider adjusting metric_tolerance or concluding the program.".to_string(),
+        });
+
+        if repo_state.queue_depth >= ctx.config.min_queue_depth && repo_state.queue_depth > 0 {
+            advisory.push(DutyItem {
+                category: "stale-queue".to_string(),
+                message: format!(
+                    "Queue depth is {} but best metric ({best:.1}ms) is already below metric_tolerance ({tolerance:.1}ms). Existing theses may no longer contain meaningful work.",
+                    repo_state.queue_depth
+                ),
+                command: "polyresearch generate --title \"...\" --body \"...\"".to_string(),
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -202,7 +226,9 @@ fn check_review_opportunities(
     node_id: &str,
     login: &str,
     advisory: &mut Vec<DutyItem>,
-) {
+) -> bool {
+    let mut added = false;
+
     for thesis in &repo_state.theses {
         if !matches!(thesis.phase, ThesisPhase::InReview) {
             continue;
@@ -233,45 +259,129 @@ fn check_review_opportunities(
                 message: format!("PR #{}: needs review.", pr_state.pr.number),
                 command: format!("polyresearch review-claim {}", pr_state.pr.number),
             });
+            added = true;
         }
     }
+
+    added
+}
+
+fn check_contributor_idle_state(
+    ctx: &AppContext,
+    repo_state: &RepositoryState,
+    node_id: &str,
+    has_review_work: bool,
+    advisory: &mut Vec<DutyItem>,
+) -> Result<()> {
+    if has_review_work || repo_state.queue_depth == 0 {
+        return Ok(());
+    }
+
+    if let Some((best, tolerance)) = metric_floor_info(ctx, repo_state) {
+        advisory.push(DutyItem {
+            category: "no-claimable-work".to_string(),
+            message: format!(
+                "Best metric ({best:.1}ms) is already below metric_tolerance ({tolerance:.1}ms). Remaining theses may not support another meaningful improvement. Wait for fresh theses from the lead."
+            ),
+            command: "sleep 60 && polyresearch duties".to_string(),
+        });
+        return Ok(());
+    }
+
+    if node_id.is_empty() {
+        return Ok(());
+    }
+
+    let claimable_for_me = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| {
+            thesis.issue.state == "OPEN"
+                && matches!(thesis.phase, ThesisPhase::Approved)
+                && !thesis
+                    .releases
+                    .iter()
+                    .any(|release| release.node == node_id)
+        })
+        .count();
+
+    if claimable_for_me == 0 {
+        advisory.push(DutyItem {
+            category: "no-claimable-work".to_string(),
+            message: "All claimable theses have been tried by this node. Waiting for fresh theses from the lead.".to_string(),
+            command: "sleep 60 && polyresearch duties".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn metric_floor_info(ctx: &AppContext, repo_state: &RepositoryState) -> Option<(f64, f64)> {
+    let tolerance = ctx.config.metric_tolerance?;
+    let best = repo_state.current_best_accepted_metric?;
+
+    matches!(
+        ctx.config.metric_direction,
+        crate::config::MetricDirection::LowerIsBetter
+    )
+    .then_some((best, tolerance))
+    .filter(|(best, tolerance)| *best < *tolerance)
+}
+
+fn render_report(value: &DutyReport) -> String {
+    let mut output = String::new();
+
+    if value.blocking.is_empty() && value.advisory.is_empty() {
+        output.push_str("No duties. All clear.\nNEXT: sleep 60 && polyresearch duties");
+        return output;
+    }
+
+    if !value.blocking.is_empty() {
+        output.push_str("BLOCKING (resolve before continuing):\n");
+        for item in &value.blocking {
+            output.push_str(&format!(
+                "  [{}] {} Run: {}\n",
+                item.category, item.message, item.command
+            ));
+        }
+    }
+
+    if !value.advisory.is_empty() {
+        if !value.blocking.is_empty() {
+            output.push('\n');
+        }
+        output.push_str("ADVISORY:\n");
+        for item in &value.advisory {
+            output.push_str(&format!(
+                "  [{}] {} Run: {}\n",
+                item.category, item.message, item.command
+            ));
+        }
+    }
+
+    output.trim_end().to_string()
 }
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let report = check(ctx, &repo_state)?;
 
-    print_value(ctx, &report, |value| {
-        let mut output = String::new();
+    print_value(ctx, &report, render_report)
+}
 
-        if value.blocking.is_empty() && value.advisory.is_empty() {
-            output.push_str("No duties. All clear.");
-            return output;
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        if !value.blocking.is_empty() {
-            output.push_str("BLOCKING (resolve before continuing):\n");
-            for item in &value.blocking {
-                output.push_str(&format!(
-                    "  [{}] {} Run: {}\n",
-                    item.category, item.message, item.command
-                ));
-            }
-        }
+    #[test]
+    fn render_report_includes_next_step_when_clear() {
+        let rendered = render_report(&DutyReport {
+            blocking: vec![],
+            advisory: vec![],
+            clean: true,
+        });
 
-        if !value.advisory.is_empty() {
-            if !value.blocking.is_empty() {
-                output.push('\n');
-            }
-            output.push_str("ADVISORY:\n");
-            for item in &value.advisory {
-                output.push_str(&format!(
-                    "  [{}] {} Run: {}\n",
-                    item.category, item.message, item.command
-                ));
-            }
-        }
-
-        output.trim_end().to_string()
-    })
+        assert!(rendered.contains("No duties. All clear."));
+        assert!(rendered.contains("NEXT: sleep 60 && polyresearch duties"));
+    }
 }

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::Result;
 use serde::Serialize;
 
 use crate::commands::{AppContext, print_value, read_node_id};
-use crate::comments::{Observation, ReleaseReason};
+use crate::comments::Observation;
 use crate::ledger::Ledger;
 use crate::state::{RepositoryState, ThesisPhase};
 
@@ -197,17 +197,6 @@ fn check_lead_duties(
         });
     }
 
-    let stale_claimable_count = stale_claimable_queue_count(repo_state);
-    if let Some(stale_count) = stale_claimable_count {
-        advisory.push(DutyItem {
-            category: "stale-queue".to_string(),
-            message: format!(
-                "All {stale_count} claimable theses have already been released with `no_improvement`. Generate fresh theses."
-            ),
-            command: "polyresearch generate --title \"...\" --body \"...\"".to_string(),
-        });
-    }
-
     if let Some((best, tolerance)) = metric_floor_info(ctx, repo_state) {
         advisory.push(DutyItem {
             category: "metric-floor".to_string(),
@@ -217,10 +206,7 @@ fn check_lead_duties(
             command: "Consider adjusting metric_tolerance or concluding the program.".to_string(),
         });
 
-        if stale_claimable_count.is_none()
-            && repo_state.queue_depth >= ctx.config.min_queue_depth
-            && repo_state.queue_depth > 0
-        {
+        if repo_state.queue_depth >= ctx.config.min_queue_depth && repo_state.queue_depth > 0 {
             advisory.push(DutyItem {
                 category: "stale-queue".to_string(),
                 message: format!(
@@ -342,23 +328,6 @@ fn metric_floor_info(ctx: &AppContext, repo_state: &RepositoryState) -> Option<(
     )
     .then_some((best, tolerance))
     .filter(|(best, tolerance)| *best < *tolerance)
-}
-
-fn stale_claimable_queue_count(repo_state: &RepositoryState) -> Option<usize> {
-    let stale_count = repo_state
-        .theses
-        .iter()
-        .filter(|thesis| {
-            thesis.issue.state == "OPEN"
-                && matches!(thesis.phase, ThesisPhase::Approved)
-                && thesis
-                    .releases
-                    .iter()
-                    .any(|release| release.reason == ReleaseReason::NoImprovement)
-        })
-        .count();
-
-    (stale_count > 0 && stale_count == repo_state.queue_depth).then_some(stale_count)
 }
 
 fn render_report(value: &DutyReport) -> String {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -29,6 +29,9 @@ use crate::cli::{Cli, Commands};
 use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 
+const LOOP_CONTINUATION_REMINDER: &str =
+    "[polyresearch] Continue the loop. Only the user can end this session.";
+
 #[derive(Clone)]
 pub struct AppContext {
     pub cli: Cli,
@@ -69,6 +72,8 @@ where
         println!("{}", serde_json::to_string_pretty(value)?);
     } else {
         println!("{}", plain(value));
+        // Keep JSON stdout machine-parseable for agent pipelines that consume `--json`.
+        eprintln!("{LOOP_CONTINUATION_REMINDER}");
     }
     Ok(())
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -29,9 +29,6 @@ use crate::cli::{Cli, Commands};
 use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 
-const LOOP_CONTINUATION_REMINDER: &str =
-    "[polyresearch] Continue the loop. Only the user can end this session.";
-
 #[derive(Clone)]
 pub struct AppContext {
     pub cli: Cli,
@@ -72,8 +69,6 @@ where
         println!("{}", serde_json::to_string_pretty(value)?);
     } else {
         println!("{}", plain(value));
-        // Keep JSON stdout machine-parseable for agent pipelines that consume `--json`.
-        eprintln!("{LOOP_CONTINUATION_REMINDER}");
     }
     Ok(())
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -862,45 +862,6 @@ async fn duties_reports_metric_floor_and_stale_queue_for_lead() {
 }
 
 #[tokio::test]
-async fn duties_reports_stale_queue_for_lead_when_all_claimable_theses_are_released() {
-    let repo = TestRepo::new("duties-stale-queue-released");
-    let mock = Arc::new(MockGitHubClient::new(
-        "lead",
-        vec![],
-        HashMap::new(),
-        vec![],
-        HashMap::new(),
-    ));
-    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
-
-    let mut thesis_one = make_approved_thesis(1);
-    thesis_one.releases.push(ReleaseRecord {
-        node: "node-a".to_string(),
-        reason: ReleaseReason::NoImprovement,
-        created_at: chrono::Utc::now(),
-    });
-
-    let mut thesis_two = make_approved_thesis(2);
-    thesis_two.releases.push(ReleaseRecord {
-        node: "node-b".to_string(),
-        reason: ReleaseReason::NoImprovement,
-        created_at: chrono::Utc::now(),
-    });
-
-    let repo_state = make_repo_state(vec![thesis_one, thesis_two], 2, None);
-    let report = commands::duties::check(&ctx, &repo_state).unwrap();
-
-    assert!(
-        report.advisory.iter().any(|d| d.category == "stale-queue"),
-        "should report a stale-queue advisory when every claimable thesis was already released with no_improvement"
-    );
-    assert!(
-        !report.advisory.iter().any(|d| d.category == "metric-floor"),
-        "release-based stale queue detection should not require a metric-floor condition"
-    );
-}
-
-#[tokio::test]
 async fn duties_reports_no_claimable_work_for_contributor_at_metric_floor() {
     let repo = TestRepo::new("duties-no-claimable-metric-floor");
     let mock = Arc::new(MockGitHubClient::new(

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -936,6 +936,39 @@ async fn duties_reports_no_claimable_work_when_all_theses_were_released_by_node(
     );
 }
 
+#[tokio::test]
+async fn duties_reports_waiting_for_approval_when_queue_has_only_submitted_theses() {
+    let repo = TestRepo::new("duties-awaiting-approval");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+    ctx.config.auto_approve = false;
+    commands::write_node_id(&repo.path, "node-a").unwrap();
+
+    let repo_state = make_repo_state(vec![make_submitted_thesis(1)], 1, None);
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+
+    assert!(
+        report
+            .advisory
+            .iter()
+            .any(|d| d.category == "awaiting-approval"),
+        "should report that the queue is waiting on maintainer approval"
+    );
+    assert!(
+        !report
+            .advisory
+            .iter()
+            .any(|d| d.category == "no-claimable-work"),
+        "submitted theses waiting on approval should not be reported as already tried by this node"
+    );
+}
+
 // --- B6: Duty gate on claim ---
 
 #[tokio::test]
@@ -1057,6 +1090,22 @@ fn make_approved_thesis(number: u64) -> ThesisState {
         phase: ThesisPhase::Approved,
         approved: true,
         maintainer_approved: true,
+        maintainer_rejected: false,
+        active_claims: vec![],
+        releases: vec![],
+        attempts: vec![],
+        pull_requests: vec![],
+        best_attempt_metric: None,
+        findings: vec![],
+    }
+}
+
+fn make_submitted_thesis(number: u64) -> ThesisState {
+    ThesisState {
+        issue: make_open_issue(number, &format!("Submitted thesis {number}")),
+        phase: ThesisPhase::Submitted,
+        approved: false,
+        maintainer_approved: false,
         maintainer_rejected: false,
         active_claims: vec![],
         releases: vec![],

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -862,6 +862,45 @@ async fn duties_reports_metric_floor_and_stale_queue_for_lead() {
 }
 
 #[tokio::test]
+async fn duties_reports_stale_queue_for_lead_when_all_claimable_theses_are_released() {
+    let repo = TestRepo::new("duties-stale-queue-released");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+
+    let mut thesis_one = make_approved_thesis(1);
+    thesis_one.releases.push(ReleaseRecord {
+        node: "node-a".to_string(),
+        reason: ReleaseReason::NoImprovement,
+        created_at: chrono::Utc::now(),
+    });
+
+    let mut thesis_two = make_approved_thesis(2);
+    thesis_two.releases.push(ReleaseRecord {
+        node: "node-b".to_string(),
+        reason: ReleaseReason::NoImprovement,
+        created_at: chrono::Utc::now(),
+    });
+
+    let repo_state = make_repo_state(vec![thesis_one, thesis_two], 2, None);
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+
+    assert!(
+        report.advisory.iter().any(|d| d.category == "stale-queue"),
+        "should report a stale-queue advisory when every claimable thesis was already released with no_improvement"
+    );
+    assert!(
+        !report.advisory.iter().any(|d| d.category == "metric-floor"),
+        "release-based stale queue detection should not require a metric-floor condition"
+    );
+}
+
+#[tokio::test]
 async fn duties_reports_no_claimable_work_for_contributor_at_metric_floor() {
     let repo = TestRepo::new("duties-no-claimable-metric-floor");
     let mock = Arc::new(MockGitHubClient::new(

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -10,13 +10,13 @@ use polyresearch_cli::cli::{
     AttemptArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
 };
 use polyresearch_cli::commands;
-use polyresearch_cli::comments::Observation;
+use polyresearch_cli::comments::{Observation, ReleaseReason};
 use polyresearch_cli::config::{MetricDirection, NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch_cli::github::{
     CommentUser, GitHubApi, Issue, IssueComment, IssueListState, PullRequest, PullRequestFile,
     PullRequestListState, RepoRef,
 };
-use polyresearch_cli::state::RepositoryState;
+use polyresearch_cli::state::{ReleaseRecord, RepositoryState, ThesisPhase, ThesisState};
 use serde::Deserialize;
 
 #[allow(unused_imports)]
@@ -825,6 +825,117 @@ async fn duties_clean_on_no_claims() {
     assert!(report.clean, "should have no blocking duties");
 }
 
+#[tokio::test]
+async fn duties_reports_metric_floor_and_stale_queue_for_lead() {
+    let repo = TestRepo::new("duties-metric-floor-lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+    ctx.config.metric_direction = MetricDirection::LowerIsBetter;
+    ctx.config.metric_tolerance = Some(50.0);
+    ctx.config.min_queue_depth = 3;
+
+    let repo_state = make_repo_state(
+        vec![
+            make_approved_thesis(1),
+            make_approved_thesis(2),
+            make_approved_thesis(3),
+        ],
+        3,
+        Some(25.8),
+    );
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+
+    assert!(
+        report.advisory.iter().any(|d| d.category == "metric-floor"),
+        "should report a metric-floor advisory"
+    );
+    assert!(
+        report.advisory.iter().any(|d| d.category == "stale-queue"),
+        "should report a stale-queue advisory when the queue looks healthy but is stale"
+    );
+}
+
+#[tokio::test]
+async fn duties_reports_no_claimable_work_for_contributor_at_metric_floor() {
+    let repo = TestRepo::new("duties-no-claimable-metric-floor");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+    ctx.config.metric_direction = MetricDirection::LowerIsBetter;
+    ctx.config.metric_tolerance = Some(50.0);
+    ctx.config.min_queue_depth = 3;
+    commands::write_node_id(&repo.path, "node-a").unwrap();
+
+    let repo_state = make_repo_state(
+        vec![
+            make_approved_thesis(1),
+            make_approved_thesis(2),
+            make_approved_thesis(3),
+        ],
+        3,
+        Some(25.8),
+    );
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+
+    assert!(
+        report
+            .advisory
+            .iter()
+            .any(|d| d.category == "no-claimable-work"),
+        "should tell contributors to wait for fresh theses when the metric floor is hit"
+    );
+}
+
+#[tokio::test]
+async fn duties_reports_no_claimable_work_when_all_theses_were_released_by_node() {
+    let repo = TestRepo::new("duties-no-claimable-released");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+    commands::write_node_id(&repo.path, "node-a").unwrap();
+
+    let mut thesis_one = make_approved_thesis(1);
+    thesis_one.releases.push(ReleaseRecord {
+        node: "node-a".to_string(),
+        reason: ReleaseReason::InfraFailure,
+        created_at: chrono::Utc::now(),
+    });
+
+    let mut thesis_two = make_approved_thesis(2);
+    thesis_two.releases.push(ReleaseRecord {
+        node: "node-a".to_string(),
+        reason: ReleaseReason::Timeout,
+        created_at: chrono::Utc::now(),
+    });
+
+    let repo_state = make_repo_state(vec![thesis_one, thesis_two], 2, None);
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+
+    assert!(
+        report
+            .advisory
+            .iter()
+            .any(|d| d.category == "no-claimable-work"),
+        "should report no-claimable-work when every approved thesis was already tried by this node"
+    );
+}
+
 // --- B6: Duty gate on claim ---
 
 #[tokio::test]
@@ -908,6 +1019,51 @@ fn make_ctx(
             can_modify: vec!["system_prompt.md".to_string()],
             cannot_modify: vec!["PREPARE.md".to_string()],
         },
+    }
+}
+
+fn make_repo_state(
+    theses: Vec<ThesisState>,
+    queue_depth: usize,
+    current_best_accepted_metric: Option<f64>,
+) -> RepositoryState {
+    RepositoryState {
+        theses,
+        active_nodes: vec![],
+        queue_depth,
+        current_best_accepted_metric,
+        recent_events: vec![],
+        audit_findings: vec![],
+    }
+}
+
+fn make_open_issue(number: u64, title: &str) -> Issue {
+    Issue {
+        number,
+        title: title.to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        labels: vec![],
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        author: None,
+        url: None,
+    }
+}
+
+fn make_approved_thesis(number: u64) -> ThesisState {
+    ThesisState {
+        issue: make_open_issue(number, &format!("Thesis {number}")),
+        phase: ThesisPhase::Approved,
+        approved: true,
+        maintainer_approved: true,
+        maintainer_rejected: false,
+        active_claims: vec![],
+        releases: vec![],
+        attempts: vec![],
+        pull_requests: vec![],
+        best_attempt_metric: None,
+        findings: vec![],
     }
 }
 


### PR DESCRIPTION
## Summary
- add a plain-text CLI reminder and a `NEXT: sleep 60 && polyresearch duties` hint so agents keep looping without prompt-only guidance or tight polling
- add lead-side `metric-floor` and `stale-queue` advisories for the case where accepted wins make the remaining queue unworkable even though `queue_depth` still looks healthy
- add contributor-side `no-claimable-work` guidance plus test coverage for the new idle and stale-queue duty paths

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to `duties` CLI reporting logic and messaging, plus new test coverage; no auth/security or data mutation paths are introduced.
> 
> **Overview**
> Enhances the `duties` command to provide clearer loop/idle guidance and detect “stale” work conditions.
> 
> Leads now get new advisories when a **lower-is-better** program has effectively hit the `metric_tolerance` floor (`metric-floor`) and when the queue appears healthy but is likely unproductive (`stale-queue`). Contributors now get idle-state advisories when there’s **no actionable work** (waiting on maintainer approval, metric floor reached, or all approved theses already tried by the current node), and the plain-text output includes a `NEXT: sleep 60 && polyresearch duties` hint when clear.
> 
> Adds e2e tests and small helpers to cover the new duty paths, and tweaks `check_review_opportunities` to return whether review work was found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741258b12bb439a0e03c4f3c27c81277f6880cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->