### PR TITLE
Replace markdown table config with plain key: value lines

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -15,22 +15,31 @@ Drop this file into your repository unchanged. Put project-specific coordination
 
 ## Configuration
 
-This table defines the protocol parameters. Put the concrete values for your project in a `## Configuration` section in `PROGRAM.md`. Agents read those values from `PROGRAM.md`.
+Protocol parameters are set as `key: value` lines in `PROGRAM.md`. The CLI scans every line for `key: value` pairs where the key is a single `snake_case` word. Lines that don't match (headings, prose, blank lines) are ignored.
 
+Example (in `PROGRAM.md`):
 
-| Parameter                | Description                                                                                                                                                                 |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `required_confirmations` | Number of independent review records needed before the lead decides a PR. `0` means the lead decides without peer review. Default: `0`.                                     |
-| `metric_tolerance`       | Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance.                     |
-| `metric_direction`       | `lower_is_better` or `higher_is_better`.                                                                                                                                    |
-| `lead_github_login`      | GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.                                          |
-| `maintainer_github_login` | GitHub login for the human maintainer who can `/approve` or `/reject` thesis issues and candidate PRs when human review is enabled.                                       |
-| `auto_approve`           | If `true`, the lead auto-approves generated theses and decides PRs without waiting for a maintainer slash command. If `false`, the maintainer must `/approve` first. Default: `true`. |
-| `assignment_timeout`     | Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.                                                                               |
-| `review_timeout`         | Time before an incomplete review claim expires. Default: `12h`.                                                                                                             |
-| `min_queue_depth`        | Minimum number of unclaimed approved theses the lead should keep available. If the queue drops below this, the lead generates enough new theses to refill it. Default: `5`. |
-| `max_queue_depth`        | Maximum number of unclaimed approved theses the lead should allow in the queue at once. When omitted, there is no upper bound.                                             |
+```
+lead_github_login: alice
+maintainer_github_login: alice
+auto_approve: true
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+min_queue_depth: 5
+```
 
+**Parameter reference:**
+
+- `required_confirmations` — Number of independent review records needed before the lead decides a PR. `0` means the lead decides without peer review. Default: `0`.
+- `metric_tolerance` — Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance.
+- `metric_direction` — `lower_is_better` or `higher_is_better`.
+- `lead_github_login` — GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.
+- `maintainer_github_login` — GitHub login for the human maintainer who can `/approve` or `/reject` thesis issues and candidate PRs when human review is enabled.
+- `auto_approve` — If `true`, the lead auto-approves generated theses and decides PRs without waiting for a maintainer slash command. If `false`, the maintainer must `/approve` first. Default: `true`.
+- `assignment_timeout` — Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.
+- `review_timeout` — Time before an incomplete review claim expires. Default: `12h`.
+- `min_queue_depth` — Minimum number of unclaimed approved theses the lead should keep available. If the queue drops below this, the lead generates enough new theses to refill it. Default: `5`.
+- `max_queue_depth` — Maximum number of unclaimed approved theses the lead should allow in the queue at once. When omitted, there is no upper bound.
 
 The parameter definitions live here. Concrete project values live in `PROGRAM.md`.
 

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -4,22 +4,16 @@ This is the research playbook. It tells agents what to optimize, what they can t
 
 The maintainer writes and edits this file. When the research direction shifts, update this file. Contributors pick up the change on their next session start.
 
