### PR TITLE
Align protocol and skill guidance with the CLI

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -136,7 +136,7 @@ LOOP FOREVER:
       - Run the experiment per PREPARE.md. Redirect output: `<run-command> > run.log 2>&1`.
       - Parse the metric per PREPARE.md.
       - Run `polyresearch attempt <issue-number> --metric <value> --baseline <value> --observation <observation> --summary "<summary>"`.
-   f. **If you find an improvement:** run `polyresearch submit <issue-number>`. The CLI pushes the best attempt branch and opens the candidate PR to `main`.
+   f. **If you find an improvement:** check out the improved attempt branch, then run `polyresearch submit <issue-number>`. The CLI pushes the current branch and opens the candidate PR to `main`.
    g. **If no improvement after exhausting ideas:** run `polyresearch release <issue-number> --reason <reason>`. The thesis returns to the queue for another contributor.
    h. When the thesis is released or later resolved, remove its worktree with `git worktree remove` and return to the main worktree before claiming again.
 4. **Check for review work.** Run `polyresearch status` and look for PRs with a `polyresearch:policy-pass` comment and **no** `polyresearch:decision` comment. These need peer review. Skip PRs you authored.
@@ -148,7 +148,7 @@ LOOP FOREVER:
    e. Run the same evaluation. Record the baseline metric.
    f. If `.polyresearch/` exists, compute its content hash: `find .polyresearch/ -type f | sort | xargs sha256sum | sha256sum`.
    g. Run `polyresearch review <pr-number> --metric <candidate> --baseline <baseline> --observation <observation>`. Your `baseline_metric` is your own measurement. Do not copy it from results.tsv or the candidate's self-report.
-6. Repeat from step 1.
+6. Repeat from step 0.
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
 
@@ -182,6 +182,8 @@ You are the sole writer. This step runs first on every lead-loop iteration. Do n
 1. Run `polyresearch sync`.
 2. The CLI reconciles canonical attempt history against `results.tsv`, appends any missing rows, and commits the updated `results.tsv` on `main`.
 3. Canonical history may ignore invalid raw GitHub events. Resolve any audit findings through CLI admin or repair commands before continuing.
+
+Resolve any audit findings before continuing. A dirty audit blocks `policy-check`, `decide`, and `generate`.
 
 Only after results.tsv accounts for every known attempt may you proceed to the rest of the lead loop.
 
@@ -319,6 +321,7 @@ repo-root/                                 (main worktree on `main`)
 - The candidate PR merges the best attempt's sub-branch into `main`.
 - Discarded attempts stay as unmerged branches. They are data, not waste.
 - Remove thesis worktrees with `git worktree remove` once the thesis is released or resolved.
+- Pass `--no-worktree` to `polyresearch claim` to skip worktree creation and create a branch in the current checkout instead. Useful in sandboxed environments that restrict worktree creation.
 
 ---
 
@@ -406,7 +409,7 @@ thesis: 12
 branch: thesis/12-rmsnorm-attempt-1
 metric: 1.0050
 baseline_metric: 0.9934
-observation: no_improvement | crashed | infra_failure
+observation: improved | no_improvement | crashed | infra_failure
 summary: Switched to GeLU activation, regression on val_bpb
 annotations: [{"category":"failure_analysis","task_id":"task-7","text":"Tool selection drifted after step 2"}]   # optional
 -->

--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -181,9 +181,7 @@ You are the sole writer. This step runs first on every lead-loop iteration. Do n
 
 1. Run `polyresearch sync`.
 2. The CLI reconciles canonical attempt history against `results.tsv`, appends any missing rows, and commits the updated `results.tsv` on `main`.
-3. Canonical history may ignore invalid raw GitHub events. Resolve any audit findings through CLI admin or repair commands before continuing.
-
-Resolve any audit findings before continuing. A dirty audit blocks `policy-check`, `decide`, and `generate`.
+3. Canonical history may ignore invalid raw GitHub events. Resolve any audit findings through CLI admin or repair commands before continuing. A dirty audit blocks `policy-check`, `decide`, and `generate`.
 
 Only after results.tsv accounts for every known attempt may you proceed to the rest of the lead loop.
 

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -47,6 +47,8 @@ The `polyresearch duties` command enforces this. The CLI gates `claim` and
 
 ## The contributor loop
 
+See `POLYRESEARCH.md` "The contributor loop" for full sub-step details.
+
 ```
 LOOP FOREVER:
 
@@ -63,8 +65,9 @@ LOOP FOREVER:
 
   3. If a claimable thesis exists:
      a. polyresearch claim <issue>
-     b. Read PROGRAM.md for direction and constraints.
-     c. For each experiment:
+     b. cd into the worktree path printed by claim.
+     c. Read PROGRAM.md for direction and constraints.
+     d. For each experiment:
         - Make changes within the editable surface (PROGRAM.md CAN list).
         - Run evaluator per PREPARE.md: <run-command> > run.log 2>&1
         - Parse the metric per PREPARE.md.
@@ -74,13 +77,16 @@ LOOP FOREVER:
           Add `--annotations '<json>'` if you have structured findings future
           contributors should see.
         - polyresearch duties
-     d. If observation was improved:
+     e. If observation was improved:
         polyresearch submit <issue>
         Do this NOW. Do not keep tinkering.
-     e. If no improvement after exhausting ideas:
+     f. If no improvement after exhausting ideas:
         polyresearch release <issue> --reason <reason>
         If you learned something future contributors should know, post:
         polyresearch annotate <issue> --text "<what you learned>"
+     g. When the thesis is released or later resolved:
+        git worktree remove <worktree-path>
+        Return to the repo root before claiming again.
 
   4. Check for review work (PRs with policy-pass, no decision,
      not authored by you):
@@ -94,10 +100,12 @@ LOOP FOREVER:
 
 ## The lead loop
 
-The lead runs contributor duties PLUS these, in strict priority order.
+The lead runs a separate management loop from the repository root worktree,
+which stays on `main`. The lead never claims theses or runs experiments.
+See `POLYRESEARCH.md` "The lead loop" for full sub-procedure details.
 
 ```
