### PR TITLE
Fix PROGRAM.md policy parsing and policy-check reruns

### DIFF
--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -26,6 +26,9 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     if pr_state.decision.is_some() {
         return Err(eyre!("PR #{} already has a decision", args.pr));
     }
+    if pr_state.policy_pass {
+        return Err(eyre!("PR #{} already has a policy-pass", args.pr));
+    }
 
     let files = ctx.github.list_pull_request_files(args.pr)?;
     let violations = files

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -258,10 +259,7 @@ impl ProgramSpec {
     pub fn editable_globset(&self) -> Result<GlobSet> {
         let mut builder = GlobSetBuilder::new();
         for pattern in &self.can_modify {
-            builder.add(
-                Glob::new(pattern)
-                    .wrap_err_with(|| format!("invalid editable glob pattern `{pattern}`"))?,
-            );
+            builder.add(compile_program_glob(pattern, "editable")?);
         }
         Ok(builder.build()?)
     }
@@ -273,7 +271,7 @@ impl ProgramSpec {
 
     pub fn is_protected(&self, file_path: &str) -> bool {
         self.cannot_modify.iter().any(|pattern| {
-            Glob::new(pattern)
+            compile_program_glob(pattern, "protected")
                 .map(|glob| glob.compile_matcher().is_match(file_path))
                 .unwrap_or(false)
         })
@@ -295,21 +293,50 @@ fn parse_markdown_list(contents: &str, heading: &str) -> Vec<String> {
             continue;
         }
 
-        if let Some(item) = trimmed.strip_prefix("- ") {
-            let value = item
-                .split(" - ")
-                .next()
-                .unwrap_or(item)
-                .trim()
-                .trim_matches('`')
-                .to_string();
-            if !value.is_empty() {
-                items.push(value);
-            }
+        if let Some(item) = trimmed.strip_prefix("- ").and_then(parse_markdown_item) {
+            items.push(item);
         }
     }
 
     items
+}
+
+fn parse_markdown_item(item: &str) -> Option<String> {
+    extract_backtick_content(item).or_else(|| {
+        let value = strip_markdown_item_description(item)
+            .trim()
+            .trim_matches('`')
+            .to_string();
+        (!value.is_empty()).then_some(value)
+    })
+}
+
+fn extract_backtick_content(item: &str) -> Option<String> {
+    let start = item.find('`')?;
+    let end = item[start + 1..].find('`')? + start + 1;
+    let content = item[start + 1..end].trim().to_string();
+    (!content.is_empty()).then_some(content)
+}
+
+fn strip_markdown_item_description(item: &str) -> &str {
+    [" — ", " – ", " - "]
+        .iter()
+        .find_map(|separator| item.split_once(separator).map(|(value, _)| value))
+        .unwrap_or(item)
+}
+
+fn compile_program_glob(pattern: &str, label: &str) -> Result<Glob> {
+    let normalized = normalize_program_pattern(pattern);
+    Glob::new(normalized.as_ref())
+        .wrap_err_with(|| format!("invalid {label} glob pattern `{pattern}`"))
+}
+
+fn normalize_program_pattern(pattern: &str) -> Cow<'_, str> {
+    if pattern.ends_with('/') {
+        Cow::Owned(format!("{pattern}**"))
+    } else {
+        Cow::Borrowed(pattern)
+    }
 }
 
 fn parse_duration(value: &str) -> Result<Duration> {
@@ -391,17 +418,62 @@ mod tests {
     fn parses_markdown_lists() {
         let contents = r#"
 ## What you CAN modify
-- `system_prompt.md` - update the prompt
-- `tools/**/*.py`
+- `lib/` — the entire lib directory
+- tools/**/*.py - helper scripts
+- scripts/**/*.sh – shell helpers
 
 ## What you CANNOT modify
-- `PREPARE.md`
+- `PREPARE.md` — trust boundary
+- docs/** - generated docs
 "#;
 
         assert_eq!(
             parse_markdown_list(contents, "## What you CAN modify"),
-            vec!["system_prompt.md".to_string(), "tools/**/*.py".to_string()]
+            vec![
+                "lib/".to_string(),
+                "tools/**/*.py".to_string(),
+                "scripts/**/*.sh".to_string()
+            ]
         );
+        assert_eq!(
+            parse_markdown_list(contents, "## What you CANNOT modify"),
+            vec!["PREPARE.md".to_string(), "docs/**".to_string()]
+        );
+    }
+
+    #[test]
+    fn extracts_backtick_content_before_description() {
+        assert_eq!(
+            parse_markdown_item("`lib/` — the entire lib directory"),
+            Some("lib/".to_string())
+        );
+    }
+
+    #[test]
+    fn editable_directory_patterns_match_descendants() {
+        let program = ProgramSpec {
+            can_modify: vec!["lib/".to_string()],
+            cannot_modify: Vec::new(),
+        };
+
+        assert!(program.is_editable("lib/rules/indent.js").unwrap());
+        assert!(
+            program
+                .is_editable("lib/linter/source-code-traverser.js")
+                .unwrap()
+        );
+        assert!(!program.is_editable("tests/lib/rules/indent.js").unwrap());
+    }
+
+    #[test]
+    fn protected_directory_patterns_match_descendants() {
+        let program = ProgramSpec {
+            can_modify: vec!["lib/".to_string()],
+            cannot_modify: vec!["lib/generated/".to_string()],
+        };
+
+        assert!(program.is_protected("lib/generated/config.js"));
+        assert!(!program.is_protected("lib/rules/indent.js"));
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -302,11 +302,9 @@ fn parse_markdown_list(contents: &str, heading: &str) -> Vec<String> {
 }
 
 fn parse_markdown_item(item: &str) -> Option<String> {
-    extract_backtick_content(item).or_else(|| {
-        let value = strip_markdown_item_description(item)
-            .trim()
-            .trim_matches('`')
-            .to_string();
+    let pattern = strip_markdown_item_description(item).trim();
+    extract_backtick_content(pattern).or_else(|| {
+        let value = pattern.trim_matches('`').to_string();
         (!value.is_empty()).then_some(value)
     })
 }
@@ -446,6 +444,14 @@ mod tests {
         assert_eq!(
             parse_markdown_item("`lib/` — the entire lib directory"),
             Some("lib/".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_backticks_in_description_when_pattern_is_not_wrapped() {
+        assert_eq!(
+            parse_markdown_item("docs/** - generated from `source`"),
+            Some("docs/**".to_string())
         );
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -319,7 +319,9 @@ fn extract_backtick_content(item: &str) -> Option<String> {
 fn strip_markdown_item_description(item: &str) -> &str {
     [" — ", " – ", " - "]
         .iter()
-        .find_map(|separator| item.split_once(separator).map(|(value, _)| value))
+        .filter_map(|separator| item.find(separator).map(|index| (index, separator)))
+        .min_by_key(|(index, _)| *index)
+        .map(|(index, _)| &item[..index])
         .unwrap_or(item)
 }
 
@@ -452,6 +454,14 @@ mod tests {
         assert_eq!(
             parse_markdown_item("docs/** - generated from `source`"),
             Some("docs/**".to_string())
+        );
+    }
+
+    #[test]
+    fn splits_on_the_earliest_separator_position() {
+        assert_eq!(
+            parse_markdown_item("tools/**/*.py - utilities — note"),
+            Some("tools/**/*.py".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- make `PROGRAM.md` list parsing robust to backtick-wrapped entries and mixed dash separators so editable and protected patterns are read correctly
- normalize directory entries like `lib/` into recursive globs so policy checks match descendant files instead of treating them as literal paths
- reject `policy-check` reruns once a PR already has a valid policy-pass to avoid duplicate protocol comments

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect policy enforcement and PR automation (what files are allowed and when protocol comments are posted), so misparsing or glob normalization bugs could incorrectly allow or reject changes.
> 
> **Overview**
> **Policy-check reruns are now blocked after success.** `policy-check` returns an error if the PR already has a `policy_pass`, preventing duplicate policy-pass comments.
> 
> **`PROGRAM.md` editable/protected patterns are parsed and matched more robustly.** Markdown list items now tolerate backtick-wrapped patterns and multiple dash separators, and directory patterns like `lib/` are normalized to recursive globs so descendant files are correctly considered editable/protected; new unit tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c90376c71498238b736a7b382eb577783a9182b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->