### PR TITLE
Preserve thesis learnings with annotations and bootstrap guidance

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -205,6 +205,7 @@ Complete all of these before opening any new thesis issue:
 1. Confirm `polyresearch audit` is clean and `results.tsv` is current. The maintain step above must be done first.
 2. Read results.tsv and PROGRAM.md. Identify patterns in what worked, what failed, and what has not been tried yet.
 3. Run `polyresearch status` and read every existing thesis title and body, open and closed.
+4. Read annotations on closed theses. Treat them as negative knowledge. Do not repeat those directions unless you can explain why the new attempt is materially different.
 
 Queue depth check:
 
@@ -407,8 +408,32 @@ metric: 1.0050
 baseline_metric: 0.9934
 observation: no_improvement | crashed | infra_failure
 summary: Switched to GeLU activation, regression on val_bpb
+annotations: [{"category":"failure_analysis","task_id":"task-7","text":"Tool selection drifted after step 2"}]   # optional
 -->
 ```
+
+The optional `annotations` field is a JSON array of objects with:
+
+- `category` — short machine-friendly label such as `failure_analysis`, `observation`, or `hypothesis`
+- `task_id` — optional benchmark task ID
+- `text` — the human-readable note
+
+When `annotations` are present, the visible part of the comment may also include a short `Annotations:` section above the HTML metadata block.
+
+**Annotation** (informational note on a thesis issue):
+
+```
+Polyresearch annotation: thesis #12 by node `alice/node-7f83`.
+
+Tried the retrieval-heavy direction twice. It regressed on tool-use tasks.
+
+<!-- polyresearch:annotation
+thesis: 12
+node: alice/node-7f83
+-->
+```
+
+Annotations are informational only. They do not change thesis state.
 
 ### On candidate PRs
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -27,6 +27,7 @@ pub enum Commands {
     Status(StatusArgs),
     Claim(IssueArgs),
     Attempt(AttemptArgs),
+    Annotate(AnnotateArgs),
     Release(ReleaseArgs),
     Submit(IssueArgs),
     ReviewClaim(PrArgs),
@@ -84,6 +85,17 @@ pub struct AttemptArgs {
 
     #[arg(long)]
     pub summary: String,
+
+    #[arg(long)]
+    pub annotations: Option<String>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct AnnotateArgs {
+    pub issue: u64,
+
+    #[arg(long)]
+    pub text: String,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/annotate.rs
+++ b/cli/src/commands/annotate.rs
@@ -1,0 +1,42 @@
+use color_eyre::eyre::Result;
+use serde::Serialize;
+
+use crate::cli::AnnotateArgs;
+use crate::commands::guards::find_thesis;
+use crate::commands::{AppContext, print_value, read_node_id};
+use crate::comments::ProtocolComment;
+use crate::state::RepositoryState;
+
+#[derive(Debug, Serialize)]
+struct AnnotateOutput {
+    issue: u64,
+    node: String,
+}
+
+pub async fn run(ctx: &AppContext, args: &AnnotateArgs) -> Result<()> {
+    let node = read_node_id(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let thesis = find_thesis(&repo_state, args.issue)?;
+
+    let comment = ProtocolComment::Annotation {
+        thesis: thesis.issue.number,
+        node: node.clone(),
+        text: args.text.clone(),
+    };
+    if !ctx.cli.dry_run {
+        ctx.github
+            .post_issue_comment(thesis.issue.number, &comment.render())?;
+    }
+
+    let output = AnnotateOutput {
+        issue: thesis.issue.number,
+        node,
+    };
+
+    print_value(ctx, &output, |value| {
+        format!(
+            "Annotated thesis #{} for node `{}`.",
+            value.issue, value.node
+        )
+    })
+}

--- a/cli/src/commands/attempt.rs
+++ b/cli/src/commands/attempt.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::cli::AttemptArgs;
 use crate::commands::guards::require_claimed_thesis;
 use crate::commands::{AppContext, current_branch, print_value, read_node_id};
-use crate::comments::{Observation, ProtocolComment};
+use crate::comments::{Observation, ProtocolComment, parse_attempt_annotations};
 use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
@@ -14,6 +14,7 @@ struct AttemptOutput {
     metric: f64,
     baseline_metric: f64,
     attempt_number: usize,
+    annotations_count: usize,
 }
 
 pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
@@ -29,6 +30,12 @@ pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
         ));
     }
 
+    let annotations = args
+        .annotations
+        .as_deref()
+        .map(parse_attempt_annotations)
+        .transpose()?;
+
     let comment = ProtocolComment::Attempt {
         thesis: args.issue,
         branch: branch.clone(),
@@ -36,6 +43,7 @@ pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
         baseline_metric: args.baseline,
         observation: args.observation,
         summary: args.summary.clone(),
+        annotations,
     };
     if !ctx.cli.dry_run {
         ctx.github
@@ -48,6 +56,10 @@ pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
         metric: args.metric,
         baseline_metric: args.baseline,
         attempt_number: thesis.attempts.len() + 1,
+        annotations_count: comment
+            .attempt_annotations()
+            .map(|items| items.len())
+            .unwrap_or(0),
     };
 
     print_value(ctx, &output, |value| {
@@ -55,6 +67,17 @@ pub async fn run(ctx: &AppContext, args: &AttemptArgs) -> Result<()> {
             "Recorded attempt {} for thesis #{} on `{}` ({:.4} vs {:.4}).",
             value.attempt_number, value.issue, value.branch, value.metric, value.baseline_metric
         );
+        if value.annotations_count > 0 {
+            msg.push_str(&format!(
+                "\nIncluded {} structured annotation{}.",
+                value.annotations_count,
+                if value.annotations_count == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ));
+        }
         if args.observation == Observation::Improved {
             msg.push_str(&format!(
                 "\nImproved result recorded. Run `polyresearch submit {}` to open a candidate PR.",

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod annotate;
 pub mod attempt;
 pub mod audit;
 pub mod claim;
@@ -46,6 +47,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,
+        Commands::Annotate(args) => annotate::run(&ctx, args).await,
         Commands::Release(args) => release::run(&ctx, args).await,
         Commands::Submit(args) => submit::run(&ctx, args).await,
         Commands::ReviewClaim(args) => review_claim::run(&ctx, args).await,

--- a/cli/src/comments.rs
+++ b/cli/src/comments.rs
@@ -81,6 +81,14 @@ impl fmt::Display for Outcome {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttemptAnnotation {
+    pub category: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    pub text: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ProtocolComment {
@@ -109,6 +117,12 @@ pub enum ProtocolComment {
         baseline_metric: f64,
         observation: Observation,
         summary: String,
+        annotations: Option<Vec<AttemptAnnotation>>,
+    },
+    Annotation {
+        thesis: u64,
+        node: String,
+        text: String,
     },
     PolicyPass {
         thesis: u64,
@@ -177,13 +191,18 @@ impl ProtocolComment {
             .as_str();
         let fields = parse_fields(payload);
 
-        match Self::parse_typed(comment_type, &fields) {
+        let visible_body = extract_visible_body(before_match);
+        match Self::parse_typed(comment_type, &fields, visible_body.as_deref()) {
             Ok(comment) => Ok(Some(comment)),
             Err(_) => Ok(None),
         }
     }
 
-    fn parse_typed(comment_type: &str, fields: &BTreeMap<String, String>) -> Result<Self> {
+    fn parse_typed(
+        comment_type: &str,
+        fields: &BTreeMap<String, String>,
+        visible_body: Option<&str>,
+    ) -> Result<Self> {
         let comment = match comment_type {
             "approval" => Self::Approval {
                 thesis: parse_u64(fields, "thesis")?,
@@ -204,6 +223,12 @@ impl ProtocolComment {
                 baseline_metric: parse_f64(fields, "baseline_metric")?,
                 observation: parse_observation(fields, "observation")?,
                 summary: parse_string(fields, "summary")?,
+                annotations: parse_optional_annotations(fields, "annotations")?,
+            },
+            "annotation" => Self::Annotation {
+                thesis: parse_u64(fields, "thesis")?,
+                node: parse_string(fields, "node")?,
+                text: visible_body.unwrap_or_default().trim().to_string(),
             },
             "policy-pass" => Self::PolicyPass {
                 thesis: parse_u64(fields, "thesis")?,
@@ -242,6 +267,16 @@ impl ProtocolComment {
         Ok(comment)
     }
 
+    pub fn attempt_annotations(&self) -> Option<&[AttemptAnnotation]> {
+        match self {
+            Self::Attempt {
+                annotations: Some(annotations),
+                ..
+            } => Some(annotations),
+            _ => None,
+        }
+    }
+
     pub fn render(&self) -> String {
         match self {
             Self::SlashApprove { reason } => render_slash_command("/approve", reason.as_deref()),
@@ -278,19 +313,30 @@ impl ProtocolComment {
                 baseline_metric,
                 observation,
                 summary,
-            } => render_block(
+                annotations,
+            } => render_block_with_body(
                 format!(
                     "Polyresearch attempt: thesis #{thesis}, branch `{branch}`, metric `{metric:.4}`, observation `{observation}`."
                 ),
+                annotations
+                    .as_ref()
+                    .map(|items| render_attempt_annotations(items)),
                 "attempt",
-                &[
-                    ("thesis", thesis.to_string()),
-                    ("branch", branch.clone()),
-                    ("metric", format!("{metric:.4}")),
-                    ("baseline_metric", format!("{baseline_metric:.4}")),
-                    ("observation", observation.to_string()),
-                    ("summary", summary.clone()),
-                ],
+                &attempt_fields(
+                    thesis.to_string(),
+                    branch,
+                    *metric,
+                    *baseline_metric,
+                    *observation,
+                    summary,
+                    annotations.as_ref(),
+                ),
+            ),
+            Self::Annotation { thesis, node, text } => render_block_with_body(
+                format!("Polyresearch annotation: thesis #{thesis} by node `{node}`."),
+                Some(text.clone()),
+                "annotation",
+                &[("thesis", thesis.to_string()), ("node", node.clone())],
             ),
             Self::PolicyPass {
                 thesis,
@@ -423,6 +469,13 @@ fn parse_fields(payload: &str) -> BTreeMap<String, String> {
         .collect()
 }
 
+fn extract_visible_body(before_match: &str) -> Option<String> {
+    let trimmed = before_match.trim_end();
+    let (_, rest) = trimmed.split_once("\n\n")?;
+    let body = rest.trim();
+    (!body.is_empty()).then(|| body.to_string())
+}
+
 fn parse_string(fields: &BTreeMap<String, String>, key: &str) -> Result<String> {
     fields
         .get(key)
@@ -440,6 +493,17 @@ fn parse_optional_string(fields: &BTreeMap<String, String>, key: &str) -> Result
     }
 
     Ok(Some(value.clone()))
+}
+
+fn parse_optional_annotations(
+    fields: &BTreeMap<String, String>,
+    key: &str,
+) -> Result<Option<Vec<AttemptAnnotation>>> {
+    let Some(value) = parse_optional_string(fields, key)? else {
+        return Ok(None);
+    };
+    let annotations = parse_attempt_annotations(&value)?;
+    Ok(Some(annotations))
 }
 
 fn parse_optional_u64(fields: &BTreeMap<String, String>, key: &str) -> Result<Option<u64>> {
@@ -503,10 +567,83 @@ fn parse_outcome(fields: &BTreeMap<String, String>, key: &str) -> Result<Outcome
     }
 }
 
+pub fn parse_attempt_annotations(raw: &str) -> Result<Vec<AttemptAnnotation>> {
+    let annotations = serde_json::from_str::<Vec<AttemptAnnotation>>(raw)
+        .map_err(|err| eyre!("invalid attempt annotations JSON: {err}"))?;
+    if annotations.is_empty() {
+        return Err(eyre!(
+            "attempt annotations must be a non-empty JSON array when provided"
+        ));
+    }
+    for (index, annotation) in annotations.iter().enumerate() {
+        if annotation.category.trim().is_empty() {
+            return Err(eyre!("attempt annotation #{index} has an empty `category`"));
+        }
+        if annotation.text.trim().is_empty() {
+            return Err(eyre!("attempt annotation #{index} has an empty `text`"));
+        }
+    }
+    Ok(annotations)
+}
+
+fn attempt_fields(
+    thesis: String,
+    branch: &str,
+    metric: f64,
+    baseline_metric: f64,
+    observation: Observation,
+    summary: &str,
+    annotations: Option<&Vec<AttemptAnnotation>>,
+) -> Vec<(&'static str, String)> {
+    let mut fields = vec![
+        ("thesis", thesis),
+        ("branch", branch.to_string()),
+        ("metric", format!("{metric:.4}")),
+        ("baseline_metric", format!("{baseline_metric:.4}")),
+        ("observation", observation.to_string()),
+        ("summary", summary.to_string()),
+    ];
+    if let Some(annotations) = annotations {
+        fields.push((
+            "annotations",
+            serde_json::to_string(annotations).expect("attempt annotations serialize"),
+        ));
+    }
+    fields
+}
+
+fn render_attempt_annotations(annotations: &[AttemptAnnotation]) -> String {
+    let mut rendered = String::from("Annotations:\n");
+    for annotation in annotations {
+        let text = annotation.text.replace('\n', " ");
+        match &annotation.task_id {
+            Some(task_id) => rendered.push_str(&format!(
+                "- [{}] task `{}`: {}\n",
+                annotation.category, task_id, text
+            )),
+            None => rendered.push_str(&format!("- [{}]: {}\n", annotation.category, text)),
+        }
+    }
+    rendered.trim_end().to_string()
+}
+
 fn render_block(summary: String, comment_type: &str, fields: &[(&str, String)]) -> String {
+    render_block_with_body(summary, None, comment_type, fields)
+}
+
+fn render_block_with_body(
+    summary: String,
+    visible_body: Option<String>,
+    comment_type: &str,
+    fields: &[(&str, String)],
+) -> String {
     let mut rendered = String::new();
     rendered.push_str(&summary);
     rendered.push_str("\n\n");
+    if let Some(visible_body) = visible_body {
+        rendered.push_str(&visible_body);
+        rendered.push_str("\n\n");
+    }
     rendered.push_str(&format!("<!-- polyresearch:{comment_type}\n"));
     for (key, value) in fields {
         rendered.push_str(&format!("{key}: {value}\n"));
@@ -546,6 +683,59 @@ summary: RMSNorm instead of LayerNorm
     }
 
     #[test]
+    fn parses_attempt_comments_with_annotations() {
+        let body = r#"Polyresearch attempt: thesis #12, branch `thesis/12-rmsnorm-attempt-1`, metric `0.9934`, observation `improved`.
+
+Annotations:
+- [failure_analysis] task `task-7`: Tool selection drifted after step 2
+
+<!-- polyresearch:attempt
+thesis: 12
+branch: thesis/12-rmsnorm-attempt-1
+metric: 0.9934
+baseline_metric: 0.9979
+observation: improved
+summary: RMSNorm instead of LayerNorm
+annotations: [{"category":"failure_analysis","task_id":"task-7","text":"Tool selection drifted after step 2"}]
+-->"#;
+
+        let parsed = ProtocolComment::parse(body).unwrap().unwrap();
+        assert_eq!(
+            parsed,
+            ProtocolComment::Attempt {
+                thesis: 12,
+                branch: "thesis/12-rmsnorm-attempt-1".to_string(),
+                metric: 0.9934,
+                baseline_metric: 0.9979,
+                observation: Observation::Improved,
+                summary: "RMSNorm instead of LayerNorm".to_string(),
+                annotations: Some(vec![AttemptAnnotation {
+                    category: "failure_analysis".to_string(),
+                    task_id: Some("task-7".to_string()),
+                    text: "Tool selection drifted after step 2".to_string(),
+                }]),
+            }
+        );
+    }
+
+    #[test]
+    fn renders_and_parses_annotation_comments() {
+        let comment = ProtocolComment::Annotation {
+            thesis: 12,
+            node: "alice/node-7f83".to_string(),
+            text: "Tried the retrieval-heavy direction twice. It regressed on tool-use tasks."
+                .to_string(),
+        };
+
+        let rendered = comment.render();
+        assert!(
+            rendered.contains("Polyresearch annotation: thesis #12 by node `alice/node-7f83`.")
+        );
+        assert!(rendered.contains("Tried the retrieval-heavy direction twice."));
+        assert_eq!(ProtocolComment::parse(&rendered).unwrap().unwrap(), comment);
+    }
+
+    #[test]
     fn renders_claim_comments_with_summary() {
         let comment = ProtocolComment::Claim {
             thesis: 42,
@@ -562,7 +752,9 @@ summary: RMSNorm instead of LayerNorm
         let approve = ProtocolComment::parse("/approve focus on normalization")
             .unwrap()
             .unwrap();
-        let reject = ProtocolComment::parse("/reject this is too broad").unwrap().unwrap();
+        let reject = ProtocolComment::parse("/reject this is too broad")
+            .unwrap()
+            .unwrap();
         let not_a_match = ProtocolComment::parse("/approved").unwrap();
 
         assert_eq!(

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -604,6 +604,7 @@ pub fn validate_issue(
                 baseline_metric,
                 observation,
                 summary,
+                ..
             }) => {
                 if *thesis != issue.number {
                     findings.push(invalid_issue_like(

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -318,7 +318,6 @@ async fn env_override_uses_session_node_id() {
     assert_eq!(output.node_id, "lead/env-node");
     assert_eq!(output.resource_policy, "Keep CPUs saturated.");
     assert!(!output.is_default_policy);
-
 }
 
 #[tokio::test]
@@ -513,6 +512,7 @@ async fn attempt_rejects_node_without_canonical_claim() {
             baseline: 0.50,
             observation: Observation::Improved,
             summary: "test".to_string(),
+            annotations: None,
         }),
     );
     commands::write_node_id(&repo.path, "node-b").unwrap();
@@ -525,6 +525,7 @@ async fn attempt_rejects_node_without_canonical_claim() {
             baseline: 0.50,
             observation: Observation::Improved,
             summary: "test".to_string(),
+            annotations: None,
         },
     )
     .await

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -33,6 +33,10 @@ description: >-
 
 `POLYRESEARCH_NODE_ID` takes precedence over `.polyresearch-node.toml` for the current session. This is required when multiple agents share one checkout or when one GitHub login runs several workers in parallel.
 
+## Bootstrap new projects
+
+If a repo has `POLYRESEARCH.md` but `PROGRAM.md` or `PREPARE.md` are missing, or still contain placeholders such as `replace-me`, draft both files before you try to claim or generate work. Use the stock `PROGRAM.md` and `PREPARE.md` files as templates; they already define the sections. Explore the repo, fill in both drafts, and hand them to the maintainer for review before launching agents.
+
 ## Core principle
 
 GitHub visibility first. All work must be visible on GitHub. Local-only work is
@@ -67,12 +71,16 @@ LOOP FOREVER:
         - IMMEDIATELY post:
           polyresearch attempt <issue> --metric <val> --baseline <val> \
             --observation <obs> --summary "<summary>"
+          Add `--annotations '<json>'` if you have structured findings future
+          contributors should see.
         - polyresearch duties
      d. If observation was improved:
         polyresearch submit <issue>
         Do this NOW. Do not keep tinkering.
      e. If no improvement after exhausting ideas:
         polyresearch release <issue> --reason <reason>
+        If you learned something future contributors should know, post:
+        polyresearch annotate <issue> --text "<what you learned>"
 
   4. Check for review work (PRs with policy-pass, no decision,
      not authored by you):
@@ -115,6 +123,8 @@ Each iteration, before any experiments:
      - If `auto_approve` is `false`, generated theses are not auto-approved.
        They stay queued for the maintainer to `/approve` or `/reject`.
      - Read results.tsv and all thesis history before generating.
+     - Read annotations on closed theses before generating. Treat them as
+       negative knowledge.
      - Read maintainer `/approve` and `/reject` comments and use them as
        directional input for future thesis generation.
      - Deduplicate against existing open and closed theses.


### PR DESCRIPTION
## Summary
- add `polyresearch annotate` plus optional structured `--annotations` on `polyresearch attempt` so experiment learnings stay visible on GitHub
- parse and render the new annotation comment formats in the CLI and validation layer
- update the protocol and polyresearch skill docs with bootstrap guidance and the new annotation workflow

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the protocol comment parser/renderer and CLI surface area, which could affect state derivation if the new formats are malformed or mis-parsed. Changes are additive and mostly isolated to comment handling and docs.
> 
> **Overview**
> Introduces a new informational `polyresearch annotate` command that posts `polyresearch:annotation` comments on thesis issues, letting contributors preserve free-text learnings without affecting thesis state.
> 
> Extends `polyresearch attempt` to accept optional JSON `--annotations`, validates/serializes them into the attempt metadata block, and renders a human-visible `Annotations:` section; parsing is updated to round-trip both attempt annotations and the new annotation comment type (with accompanying tests).
> 
> Updates `POLYRESEARCH.md` and the polyresearch skill guide to document the annotation workflow, structured annotation schema, and to remind leads to consult closed-thesis annotations during thesis generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007fe197364cf7f0ea5cf577c2407c3fd9589899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->