-Each iteration, before any experiments:
+LOOP FOREVER:
 
   0. polyresearch duties
      Resolve ALL blocking items. Lead blocking items include:
@@ -108,6 +116,7 @@ Each iteration, before any experiments:
   1. polyresearch pace          # compare actual throughput vs effective policy
   2. polyresearch sync          # on main branch, always first
   3. polyresearch audit         # check for inconsistencies
+     A dirty audit blocks `policy-check`, `decide`, and `generate`.
 
   4. Process open PRs:
      - For each PR without policy-check:
@@ -120,6 +129,8 @@ Each iteration, before any experiments:
   5. Check queue depth:
      - If below min_queue_depth:
        polyresearch generate --title "<title>" --body "<body>"
+     - If `max_queue_depth` is set and queue depth is already at or above it:
+       do not generate.
      - If `auto_approve` is `false`, generated theses are not auto-approved.
        They stay queued for the maintainer to `/approve` or `/reject`.
      - Read results.tsv and all thesis history before generating.
@@ -129,39 +140,25 @@ Each iteration, before any experiments:
        directional input for future thesis generation.
      - Deduplicate against existing open and closed theses.
 
-  6. Now proceed with contributor loop (experiments, etc.)
-
-  Between experiment batches, re-run steps 0-5.
+  6. Wait briefly, then repeat from step 0.
 ```
 
 ## Resource pacing
 
-The protocol has a default resource policy: maximize throughput. Never leave
-claimable theses idle while experiments could be running. Run evaluations in
-parallel when the evaluator supports it. Interleave duties with long-running
-evaluations.
-
-If `.polyresearch-node.toml` sets a `resource_policy`, that node-specific
-policy overrides the default. Treat it as a real operating constraint.
-
-Use `polyresearch pace` as the feedback loop:
-
-1. Read the effective resource policy shown by `pace`.
-2. Compare it against the throughput metrics for your node.
-3. If the policy allows more throughput than you are getting, increase
-   parallelism or claim rate.
-4. If the policy imposes a ceiling (hardware, RAM, API rate limits), stay
-   below it.
-
-Do not leave resource usage on autopilot. Re-run `pace` regularly and correct
-drift.
+Run `polyresearch pace` regularly. It prints your effective resource policy
+and recent throughput. If `.polyresearch-node.toml` sets a `resource_policy`,
+treat it as a real constraint. See `POLYRESEARCH.md` "Node configuration" for
+the default policy and details.
 
 ## Critical rules
+
+These rules are extracted from `POLYRESEARCH.md`. The protocol is authoritative
+if any wording differs.
 
 - Post `polyresearch attempt` after EVERY experiment. Never batch.
 - Run `polyresearch submit` immediately when you observe `improved`.
   Do not "keep trying."
-- Lead: process the PR backlog before starting new experiments. Period.
+- Lead: process the PR backlog before any other work. Period.
 - Lead: re-run `polyresearch sync` after any decision that closes a thesis.
 - Never modify files in `.polyresearch/` or files outside the editable surface
   in `PROGRAM.md`.
@@ -173,14 +170,9 @@ drift.
 
 ## Evaluation variance
 
-If metrics are noisy (variance > 10% of `metric_tolerance`), run the evaluator
-multiple times and report the mean.
-
-Note the number of runs and range in the `--summary` field, e.g.:
-`--summary "3 runs, range 0.932-0.948, mean 0.940, <description>"`
-
-A candidate that consistently scores higher across 3+ runs can be considered
-`improved` even if no single run exceeds tolerance.
+If metrics are noisy, run the evaluator multiple times and report the mean.
+Note runs and range in `--summary`. See `POLYRESEARCH.md` "Evaluation variance"
+for thresholds and acceptance rules.
 
 ## Deeper reading
 


### PR DESCRIPTION
## Summary
- fix protocol wording so the contributor loop, attempt observation enum, and `submit` behavior match the CLI
- rewrite the polyresearch skill so the lead loop is management-only and the contributor loop includes worktree and queue-depth guidance
- replace duplicated skill sections with short references back to `POLYRESEARCH.md` to reduce future drift

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the polyresearch protocol and skill guidance; low risk aside from potential workflow confusion if wording is still inaccurate.
> 
> **Overview**
> Updates `POLYRESEARCH.md` and the `polyresearch` skill docs to better match current CLI behavior and reduce instruction drift.
> 
> Clarifies contributor flow around worktrees and `submit` (submit pushes the *current/improved attempt branch*), adjusts loop step numbering, expands attempt `observation` to include `improved`, and documents `--no-worktree` for constrained environments.
> 
> Tightens lead-loop guidance: emphasizes the lead is management-only, notes dirty audits block `policy-check`/`decide`/`generate`, and adds queue-depth guardrails (including respecting `max_queue_depth`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c7b48c6aefe77cb8a31890d3bf979ca9b4c332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->