### PR TITLE
Rewrite README and update skill bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Polyresearch keeps the same loop and adds three things:
 
 A polyresearch project is any GitHub repo with a few coordination files:
 
-- *`PROGRAM.md`* -- the research playbook. Same concept as autoresearch's [program.md](https://github.com/karpathy/autoresearch/blob/master/program.md). Describes the research goal, which files agents can edit, strategy, and constraints.
-- `*PREPARE.md*` -- the evaluation setup. What commands to run, how to parse the metric, what the ground truth is. The evaluation code is outside the editable surface, so agents cannot change how they are judged.
-- `*POLYRESEARCH.md*` -- the coordination protocol. Same for every project, like a LICENSE file. Not modified.
-- `*.polyresearch/*` -- the reproducible environment. Setup scripts, evaluators, frozen dependencies. Optional.
+- **`PROGRAM.md`** — the research playbook. Same concept as autoresearch's [program.md](https://github.com/karpathy/autoresearch/blob/master/program.md). Describes the research goal, which files agents can edit, strategy, and constraints.
+- **`PREPARE.md`** — the evaluation setup. What commands to run, how to parse the metric, what the ground truth is. The evaluation code is outside the editable surface, so agents cannot change how they are judged.
+- **`POLYRESEARCH.md`** — the coordination protocol. Same for every project, like a LICENSE file. Not modified.
+- **`.polyresearch/`** — the reproducible environment. Setup scripts, evaluators, frozen dependencies. Optional.
 
 Contributors pick up theses from the GitHub Issues queue, run experiments, and submit results. Other contributors independently verify results. The lead manages the queue and merges accepted work. Everything is coordinated through structured comments on GitHub -- no external services, no database. Requires `git` and `gh`.
 


### PR DESCRIPTION
## Summary
- Rewrote README: clear intro explaining autoresearch → polyresearch, two-step install (CLI + skill), usage sections for lead/contributor/remote, concise design section, simplified examples table, agent-facing CLI section.

## Test plan
- [ ] Review README renders correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change limited to README markdown formatting; no code or behavior changes.
> 
> **Overview**
> Improves `README.md` rendering by rewriting the “How it works” coordination-files section into a proper markdown list with consistent bolded filenames and descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d443b122ea1e5a9fdb1703c4690c007c77617740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->