### PR TITLE
Add GitHub API rate-limit awareness, retry/backoff, and concurrency throttling

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -27,7 +27,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 
 #[derive(Clone)]
@@ -115,7 +115,7 @@ pub fn write_node_config(
     node: &str,
     resource_policy: Option<&str>,
 ) -> Result<()> {
-    let existing_budget = NodeConfig::load_api_budget(repo_root).unwrap_or(DEFAULT_API_BUDGET);
+    let existing_budget = NodeConfig::load_api_budget(repo_root);
     NodeConfig::new(
         node.to_string(),
         resource_policy.map(ToString::to_string),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -27,7 +27,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
+use crate::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 
 #[derive(Clone)]
@@ -36,9 +36,24 @@ pub struct AppContext {
     pub repo_root: PathBuf,
     pub repo: RepoRef,
     pub github: Arc<dyn GitHubApi>,
+    pub api_budget: u64,
     pub config: ProtocolConfig,
     pub program: ProgramSpec,
 }
+
+#[derive(Debug)]
+pub struct ProcessExit {
+    pub code: i32,
+    pub message: String,
+}
+
+impl std::fmt::Display for ProcessExit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ProcessExit {}
 
 pub async fn run(ctx: AppContext) -> Result<()> {
     match &ctx.cli.command {
@@ -75,8 +90,20 @@ where
     Ok(())
 }
 
+pub fn exit_with(code: i32, message: impl Into<String>) -> Result<()> {
+    Err(ProcessExit {
+        code,
+        message: message.into(),
+    }
+    .into())
+}
+
 pub fn read_node_config(repo_root: &PathBuf) -> Result<NodeConfig> {
     NodeConfig::load(repo_root)
+}
+
+pub fn read_api_budget(repo_root: &PathBuf) -> Result<u64> {
+    NodeConfig::load_api_budget(repo_root)
 }
 
 pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
@@ -92,7 +119,12 @@ pub fn write_node_config(
     node: &str,
     resource_policy: Option<&str>,
 ) -> Result<()> {
-    NodeConfig::new(node.to_string(), resource_policy.map(ToString::to_string)).save(repo_root)
+    NodeConfig::new(
+        node.to_string(),
+        resource_policy.map(ToString::to_string),
+        DEFAULT_API_BUDGET,
+    )
+    .save(repo_root)
 }
 
 pub fn current_branch(repo_root: &PathBuf) -> Result<String> {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -102,10 +102,6 @@ pub fn read_node_config(repo_root: &PathBuf) -> Result<NodeConfig> {
     NodeConfig::load(repo_root)
 }
 
-pub fn read_api_budget(repo_root: &PathBuf) -> Result<u64> {
-    NodeConfig::load_api_budget(repo_root)
-}
-
 pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
     Ok(read_node_config(repo_root)?.node_id)
 }
@@ -119,10 +115,11 @@ pub fn write_node_config(
     node: &str,
     resource_policy: Option<&str>,
 ) -> Result<()> {
+    let existing_budget = NodeConfig::load_api_budget(repo_root).unwrap_or(DEFAULT_API_BUDGET);
     NodeConfig::new(
         node.to_string(),
         resource_policy.map(ToString::to_string),
-        DEFAULT_API_BUDGET,
+        existing_budget,
     )
     .save(repo_root)
 }

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -156,10 +156,7 @@ pub fn build_output(
         .map(|timestamp| now.signed_duration_since(timestamp).num_minutes().max(0));
     let issue_count = repo_state.theses.len();
     let derive_cost = 2 + issue_count as u64 + repo_state.pull_request_count as u64;
-    let commands_left = match derive_cost {
-        0 => 0,
-        _ => rate_limit.resources.core.remaining / derive_cost,
-    };
+    let commands_left = rate_limit.resources.core.remaining / derive_cost;
 
     PaceOutput {
         repo,

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -2,9 +2,12 @@ use chrono::{DateTime, Duration, Utc};
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
-use crate::commands::{AppContext, print_value, read_node_config};
+use crate::commands::{AppContext, exit_with, print_value, read_node_config};
 use crate::config::NodeConfig;
+use crate::github::RateLimitStatus;
 use crate::state::{RepositoryState, ThesisPhase};
+
+const RATE_LIMIT_EXIT_CODE: i32 = 75;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PaceOutput {
@@ -12,6 +15,8 @@ pub struct PaceOutput {
     pub node_id: String,
     pub resource_policy: String,
     pub is_default_policy: bool,
+    pub api_budget: u64,
+    pub rate_limit: PaceRateLimit,
     pub attempts_last_hour: usize,
     pub attempts_last_4_hours: usize,
     pub idle_minutes: Option<i64>,
@@ -19,10 +24,31 @@ pub struct PaceOutput {
     pub active_claims: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PaceRateLimit {
+    pub configured_budget: u64,
+    pub limit: u64,
+    pub remaining: u64,
+    pub used: u64,
+    pub resets_at: Option<DateTime<Utc>>,
+    pub issue_count: usize,
+    pub pull_request_count: usize,
+    pub derive_cost: u64,
+    pub commands_left: u64,
+    pub is_low: bool,
+}
+
 pub async fn run(ctx: &AppContext) -> Result<()> {
     let node_config = read_node_config(&ctx.repo_root)?;
+    let rate_limit = ctx.github.get_rate_limit_status()?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let output = build_output(ctx.repo.slug(), &node_config, &repo_state);
+    let output = build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &rate_limit,
+    );
 
     print_value(ctx, &output, |value| {
         let resource_label = if value.is_default_policy {
@@ -35,8 +61,26 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             .idle_minutes
             .map(|minutes| minutes.to_string())
             .unwrap_or_else(|| "n/a".to_string());
+        let reset = value
+            .rate_limit
+            .resets_at
+            .map(|timestamp| {
+                let minutes = (timestamp - Utc::now()).num_minutes().max(0);
+                format!("{} (in {minutes} min)", timestamp.to_rfc3339())
+            })
+            .unwrap_or_else(|| "unknown".to_string());
         rendered.push_str(&format!(
-            "\n\nThroughput ({}):\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}\n  Active claims:               {}",
+            "\n\nAPI budget:\n  Configured budget:           {}/hr\n  GitHub core limit:           {}/hr\n  Remaining quota:             {}\n  Used quota:                  {}\n  Resets at:                   {}\n  Cost per command:            {} calls ({} issues + {} PRs + 2 lists)\n  Commands left:               ~{}\n  Near limit:                  {}\n\nThroughput ({}):\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}\n  Active claims:               {}",
+            value.rate_limit.configured_budget,
+            value.rate_limit.limit,
+            value.rate_limit.remaining,
+            value.rate_limit.used,
+            reset,
+            value.rate_limit.derive_cost,
+            value.rate_limit.issue_count,
+            value.rate_limit.pull_request_count,
+            value.rate_limit.commands_left,
+            if value.rate_limit.is_low { "yes" } else { "no" },
             value.node_id,
             value.attempts_last_hour,
             value.attempts_last_4_hours,
@@ -45,13 +89,35 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             value.active_claims
         ));
         rendered
-    })
+    })?;
+
+    if output.rate_limit.remaining < output.rate_limit.derive_cost {
+        let retry_message = output
+            .rate_limit
+            .resets_at
+            .map(|timestamp| {
+                let minutes = (timestamp - Utc::now()).num_minutes().max(0);
+                format!(
+                    "RATE LIMITED: wait about {minutes} minutes for the GitHub core quota to reset at {} before continuing.",
+                    timestamp.to_rfc3339()
+                )
+            })
+            .unwrap_or_else(|| {
+                "RATE LIMITED: wait for the GitHub core quota to reset before continuing."
+                    .to_string()
+            });
+        return exit_with(RATE_LIMIT_EXIT_CODE, retry_message);
+    }
+
+    Ok(())
 }
 
 pub fn build_output(
     repo: String,
+    api_budget: u64,
     node_config: &NodeConfig,
     repo_state: &RepositoryState,
+    rate_limit: &RateLimitStatus,
 ) -> PaceOutput {
     let now = Utc::now();
     let one_hour_ago = now - Duration::hours(1);
@@ -88,12 +154,31 @@ pub fn build_output(
         .count();
     let idle_minutes = last_activity(repo_state, &node_id)
         .map(|timestamp| now.signed_duration_since(timestamp).num_minutes().max(0));
+    let issue_count = repo_state.theses.len();
+    let derive_cost = 2 + issue_count as u64 + repo_state.pull_request_count as u64;
+    let commands_left = match derive_cost {
+        0 => 0,
+        _ => rate_limit.resources.core.remaining / derive_cost,
+    };
 
     PaceOutput {
         repo,
         node_id,
         resource_policy: resource_policy.to_string(),
         is_default_policy,
+        api_budget,
+        rate_limit: PaceRateLimit {
+            configured_budget: api_budget,
+            limit: rate_limit.resources.core.limit,
+            remaining: rate_limit.resources.core.remaining,
+            used: rate_limit.resources.core.used,
+            resets_at: rate_limit.resources.core.reset_at(),
+            issue_count,
+            pull_request_count: repo_state.pull_request_count,
+            derive_cost,
+            commands_left,
+            is_low: rate_limit.resources.core.remaining < derive_cost.saturating_mul(2),
+        },
         attempts_last_hour,
         attempts_last_4_hours,
         idle_minutes,

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -40,8 +40,8 @@ pub struct PaceRateLimit {
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
     let node_config = read_node_config(&ctx.repo_root)?;
-    let rate_limit = ctx.github.get_rate_limit_status()?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let rate_limit = ctx.github.get_rate_limit_status()?;
     let output = build_output(
         ctx.repo.slug(),
         ctx.api_budget,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -79,19 +79,14 @@ impl NodeConfig {
         Ok(Self::new(node_id, resource_policy, api_budget))
     }
 
-    pub fn load_api_budget(repo_root: &Path) -> Result<u64> {
+    pub fn load_api_budget(repo_root: &Path) -> u64 {
         let path = node_config_path(repo_root);
-        if !path.exists() {
-            return Ok(DEFAULT_API_BUDGET);
-        }
-
-        let contents = fs::read_to_string(&path)
-            .wrap_err_with(|| format!("failed to read {}", path.display()))?;
-        let parsed: NodeBudgetConfig = toml::from_str(&contents)
-            .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
-        Ok(normalize_api_budget(
-            parsed.api_budget.unwrap_or(DEFAULT_API_BUDGET),
-        ))
+        let budget = fs::read_to_string(&path)
+            .ok()
+            .and_then(|contents| toml::from_str::<NodeConfig>(&contents).ok())
+            .map(|config| config.api_budget)
+            .unwrap_or(DEFAULT_API_BUDGET);
+        normalize_api_budget(budget)
     }
 
     pub fn save(&self, repo_root: &Path) -> Result<()> {
@@ -129,12 +124,6 @@ fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
     let contents =
         fs::read_to_string(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
     toml::from_str(&contents).wrap_err_with(|| format!("failed to parse {}", path.display()))
-}
-
-#[derive(Debug, Deserialize)]
-struct NodeBudgetConfig {
-    #[serde(default)]
-    api_budget: Option<u64>,
 }
 
 fn default_api_budget() -> u64 {
@@ -629,6 +618,44 @@ resource_policy = "Run 4 evals in parallel."
     fn defaults_api_budget_when_missing() {
         let config = NodeConfig::new("node-7f83", None, 0);
         assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
+    }
+
+    #[test]
+    fn load_api_budget_reads_custom_value() {
+        let repo_root = unique_temp_dir("budget-custom");
+        fs::write(
+            node_config_path(&repo_root),
+            "node_id = \"n\"\napi_budget = 1000\n",
+        )
+        .unwrap();
+
+        assert_eq!(NodeConfig::load_api_budget(&repo_root), 1_000);
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn load_api_budget_defaults_when_file_missing() {
+        let repo_root = unique_temp_dir("budget-missing");
+        assert_eq!(NodeConfig::load_api_budget(&repo_root), DEFAULT_API_BUDGET);
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn load_api_budget_defaults_on_corrupt_file() {
+        let repo_root = unique_temp_dir("budget-corrupt");
+        fs::write(node_config_path(&repo_root), "not valid toml {{{{").unwrap();
+
+        assert_eq!(NodeConfig::load_api_budget(&repo_root), DEFAULT_API_BUDGET);
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn load_api_budget_defaults_when_field_absent() {
+        let repo_root = unique_temp_dir("budget-absent");
+        fs::write(node_config_path(&repo_root), "node_id = \"n\"\n").unwrap();
+
+        assert_eq!(NodeConfig::load_api_budget(&repo_root), DEFAULT_API_BUDGET);
+        fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -9,6 +9,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
+pub const DEFAULT_API_BUDGET: u64 = 5_000;
 pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,13 +24,20 @@ pub struct NodeConfig {
     pub node_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_policy: Option<String>,
+    #[serde(default = "default_api_budget")]
+    pub api_budget: u64,
 }
 
 impl NodeConfig {
-    pub fn new(node_id: impl Into<String>, resource_policy: Option<String>) -> Self {
+    pub fn new(
+        node_id: impl Into<String>,
+        resource_policy: Option<String>,
+        api_budget: u64,
+    ) -> Self {
         Self {
             node_id: node_id.into(),
             resource_policy: normalize_resource_policy(resource_policy),
+            api_budget: normalize_api_budget(api_budget),
         }
     }
 
@@ -60,9 +68,29 @@ impl NodeConfig {
             }
         };
 
-        Ok(Self::new(
-            node_id,
-            file_config.and_then(|config| config.resource_policy),
+        let resource_policy = file_config
+            .as_ref()
+            .and_then(|config| config.resource_policy.clone());
+        let api_budget = file_config
+            .as_ref()
+            .map(|config| config.api_budget)
+            .unwrap_or(DEFAULT_API_BUDGET);
+
+        Ok(Self::new(node_id, resource_policy, api_budget))
+    }
+
+    pub fn load_api_budget(repo_root: &Path) -> Result<u64> {
+        let path = node_config_path(repo_root);
+        if !path.exists() {
+            return Ok(DEFAULT_API_BUDGET);
+        }
+
+        let contents = fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+        let parsed: NodeBudgetConfig = toml::from_str(&contents)
+            .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
+        Ok(normalize_api_budget(
+            parsed.api_budget.unwrap_or(DEFAULT_API_BUDGET),
         ))
     }
 
@@ -87,6 +115,10 @@ impl NodeConfig {
             None => (DEFAULT_RESOURCE_POLICY, true),
         }
     }
+
+    pub fn effective_api_budget(&self) -> u64 {
+        normalize_api_budget(self.api_budget)
+    }
 }
 
 pub fn node_config_path(repo_root: &Path) -> PathBuf {
@@ -97,6 +129,16 @@ fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
     let contents =
         fs::read_to_string(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
     toml::from_str(&contents).wrap_err_with(|| format!("failed to parse {}", path.display()))
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeBudgetConfig {
+    #[serde(default)]
+    api_budget: Option<u64>,
+}
+
+fn default_api_budget() -> u64 {
+    DEFAULT_API_BUDGET
 }
 
 fn node_id_override() -> Option<String> {
@@ -507,6 +549,7 @@ mod tests {
             &path,
             r#"node_id = "node-7f83"
 resource_policy = "Run 4 evals in parallel."
+api_budget = 15000
 "#,
         )
         .unwrap();
@@ -517,6 +560,7 @@ resource_policy = "Run 4 evals in parallel."
             config.resource_policy.as_deref(),
             Some("Run 4 evals in parallel.")
         );
+        assert_eq!(config.api_budget, 15_000);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -575,10 +619,16 @@ resource_policy = "Run 4 evals in parallel."
 
     #[test]
     fn defaults_resource_policy_when_missing() {
-        let config = NodeConfig::new("node-7f83", None);
+        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET);
         let (policy, is_default) = config.effective_resource_policy();
         assert!(is_default);
         assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
+    }
+
+    #[test]
+    fn defaults_api_budget_when_missing() {
+        let config = NodeConfig::new("node-7f83", None, 0);
+        assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
     }
 
     #[test]
@@ -650,4 +700,11 @@ fn normalize_resource_policy(resource_policy: Option<String>) -> Option<String> 
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+fn normalize_api_budget(api_budget: u64) -> u64 {
+    match api_budget {
+        0 => DEFAULT_API_BUDGET,
+        value => value,
+    }
 }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -761,7 +761,10 @@ fn run_text_command(mut command: Command) -> Result<String> {
 }
 
 fn run_command_with_retries(command: &mut Command) -> Result<String> {
-    for attempt in 0..=TRANSIENT_RETRY_DELAYS_SECS.len() {
+    let max_possible_retries = TRANSIENT_RETRY_DELAYS_SECS
+        .len()
+        .max(SECONDARY_RETRY_DELAYS_SECS.len());
+    for attempt in 0..=max_possible_retries {
         let output = clone_command(command)
             .output()
             .wrap_err("failed to run GitHub CLI command")?;

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -380,6 +380,7 @@ impl GitHubClient {
         endpoint: &str,
         fields: &[(&str, &str)],
     ) -> Result<serde_json::Value> {
+        let idempotent = method.eq_ignore_ascii_case("GET") || method.eq_ignore_ascii_case("HEAD");
         let mut command = Command::new("gh");
         command.arg("api");
         command.arg("--method").arg(method);
@@ -387,19 +388,19 @@ impl GitHubClient {
         for (key, value) in fields {
             command.arg("-f").arg(format!("{key}={value}"));
         }
-        run_json_command(command)
+        run_json_command(command, idempotent)
     }
 
     fn gh_json<const N: usize>(&self, args: [&str; N]) -> Result<serde_json::Value> {
         let mut command = Command::new("gh");
         command.args(args);
-        run_json_command(command)
+        run_json_command(command, true)
     }
 
     fn gh_output<const N: usize>(&self, args: [&str; N]) -> Result<String> {
         let mut command = Command::new("gh");
         command.args(args);
-        run_text_command(command)
+        run_text_command(command, false)
     }
 }
 
@@ -750,17 +751,17 @@ impl std::fmt::Display for GitHubCliError {
 
 impl std::error::Error for GitHubCliError {}
 
-fn run_json_command(mut command: Command) -> Result<serde_json::Value> {
-    let stdout = run_command_with_retries(&mut command)?;
+fn run_json_command(mut command: Command, idempotent: bool) -> Result<serde_json::Value> {
+    let stdout = run_command_with_retries(&mut command, idempotent)?;
     Ok(serde_json::from_str(&stdout)
         .wrap_err_with(|| format!("failed to parse GitHub CLI JSON output: {stdout}"))?)
 }
 
-fn run_text_command(mut command: Command) -> Result<String> {
-    run_command_with_retries(&mut command)
+fn run_text_command(mut command: Command, idempotent: bool) -> Result<String> {
+    run_command_with_retries(&mut command, idempotent)
 }
 
-fn run_command_with_retries(command: &mut Command) -> Result<String> {
+fn run_command_with_retries(command: &mut Command, idempotent: bool) -> Result<String> {
     let max_possible_retries = TRANSIENT_RETRY_DELAYS_SECS
         .len()
         .max(SECONDARY_RETRY_DELAYS_SECS.len());
@@ -774,7 +775,7 @@ fn run_command_with_retries(command: &mut Command) -> Result<String> {
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let Some(retry) = classify_retry(&stderr) else {
+        let Some(retry) = classify_retry(&stderr, idempotent) else {
             return Err(eyre!("GitHub CLI command failed: {stderr}"));
         };
 
@@ -855,12 +856,13 @@ impl std::fmt::Display for RetryReason {
     }
 }
 
-fn classify_retry(stderr: &str) -> Option<RetryReason> {
+fn classify_retry(stderr: &str, idempotent: bool) -> Option<RetryReason> {
     let lowered = stderr.to_ascii_lowercase();
-    if lowered.contains("http 502")
-        || lowered.contains("http 503")
-        || lowered.contains("bad gateway")
-        || lowered.contains("service unavailable")
+    if idempotent
+        && (lowered.contains("http 502")
+            || lowered.contains("http 503")
+            || lowered.contains("bad gateway")
+            || lowered.contains("service unavailable"))
     {
         return Some(RetryReason::Transient);
     }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -3,11 +3,18 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Context, Result, eyre};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+
+const COMMENT_FETCH_CONCURRENCY_LIMIT: usize = 5;
+const TRANSIENT_RETRY_DELAYS_SECS: [u64; 3] = [5, 10, 20];
+const SECONDARY_RETRY_DELAYS_SECS: [u64; 3] = [60, 120, 240];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepoRef {
@@ -73,6 +80,7 @@ pub trait GitHubApi: Send + Sync {
     fn current_login(&self) -> Result<String>;
     fn auth_status(&self) -> Result<String>;
     fn auth_token(&self) -> Result<String>;
+    fn get_rate_limit_status(&self) -> Result<RateLimitStatus>;
     fn repo_has_issues(&self) -> Result<bool>;
     fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>>;
     fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>>;
@@ -133,6 +141,10 @@ impl GitHubClient {
         }
 
         Ok(String::from_utf8(output.stdout)?.trim().to_string())
+    }
+
+    pub fn get_rate_limit_status(&self) -> Result<RateLimitStatus> {
+        self.gh_api_json_typed("GET", "rate_limit", &[])
     }
 
     pub fn repo_has_issues(&self) -> Result<bool> {
@@ -404,6 +416,10 @@ impl GitHubApi for GitHubClient {
         GitHubClient::auth_token(self)
     }
 
+    fn get_rate_limit_status(&self) -> Result<RateLimitStatus> {
+        GitHubClient::get_rate_limit_status(self)
+    }
+
     fn repo_has_issues(&self) -> Result<bool> {
         GitHubClient::repo_has_issues(self)
     }
@@ -489,23 +505,42 @@ pub async fn fetch_all_comments(
     HashMap<u64, Vec<IssueComment>>,
     HashMap<u64, Vec<IssueComment>>,
 )> {
+    let limiter = Arc::new(Semaphore::new(COMMENT_FETCH_CONCURRENCY_LIMIT));
     let mut issue_tasks = tokio::task::JoinSet::new();
     for issue_number in issue_numbers.iter().copied() {
         let github = Arc::clone(&github);
-        issue_tasks.spawn_blocking(move || {
-            github
-                .list_issue_comments(issue_number)
-                .map(|comments| (issue_number, comments))
+        let limiter = Arc::clone(&limiter);
+        issue_tasks.spawn(async move {
+            let _permit = limiter
+                .acquire_owned()
+                .await
+                .map_err(|_error| eyre!("GitHub comment fetch limiter was closed"))?;
+            tokio::task::spawn_blocking(move || {
+                github
+                    .list_issue_comments(issue_number)
+                    .map(|comments| (issue_number, comments))
+            })
+            .await
+            .map_err(|err| eyre!("issue comment fetch task failed: {err}"))?
         });
     }
 
     let mut pr_tasks = tokio::task::JoinSet::new();
     for pr_number in pr_numbers.iter().copied() {
         let github = Arc::clone(&github);
-        pr_tasks.spawn_blocking(move || {
-            github
-                .list_pull_request_comments(pr_number)
-                .map(|comments| (pr_number, comments))
+        let limiter = Arc::clone(&limiter);
+        pr_tasks.spawn(async move {
+            let _permit = limiter
+                .acquire_owned()
+                .await
+                .map_err(|_error| eyre!("GitHub comment fetch limiter was closed"))?;
+            tokio::task::spawn_blocking(move || {
+                github
+                    .list_pull_request_comments(pr_number)
+                    .map(|comments| (pr_number, comments))
+            })
+            .await
+            .map_err(|err| eyre!("pull request comment fetch task failed: {err}"))?
         });
     }
 
@@ -648,34 +683,245 @@ pub struct PullRequestFile {
     pub filename: String,
 }
 
-fn run_json_command(mut command: Command) -> Result<serde_json::Value> {
-    let output = command
-        .output()
-        .wrap_err("failed to run GitHub CLI command")?;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitStatus {
+    pub resources: RateLimitResources,
+}
 
-    if !output.status.success() {
-        return Err(eyre!(
-            "GitHub CLI command failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitResources {
+    pub core: RateLimitBucket,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitBucket {
+    pub limit: u64,
+    pub remaining: u64,
+    pub reset: u64,
+    pub used: u64,
+}
+
+impl RateLimitBucket {
+    pub fn reset_at(&self) -> Option<DateTime<Utc>> {
+        DateTime::from_timestamp(self.reset as i64, 0)
     }
+}
 
-    let stdout = String::from_utf8(output.stdout)?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitKind {
+    Primary,
+    Secondary,
+}
+
+impl std::fmt::Display for RateLimitKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Primary => write!(f, "primary"),
+            Self::Secondary => write!(f, "secondary"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum GitHubCliError {
+    RateLimited {
+        kind: RateLimitKind,
+        retry_after_secs: u64,
+        attempts: usize,
+        stderr: String,
+    },
+}
+
+impl std::fmt::Display for GitHubCliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RateLimited {
+                kind,
+                retry_after_secs,
+                attempts,
+                stderr,
+            } => write!(
+                f,
+                "GitHub API {kind} rate limit hit after {attempts} retries. Retry after about {retry_after_secs}s. Last error: {stderr}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GitHubCliError {}
+
+fn run_json_command(mut command: Command) -> Result<serde_json::Value> {
+    let stdout = run_command_with_retries(&mut command)?;
     Ok(serde_json::from_str(&stdout)
         .wrap_err_with(|| format!("failed to parse GitHub CLI JSON output: {stdout}"))?)
 }
 
 fn run_text_command(mut command: Command) -> Result<String> {
-    let output = command
-        .output()
-        .wrap_err("failed to run GitHub CLI command")?;
+    run_command_with_retries(&mut command)
+}
 
-    if !output.status.success() {
-        return Err(eyre!(
-            "GitHub CLI command failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+fn run_command_with_retries(command: &mut Command) -> Result<String> {
+    for attempt in 0..=TRANSIENT_RETRY_DELAYS_SECS.len() {
+        let output = clone_command(command)
+            .output()
+            .wrap_err("failed to run GitHub CLI command")?;
+
+        if output.status.success() {
+            return Ok(String::from_utf8(output.stdout)?);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let Some(retry) = classify_retry(&stderr) else {
+            return Err(eyre!("GitHub CLI command failed: {stderr}"));
+        };
+
+        let retry_after = match retry {
+            RetryReason::Transient => Duration::from_secs(
+                TRANSIENT_RETRY_DELAYS_SECS
+                    [attempt.min(TRANSIENT_RETRY_DELAYS_SECS.len().saturating_sub(1))],
+            ),
+            RetryReason::RateLimited(kind) => resolve_rate_limit_delay(kind, attempt, &stderr)
+                .unwrap_or_else(|| {
+                    Duration::from_secs(
+                        SECONDARY_RETRY_DELAYS_SECS
+                            [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
+                    )
+                }),
+        };
+
+        let max_retries = match retry {
+            RetryReason::Transient => TRANSIENT_RETRY_DELAYS_SECS.len(),
+            RetryReason::RateLimited(_) => SECONDARY_RETRY_DELAYS_SECS.len(),
+        };
+
+        if attempt >= max_retries {
+            return match retry {
+                RetryReason::Transient => Err(eyre!("GitHub CLI command failed: {stderr}")),
+                RetryReason::RateLimited(kind) => Err(GitHubCliError::RateLimited {
+                    kind,
+                    retry_after_secs: retry_after.as_secs(),
+                    attempts: attempt,
+                    stderr,
+                }
+                .into()),
+            };
+        }
+
+        eprintln!(
+            "GitHub CLI command hit a {} condition. Retrying in {}s...",
+            retry,
+            retry_after.as_secs()
+        );
+        thread::sleep(retry_after);
     }
 
-    Ok(String::from_utf8(output.stdout)?)
+    Err(eyre!("GitHub CLI command failed after retries"))
+}
+
+fn clone_command(command: &Command) -> Command {
+    let mut cloned = Command::new(command.get_program());
+    cloned.args(command.get_args());
+    if let Some(current_dir) = command.get_current_dir() {
+        cloned.current_dir(current_dir);
+    }
+    for (key, value) in command.get_envs() {
+        match value {
+            Some(value) => {
+                cloned.env(key, value);
+            }
+            None => {
+                cloned.env_remove(key);
+            }
+        }
+    }
+    cloned
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryReason {
+    RateLimited(RateLimitKind),
+    Transient,
+}
+
+impl std::fmt::Display for RetryReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RateLimited(kind) => write!(f, "{kind} rate limit"),
+            Self::Transient => write!(f, "transient error"),
+        }
+    }
+}
+
+fn classify_retry(stderr: &str) -> Option<RetryReason> {
+    let lowered = stderr.to_ascii_lowercase();
+    if lowered.contains("http 502")
+        || lowered.contains("http 503")
+        || lowered.contains("bad gateway")
+        || lowered.contains("service unavailable")
+    {
+        return Some(RetryReason::Transient);
+    }
+
+    if lowered.contains("secondary rate limit") || lowered.contains("abuse detection") {
+        return Some(RetryReason::RateLimited(RateLimitKind::Secondary));
+    }
+
+    if lowered.contains("api rate limit exceeded")
+        || lowered.contains("rate limit exceeded")
+        || lowered.contains("http 429")
+    {
+        let kind = current_rate_limit_status()
+            .map(|status| {
+                if status.resources.core.remaining == 0 {
+                    RateLimitKind::Primary
+                } else {
+                    RateLimitKind::Secondary
+                }
+            })
+            .unwrap_or(RateLimitKind::Primary);
+        return Some(RetryReason::RateLimited(kind));
+    }
+
+    None
+}
+
+fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -> Option<Duration> {
+    match kind {
+        RateLimitKind::Primary => current_rate_limit_status().and_then(|status| {
+            status.resources.core.reset_at().map(|reset_at| {
+                let wait = (reset_at - Utc::now())
+                    .to_std()
+                    .unwrap_or_else(|_| Duration::from_secs(0));
+                wait + Duration::from_secs(1)
+            })
+        }),
+        RateLimitKind::Secondary => parse_retry_after(stderr).or_else(|| {
+            Some(Duration::from_secs(
+                SECONDARY_RETRY_DELAYS_SECS
+                    [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
+            ))
+        }),
+    }
+}
+
+fn current_rate_limit_status() -> Option<RateLimitStatus> {
+    let mut command = Command::new("gh");
+    command.args(["api", "rate_limit"]);
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+fn parse_retry_after(stderr: &str) -> Option<Duration> {
+    let lowered = stderr.to_ascii_lowercase();
+    let retry_after_index = lowered.find("retry-after")?;
+    let digits = lowered[retry_after_index..]
+        .chars()
+        .skip_while(|character| !character.is_ascii_digit())
+        .take_while(|character| character.is_ascii_digit())
+        .collect::<String>();
+    let seconds = digits.parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds))
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre::{Context, Result};
 use polyresearch_cli::cli::Cli;
 use polyresearch_cli::commands;
 use polyresearch_cli::commands::AppContext;
-use polyresearch_cli::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
+use polyresearch_cli::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch_cli::github::{GitHubApi, GitHubClient, RepoRef};
 
 #[tokio::main]
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     let repo_root = discover_repo_root(&cwd)?;
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-    let api_budget = NodeConfig::load_api_budget(&repo_root).unwrap_or(DEFAULT_API_BUDGET);
+    let api_budget = NodeConfig::load_api_budget(&repo_root);
     let config = ProtocolConfig::load(&repo_root)?;
     let program = ProgramSpec::load(&repo_root, &config)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::PathBuf;
+use std::process;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -7,7 +8,7 @@ use color_eyre::eyre::{Context, Result};
 use polyresearch_cli::cli::Cli;
 use polyresearch_cli::commands;
 use polyresearch_cli::commands::AppContext;
-use polyresearch_cli::config::{ProgramSpec, ProtocolConfig};
+use polyresearch_cli::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch_cli::github::{GitHubApi, GitHubClient, RepoRef};
 
 #[tokio::main]
@@ -19,6 +20,7 @@ async fn main() -> Result<()> {
     let repo_root = discover_repo_root(&cwd)?;
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
+    let api_budget = NodeConfig::load_api_budget(&repo_root)?;
     let config = ProtocolConfig::load(&repo_root)?;
     let program = ProgramSpec::load(&repo_root, &config)?;
 
@@ -27,11 +29,21 @@ async fn main() -> Result<()> {
         repo_root,
         repo,
         github,
+        api_budget,
         config,
         program,
     };
 
-    commands::run(ctx).await
+    match commands::run(ctx).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if let Some(exit) = error.downcast_ref::<commands::ProcessExit>() {
+                eprintln!("{}", exit.message);
+                process::exit(exit.code);
+            }
+            Err(error)
+        }
+    }
 }
 
 fn discover_repo_root(start: &PathBuf) -> Result<PathBuf> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre::{Context, Result};
 use polyresearch_cli::cli::Cli;
 use polyresearch_cli::commands;
 use polyresearch_cli::commands::AppContext;
-use polyresearch_cli::config::{NodeConfig, ProgramSpec, ProtocolConfig};
+use polyresearch_cli::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch_cli::github::{GitHubApi, GitHubClient, RepoRef};
 
 #[tokio::main]
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     let repo_root = discover_repo_root(&cwd)?;
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-    let api_budget = NodeConfig::load_api_budget(&repo_root)?;
+    let api_budget = NodeConfig::load_api_budget(&repo_root).unwrap_or(DEFAULT_API_BUDGET);
     let config = ProtocolConfig::load(&repo_root)?;
     let program = ProgramSpec::load(&repo_root, &config)?;
 

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -13,6 +13,7 @@ use crate::validation::{AuditFinding, ProtocolEnvelope, validate_issue, validate
 #[derive(Debug, Clone, Serialize)]
 pub struct RepositoryState {
     pub theses: Vec<ThesisState>,
+    pub pull_request_count: usize,
     pub active_nodes: Vec<String>,
     pub queue_depth: usize,
     pub current_best_accepted_metric: Option<f64>,
@@ -129,6 +130,17 @@ impl RepositoryState {
         let pr_numbers = prs.iter().map(|pr| pr.number).collect::<Vec<_>>();
         let (mut issue_comments, mut pr_comments) =
             fetch_all_comments(Arc::clone(github), &issue_numbers, &pr_numbers).await?;
+        Self::derive_from_fetched(issues, prs, &mut issue_comments, &mut pr_comments, config)
+    }
+
+    pub fn derive_from_fetched(
+        issues: Vec<Issue>,
+        prs: Vec<PullRequest>,
+        issue_comments: &mut std::collections::HashMap<u64, Vec<IssueComment>>,
+        pr_comments: &mut std::collections::HashMap<u64, Vec<IssueComment>>,
+        config: &ProtocolConfig,
+    ) -> Result<Self> {
+        let pull_request_count = prs.len();
         let pr_states = prs
             .into_iter()
             .map(|pr| {
@@ -183,6 +195,7 @@ impl RepositoryState {
 
         Ok(Self {
             theses,
+            pull_request_count,
             active_nodes,
             queue_depth,
             current_best_accepted_metric,

--- a/cli/src/tui/views.rs
+++ b/cli/src/tui/views.rs
@@ -239,7 +239,13 @@ fn draw_detail(
             .pull_requests
             .iter()
             .filter(|pr| pr.pr.state == "OPEN")
-            .map(|pr| format!("#{} {}", pr.pr.number, pr.maintainer_status(ctx.config.auto_approve)))
+            .map(|pr| {
+                format!(
+                    "#{} {}",
+                    pr.pr.number,
+                    pr.maintainer_status(ctx.config.auto_approve)
+                )
+            })
             .collect::<Vec<_>>()
             .join(", ");
         format!(

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -395,6 +395,110 @@ async fn pace_reports_default_policy_and_node_metrics() {
     assert_eq!(output.idle_minutes, Some(0));
     assert_eq!(output.rate_limit.derive_cost, 5);
     assert_eq!(output.rate_limit.commands_left, 769);
+    assert!(!output.rate_limit.is_low);
+}
+
+#[tokio::test]
+async fn pace_reports_low_when_quota_near_exhaustion() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("pace-low");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &default_rate_limit_status(3),
+    );
+
+    assert_eq!(output.rate_limit.derive_cost, 2);
+    assert_eq!(output.rate_limit.commands_left, 1);
+    assert!(output.rate_limit.is_low);
+}
+
+#[tokio::test]
+async fn pace_reports_exhausted_when_quota_below_derive_cost() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("pace-exhausted");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &default_rate_limit_status(1),
+    );
+
+    assert_eq!(output.rate_limit.derive_cost, 2);
+    assert_eq!(output.rate_limit.commands_left, 0);
+    assert!(output.rate_limit.is_low);
+    assert!(output.rate_limit.remaining < output.rate_limit.derive_cost);
+}
+
+#[tokio::test]
+async fn init_preserves_custom_api_budget() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("init-budget");
+    let toml_path = repo.path.join(".polyresearch-node.toml");
+    fs::write(&toml_path, "node_id = \"old/node\"\napi_budget = 1000\n").unwrap();
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Init(InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+        }),
+    );
+
+    commands::init::run(
+        &ctx,
+        &InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
+    assert_eq!(config.node_id, "lead/new-node");
+    assert_eq!(config.api_budget, 1_000);
 }
 
 #[tokio::test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -12,10 +12,12 @@ use polyresearch_cli::cli::{
 };
 use polyresearch_cli::commands;
 use polyresearch_cli::comments::{Observation, ReleaseReason};
-use polyresearch_cli::config::{MetricDirection, NodeConfig, ProgramSpec, ProtocolConfig};
+use polyresearch_cli::config::{
+    DEFAULT_API_BUDGET, MetricDirection, NodeConfig, ProgramSpec, ProtocolConfig,
+};
 use polyresearch_cli::github::{
     CommentUser, GitHubApi, Issue, IssueComment, IssueListState, PullRequest, PullRequestFile,
-    PullRequestListState, RepoRef,
+    PullRequestListState, RateLimitBucket, RateLimitResources, RateLimitStatus, RepoRef,
 };
 use polyresearch_cli::state::{ReleaseRecord, RepositoryState, ThesisPhase, ThesisState};
 use serde::Deserialize;
@@ -78,6 +80,10 @@ impl GitHubApi for MockGitHubClient {
 
     fn auth_token(&self) -> Result<String> {
         Ok("test-token".to_string())
+    }
+
+    fn get_rate_limit_status(&self) -> Result<RateLimitStatus> {
+        Ok(default_rate_limit_status(4_000))
     }
 
     fn repo_has_issues(&self) -> Result<bool> {
@@ -291,6 +297,7 @@ async fn init_writes_node_identity() {
         config.resource_policy.as_deref(),
         Some("Use 2 GPUs and keep them busy.")
     );
+    assert_eq!(config.api_budget, DEFAULT_API_BUDGET);
 }
 
 #[tokio::test]
@@ -313,11 +320,18 @@ async fn env_override_uses_session_node_id() {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
         .await
         .unwrap();
-    let output = commands::pace::build_output(ctx.repo.slug(), &node_config, &repo_state);
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &default_rate_limit_status(4_000),
+    );
 
     assert_eq!(output.node_id, "lead/env-node");
     assert_eq!(output.resource_policy, "Keep CPUs saturated.");
     assert!(!output.is_default_policy);
+    assert_eq!(output.rate_limit.configured_budget, DEFAULT_API_BUDGET);
 }
 
 #[tokio::test]
@@ -364,7 +378,13 @@ async fn pace_reports_default_policy_and_node_metrics() {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
         .await
         .unwrap();
-    let output = commands::pace::build_output(ctx.repo.slug(), &node_config, &repo_state);
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &default_rate_limit_status(3_847),
+    );
 
     assert_eq!(output.node_id, "test-node");
     assert!(output.is_default_policy);
@@ -373,6 +393,8 @@ async fn pace_reports_default_policy_and_node_metrics() {
     assert_eq!(output.claimable_theses, 1);
     assert_eq!(output.active_claims, 2);
     assert_eq!(output.idle_minutes, Some(0));
+    assert_eq!(output.rate_limit.derive_cost, 5);
+    assert_eq!(output.rate_limit.commands_left, 769);
 }
 
 #[tokio::test]
@@ -925,6 +947,7 @@ async fn duties_reports_metric_floor_and_stale_queue_for_lead() {
             make_approved_thesis(2),
             make_approved_thesis(3),
         ],
+        0,
         3,
         Some(25.8),
     );
@@ -962,6 +985,7 @@ async fn duties_reports_no_claimable_work_for_contributor_at_metric_floor() {
             make_approved_thesis(2),
             make_approved_thesis(3),
         ],
+        0,
         3,
         Some(25.8),
     );
@@ -1003,7 +1027,7 @@ async fn duties_reports_no_claimable_work_when_all_theses_were_released_by_node(
         created_at: chrono::Utc::now(),
     });
 
-    let repo_state = make_repo_state(vec![thesis_one, thesis_two], 2, None);
+    let repo_state = make_repo_state(vec![thesis_one, thesis_two], 0, 2, None);
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
 
     assert!(
@@ -1029,7 +1053,7 @@ async fn duties_reports_waiting_for_approval_when_queue_has_only_submitted_these
     ctx.config.auto_approve = false;
     commands::write_node_id(&repo.path, "node-a").unwrap();
 
-    let repo_state = make_repo_state(vec![make_submitted_thesis(1)], 1, None);
+    let repo_state = make_repo_state(vec![make_submitted_thesis(1)], 0, 1, None);
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
 
     assert!(
@@ -1116,6 +1140,7 @@ fn make_ctx(
             name: "test-repo".to_string(),
         },
         github,
+        api_budget: DEFAULT_API_BUDGET,
         config: ProtocolConfig {
             required_confirmations: 0,
             metric_tolerance: Some(0.01),
@@ -1137,11 +1162,13 @@ fn make_ctx(
 
 fn make_repo_state(
     theses: Vec<ThesisState>,
+    pull_request_count: usize,
     queue_depth: usize,
     current_best_accepted_metric: Option<f64>,
 ) -> RepositoryState {
     RepositoryState {
         theses,
+        pull_request_count,
         active_nodes: vec![],
         queue_depth,
         current_best_accepted_metric,
@@ -1177,6 +1204,19 @@ fn make_approved_thesis(number: u64) -> ThesisState {
         pull_requests: vec![],
         best_attempt_metric: None,
         findings: vec![],
+    }
+}
+
+fn default_rate_limit_status(remaining: u64) -> RateLimitStatus {
+    RateLimitStatus {
+        resources: RateLimitResources {
+            core: RateLimitBucket {
+                limit: DEFAULT_API_BUDGET,
+                remaining,
+                used: DEFAULT_API_BUDGET.saturating_sub(remaining),
+                reset: (chrono::Utc::now() + chrono::Duration::minutes(42)).timestamp() as u64,
+            },
+        },
     }
 }
 

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -97,6 +97,8 @@ LOOP FOREVER:
      g. When the thesis is released or later resolved:
         git worktree remove <worktree-path>
         Return to the repo root before claiming again.
+        Immediately continue from step 0. Do not end the session after one
+        thesis cycle.
 
   4. Check for review work (PRs with policy-pass, no decision,
      not authored by you):
@@ -168,6 +170,8 @@ if any wording differs.
 - Post `polyresearch attempt` after EVERY experiment. Never batch.
 - Run `polyresearch submit` immediately when you observe `improved`.
   Do not "keep trying."
+- After `submit` or `release`, finish cleanup and then continue the loop from
+  step 0. Ending the session after one thesis cycle is a protocol violation.
 - Lead: process the PR backlog before any other work. Period.
 - Lead: re-run `polyresearch sync` after any decision that closes a thesis.
 - Never modify files in `.polyresearch/` or files outside the editable surface


### PR DESCRIPTION
## Summary

- **api_budget config**: New `api_budget` field in `.polyresearch-node.toml` (default 5000 for `gh auth login` / PAT, configurable to 1000 for `GITHUB_TOKEN` or 15000 for Enterprise Cloud). Plumbed through `AppContext` so all commands have access.
- **Concurrency limiting**: `fetch_all_comments` now uses a `tokio::sync::Semaphore` with max 5 concurrent `gh` subprocess spawns (down from unbounded/82+), preventing GitHub's secondary abuse detection trigger.
- **Rate-limit-aware `pace`**: Queries `GET /rate_limit` (free call), reports remaining quota, cost per `derive()` call (2 + issues + PRs), estimated commands left, and exits with code 75 when budget is exhausted so agents see "wait and retry" instead of a generic crash.
- **Retry with backoff**: `run_json_command` / `run_text_command` now classify errors (primary rate limit, secondary rate limit, transient 502/503, non-retryable) and retry with appropriate delays following GitHub's official best practices. After exhausting retries, returns a structured `GitHubCliError::RateLimited` with reset timing.
- **SKILL.md loop enforcement**: Added explicit post-thesis continuation instructions after submit/release steps to address Cursor agent stopping after one thesis cycle.

## Motivation

Analysis of three agent sessions from the eslint polyresearch run:
- Claude Code contributor session: 76 rate-limit errors, 16+ minutes in nohup retry scripts
- Claude Code lead session: 23 rate-limit errors, ended sleeping 600s for cooldown
- Cursor contributor session: completed one thesis then stopped looping

Root cause: with 64 thesis issues + 18 PRs, each `RepositoryState::derive()` fires 84 GitHub API calls. The contributor loop called `derive()` 4x per iteration (336 calls) with 82 concurrent subprocess spawns, exhausting the 5000/hr primary limit and repeatedly triggering the 100-concurrent secondary limit.

## Test plan

- [x] `cargo test` passes (37 unit + 26 e2e tests)
- [x] New `defaults_api_budget_when_missing` test verifies budget fallback
- [x] Existing `loads_node_config_from_toml` test updated with `api_budget = 15000`
- [x] `pace_reports_default_policy_and_node_metrics` test verifies derive_cost and commands_left calculation
- [x] `env_override_uses_session_node_id` test verifies rate_limit.configured_budget
- [ ] Manual: run `polyresearch pace` against a live repo and verify API budget section appears
- [ ] Manual: verify exit code 75 when quota is near zero

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core GitHub CLI invocation paths by adding retry/backoff and rate-limit classification, which could change failure modes and timing across most commands. Also adds new persisted `api_budget` config and an early-exit path in `pace` that downstream automation must handle.
> 
> **Overview**
> Adds GitHub API rate-limit awareness end-to-end: introduces a persisted `api_budget` in `.polyresearch-node.toml` (defaulting to `DEFAULT_API_BUDGET`) and plumbs it through `AppContext`, preserving existing budgets when rewriting node config.
> 
> Hardens GitHub CLI interactions by throttling comment fetch concurrency (semaphore limit of 5) and adding retry/backoff logic for idempotent requests, including primary/secondary rate-limit detection with structured `GitHubCliError` errors.
> 
> Enhances `polyresearch pace` to query `rate_limit`, display quota/cost/estimated commands remaining, and exit with a dedicated code (`75`) via a new `ProcessExit` helper when quota is insufficient; `main` now converts `ProcessExit` errors into real process exit codes. Updates state derivation to track `pull_request_count` for the pacing cost estimate, and refreshes tests/docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0817e7e0f61d38d5e447cec610027f38702750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->