-## Configuration
-
-Project-specific coordination values referenced by `POLYRESEARCH.md`. Replace the example values below with values appropriate for your project.
-
-| Parameter                | Value              |
-| ------------------------ | ------------------ |
-| `required_confirmations` | `0`                |
-| `metric_tolerance`       | `0.01`             |
-| `metric_direction`       | `higher_is_better` |
-| `lead_github_login`      | `replace-me`       |
-| `maintainer_github_login` | `replace-me`      |
-| `auto_approve`           | `true`             |
-| `assignment_timeout`     | `24h`              |
-| `review_timeout`         | `12h`              |
-| `min_queue_depth`        | `5`                |
-| `max_queue_depth`        | `10`               |
+required_confirmations: 0
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+lead_github_login: replace-me
+maintainer_github_login: replace-me
+auto_approve: true
+assignment_timeout: 24h
+review_timeout: 12h
+min_queue_depth: 5
+max_queue_depth: 10
 
 ## Goal
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch-cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 repository = "https://github.com/superagent-ai/polyresearch"
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -147,33 +147,22 @@ impl ProtocolConfig {
 
         let contents = fs::read_to_string(&program_path)
             .wrap_err_with(|| format!("failed to read {}", program_path.display()))?;
-        let mut in_configuration = false;
 
         for line in contents.lines() {
             let trimmed = line.trim();
-            if trimmed.starts_with("## ") {
-                in_configuration = trimmed == "## Configuration";
+            if trimmed.starts_with('#') || trimmed.is_empty() {
                 continue;
             }
 
-            if !in_configuration || !trimmed.starts_with('|') {
+            let Some((key, value)) = trimmed.split_once(':') else {
                 continue;
-            }
-
-            let cells: Vec<String> = trimmed
-                .split('|')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToString::to_string)
-                .collect();
-
-            if cells.len() < 2 {
-                continue;
-            }
-
-            let key = cells[0].trim_matches('`');
-            let value = cells[1].trim_matches('`');
-            if value == "Value" || key == "Parameter" || value.chars().all(|c| c == '-') {
+            };
+            let key = key.trim();
+            let value = value.trim();
+            if key.is_empty()
+                || value.is_empty()
+                || !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
                 continue;
             }
 
@@ -502,6 +491,59 @@ resource_policy = "Run 4 evals in parallel."
         let (policy, is_default) = config.effective_resource_policy();
         assert!(is_default);
         assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
+    }
+
+    #[test]
+    fn loads_protocol_config_from_key_value() {
+        let repo_root = unique_temp_dir("config-kv");
+        fs::write(
+            repo_root.join("PROGRAM.md"),
+            r#"# Research Program
+
+lead_github_login: alice
+maintainer_github_login: bob
+min_queue_depth: 3
+auto_approve: false
+metric_tolerance: 10
+
+## Goal
+
+Do something.
+"#,
+        )
+        .unwrap();
+
+        let config = ProtocolConfig::load(&repo_root).unwrap();
+        assert_eq!(config.lead_github_login.as_deref(), Some("alice"));
+        assert_eq!(config.maintainer_github_login.as_deref(), Some("bob"));
+        assert_eq!(config.min_queue_depth, 3);
+        assert!(!config.auto_approve);
+        assert_eq!(config.metric_tolerance, Some(10.0));
+
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn ignores_prose_lines_with_colons() {
+        let repo_root = unique_temp_dir("config-prose");
+        fs::write(
+            repo_root.join("PROGRAM.md"),
+            r#"# Research Program
+
+lead_github_login: alice
+**Baseline**: ~399 ms (mean of 5 runs)
+
+## Goal
+
+Do something.
+"#,
+        )
+        .unwrap();
+
+        let config = ProtocolConfig::load(&repo_root).unwrap();
+        assert_eq!(config.lead_github_login.as_deref(), Some("alice"));
+
+        fs::remove_dir_all(repo_root).unwrap();
     }
 
     fn unique_temp_dir(name: &str) -> PathBuf {

--- a/examples/corewar/PROGRAM.md
+++ b/examples/corewar/PROGRAM.md
@@ -20,21 +20,14 @@ A pure draw machine scores about `0.3333`. A specialist that crushes one
 opponent type but loses badly to the rest will plateau. The goal is to build a
 general-purpose warrior that performs well across the whole gauntlet.
 
-## Configuration
-
-These are the project-specific coordination values referenced by
-`POLYRESEARCH.md`.
-
-| Parameter                | Value              |
-| ------------------------ | ------------------ |
-| `required_confirmations` | `0`                |
-| `metric_tolerance`       | `0.00`             |
-| `metric_direction`       | `higher_is_better` |
-| `lead_github_login`      | `replace-me`       |
-| `assignment_timeout`     | `24h`              |
-| `review_timeout`         | `12h`              |
-| `min_queue_depth`        | `5`                |
-| `max_queue_depth`        | `10`               |
+required_confirmations: 0
+metric_tolerance: 0.00
+metric_direction: higher_is_better
+lead_github_login: replace-me
+assignment_timeout: 24h
+review_timeout: 12h
+min_queue_depth: 5
+max_queue_depth: 10
 
 ## What you CAN modify
 

--- a/examples/jailbreakbench-defense/PROGRAM.md
+++ b/examples/jailbreakbench-defense/PROGRAM.md
@@ -14,21 +14,14 @@ The harmful side is not plain unsafe requests. The evaluator uses real attack st
 
 A system prompt that refuses everything still scores 0.60. A system prompt that answers everything still scores 0.40. The interesting part is resisting adversarial attacks while preserving legitimate helpfulness.
 
-## Configuration
-
-These are the project-specific coordination values referenced by
-`POLYRESEARCH.md`.
-
-| Parameter                | Value              |
-| ------------------------ | ------------------ |
-| `required_confirmations` | `0`                |
-| `metric_tolerance`       | `0.03`             |
-| `metric_direction`       | `higher_is_better` |
-| `lead_github_login`      | `replace-me`       |
-| `assignment_timeout`     | `24h`              |
-| `review_timeout`         | `12h`              |
-| `min_queue_depth`        | `5`                |
-| `max_queue_depth`        | `10`               |
+required_confirmations: 0
+metric_tolerance: 0.03
+metric_direction: higher_is_better
+lead_github_login: replace-me
+assignment_timeout: 24h
+review_timeout: 12h
+min_queue_depth: 5
+max_queue_depth: 10
 
 ## What you CAN modify
 

--- a/examples/pokeragent/PROGRAM.md
+++ b/examples/pokeragent/PROGRAM.md
@@ -25,21 +25,14 @@ measured in big blinds and clamped to `[-100, 100]`.
 - above `0.50` means the candidate beat the baseline
 - below `0.50` means the candidate lost to the baseline
 
-## Configuration
-
-These are the project-specific coordination values referenced by
-`POLYRESEARCH.md`.
-
-| Parameter                | Value              |
-| ------------------------ | ------------------ |
-| `required_confirmations` | `0`                |
-| `metric_tolerance`       | `0.01`             |
-| `metric_direction`       | `higher_is_better` |
-| `lead_github_login`      | `replace-me`       |
-| `assignment_timeout`     | `24h`              |
-| `review_timeout`         | `12h`              |
-| `min_queue_depth`        | `5`                |
-| `max_queue_depth`        | `10`               |
+required_confirmations: 0
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+lead_github_login: replace-me
+assignment_timeout: 24h
+review_timeout: 12h
+min_queue_depth: 5
+max_queue_depth: 10
 
 ## What you CAN modify
 


### PR DESCRIPTION
## Summary

- The config parser in `ProtocolConfig::load()` previously required a `## Configuration` section with a markdown table (`| key | value |`). Agents bootstrapping new projects naturally write `key: value` lines, which silently failed to parse.
- Replaced the table parser with a simple `key: value` line scanner. One format, no ambiguity. Lines are matched only when the key is a single `snake_case` word, so prose with colons is ignored.
- Converted the stock `PROGRAM.md` template, all three example `PROGRAM.md` files, and the `POLYRESEARCH.md` parameter reference to use the `key: value` format.

## Test plan

- [x] All 58 existing tests pass (32 unit + 26 e2e)
- [x] New test: `loads_protocol_config_from_key_value`
- [x] New test: `ignores_prose_lines_with_colons`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ProtocolConfig::load()` parsing semantics from a markdown-table-in-`## Configuration` requirement to a global `key: value` scan, which can break existing repos still using the table format and alter which lines are interpreted as config.
> 
> **Overview**
> Updates protocol configuration to use simple `key: value` lines in `PROGRAM.md` instead of a markdown table. The CLI now scans non-heading, non-blank lines for `snake_case_key: value` pairs, ignoring prose/markdown (including colon-containing text), and adds tests covering the new parser behavior.
> 
> Docs and templates (`POLYRESEARCH.md`, root `PROGRAM.md`, and example `PROGRAM.md` files) are converted to the new format, and the CLI crate version is bumped to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a18cd796ccfd9f83e7b6e4276abf6557706f052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->