### PR TITLE
Bump CLI version to 0.3.1 for release

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch-cli"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 repository = "https://github.com/superagent-ai/polyresearch"
 


### PR DESCRIPTION
## Summary
- bump the CLI crate version from `0.3.0` to `0.3.1`
- sync the root package entry in `cli/Cargo.lock` so release builds stop dirtying the lockfile
- validate the `v0.3.1` release flow locally before tagging

## Test plan
- [x] `cargo test --manifest-path cli/Cargo.toml`
- [x] `dist plan --tag v0.3.1`
- [x] `dist build --artifacts local --target aarch64-apple-darwin --tag v0.3.1`
- [x] `dist build --artifacts global --tag v0.3.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk versioning-only change that updates crate metadata and lockfile entry with no functional code modifications.
> 
> **Overview**
> Bumps the `polyresearch-cli` crate version from `0.3.0` to `0.3.1` in `cli/Cargo.toml`.
> 
> Updates the corresponding `polyresearch-cli` entry in `cli/Cargo.lock` to keep the lockfile in sync for release builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc29b08ec0b537c525c2690c2b656e63223a3a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->