### PR TITLE
Bump CLI version to 0.3.2 for release

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -26,7 +26,7 @@ auto_approve: true
 metric_tolerance: 0.01
 metric_direction: higher_is_better
 min_queue_depth: 5
-cli_version: 0.3.1
+cli_version: 0.3.2
 ```
 
 **Parameter reference:**

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.3.1
+cli_version: 0.3.2
 
 ## Goal
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 repository = "https://github.com/superagent-ai/polyresearch"
 


### PR DESCRIPTION
## Summary

- Bumps `cli/Cargo.toml` version from 0.3.1 to 0.3.2.
- Updates `cli_version` in `PROGRAM.md` and `POLYRESEARCH.md` example to 0.3.2.

After merge, tag `v0.3.2` on main to trigger the release workflow.

## Test plan

- [x] `cargo build` succeeds with new version
- [ ] Merge, then `git tag v0.3.2 && git push origin v0.3.2` to trigger release CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version-only changes in release metadata/docs with no functional code modifications.
> 
> **Overview**
> Updates the `polyresearch-cli` crate version to `0.3.2` (in `cli/Cargo.toml` and `cli/Cargo.lock`).
> 
> Refreshes protocol/program documentation examples (`PROGRAM.md`, `POLYRESEARCH.md`) to require/use `cli_version: 0.3.2` for coordination/version checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8554796304fa0b9f073d00688a75c6514706c363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->