### PR TITLE
Add cli_version enforcement to ensure all nodes run the same CLI version

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -26,6 +26,7 @@ auto_approve: true
 metric_tolerance: 0.01
 metric_direction: higher_is_better
 min_queue_depth: 5
+cli_version: 0.3.1
 ```
 
 **Parameter reference:**
@@ -40,6 +41,7 @@ min_queue_depth: 5
 - `review_timeout` — Time before an incomplete review claim expires. Default: `12h`.
 - `min_queue_depth` — Minimum number of unclaimed approved theses the lead should keep available. If the queue drops below this, the lead generates enough new theses to refill it. Default: `5`.
 - `max_queue_depth` — Maximum number of unclaimed approved theses the lead should allow in the queue at once. When omitted, there is no upper bound.
+- `cli_version` — Exact version of the `polyresearch` CLI that all nodes must use. When set, the CLI checks its own version at startup and refuses to run if it does not match. When omitted, no version check is performed.
 
 The parameter definitions live here. Concrete project values live in `PROGRAM.md`.
 

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,6 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
+cli_version: 0.3.1
 
 ## Goal
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -149,6 +149,7 @@ pub struct ProtocolConfig {
     pub review_timeout: Duration,
     pub min_queue_depth: usize,
     pub max_queue_depth: Option<usize>,
+    pub cli_version: Option<String>,
 }
 
 impl Default for ProtocolConfig {
@@ -164,6 +165,7 @@ impl Default for ProtocolConfig {
             review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: None,
+            cli_version: None,
         }
     }
 }
@@ -241,6 +243,9 @@ impl ProtocolConfig {
                             format!("invalid max_queue_depth value `{value}`")
                         })?);
                 }
+                "cli_version" => {
+                    config.cli_version = Some(value.to_string());
+                }
                 _ => {}
             }
         }
@@ -263,6 +268,18 @@ impl ProtocolConfig {
         self.maintainer_github_login
             .as_deref()
             .ok_or_else(|| eyre!("maintainer_github_login is required in PROGRAM.md"))
+    }
+
+    pub fn check_cli_version(&self, current: &str) -> Result<()> {
+        let Some(required) = &self.cli_version else {
+            return Ok(());
+        };
+        if current == required {
+            return Ok(());
+        }
+        Err(eyre!(
+            "this project requires polyresearch CLI v{required}, but you are running v{current}"
+        ))
     }
 }
 
@@ -709,6 +726,62 @@ Do something.
         assert_eq!(config.lead_github_login.as_deref(), Some("alice"));
 
         fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn loads_cli_version_from_program() {
+        let repo_root = unique_temp_dir("cli-version-load");
+        fs::write(
+            repo_root.join("PROGRAM.md"),
+            "# Research Program\n\ncli_version: 1.2.3\n\n## Goal\n\nDo something.\n",
+        )
+        .unwrap();
+
+        let config = ProtocolConfig::load(&repo_root).unwrap();
+        assert_eq!(config.cli_version.as_deref(), Some("1.2.3"));
+
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn cli_version_defaults_to_none() {
+        let repo_root = unique_temp_dir("cli-version-none");
+        fs::write(
+            repo_root.join("PROGRAM.md"),
+            "# Research Program\n\nlead_github_login: alice\n\n## Goal\n\nDo something.\n",
+        )
+        .unwrap();
+
+        let config = ProtocolConfig::load(&repo_root).unwrap();
+        assert!(config.cli_version.is_none());
+
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn check_cli_version_passes_when_matching() {
+        let config = ProtocolConfig {
+            cli_version: Some("1.2.3".to_string()),
+            ..Default::default()
+        };
+        assert!(config.check_cli_version("1.2.3").is_ok());
+    }
+
+    #[test]
+    fn check_cli_version_fails_on_mismatch() {
+        let config = ProtocolConfig {
+            cli_version: Some("2.0.0".to_string()),
+            ..Default::default()
+        };
+        let err = config.check_cli_version("1.2.3").unwrap_err();
+        assert!(err.to_string().contains("v2.0.0"));
+        assert!(err.to_string().contains("v1.2.3"));
+    }
+
+    #[test]
+    fn check_cli_version_skipped_when_unset() {
+        let config = ProtocolConfig::default();
+        assert!(config.check_cli_version("0.0.0").is_ok());
     }
 
     fn unique_temp_dir(name: &str) -> PathBuf {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<()> {
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
     let api_budget = NodeConfig::load_api_budget(&repo_root);
     let config = ProtocolConfig::load(&repo_root)?;
+    config.check_cli_version(env!("CARGO_PKG_VERSION"))?;
     let program = ProgramSpec::load(&repo_root, &config)?;
 
     let ctx = AppContext {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -705,6 +705,7 @@ mod tests {
             review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
+            cli_version: None,
         }
     }
 }

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -961,6 +961,7 @@ mod tests {
             review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
+            cli_version: None,
         }
     }
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1256,6 +1256,7 @@ fn make_ctx(
             review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
+            cli_version: None,
         },
         program: ProgramSpec {
             can_modify: vec!["system_prompt.md".to_string()],


### PR DESCRIPTION
## Summary

- Adds `cli_version` as a new protocol parameter in `PROGRAM.md`, parsed by `ProtocolConfig` alongside existing settings like `metric_tolerance` and `auto_approve`.
- At startup, the CLI compares the configured version against its own `CARGO_PKG_VERSION` and exits with a clear error on mismatch. When omitted, no check runs (backward compatible).
- Documents the parameter in `POLYRESEARCH.md` and adds 5 unit tests covering parsing, match, mismatch, and skip-when-unset.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes all 75 tests (46 unit + 29 e2e)
- [ ] Manual: set `cli_version` to a wrong value in a test project's `PROGRAM.md` and verify the CLI refuses to run
- [ ] Manual: remove `cli_version` from `PROGRAM.md` and verify the CLI runs without complaint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new startup gate that can prevent the CLI from running when `PROGRAM.md` specifies a different version, potentially impacting all nodes if misconfigured. Scope is limited to config parsing/startup with added test coverage.
> 
> **Overview**
> Adds an optional `cli_version` protocol parameter that can be set in `PROGRAM.md` and documented in `POLYRESEARCH.md` to pin the exact `polyresearch` CLI version expected by a project.
> 
> On CLI startup, the loaded `ProtocolConfig` now compares `cli_version` (when present) against the running `CARGO_PKG_VERSION` and errors out with a clear message on mismatch; existing configs remain backward-compatible when the field is omitted. Tests/fixtures are updated to include the new config field and new unit tests cover parsing plus match/mismatch/skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d844f49341ec010211959a2ca1a9294cbb7faab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->