### PR TITLE
Add parallel sub-agent support for contributor workflows

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -89,20 +89,24 @@ Each node keeps a local `.polyresearch-node.toml` file at the repo root:
 
 ```toml
 node_id = "alice/mac.lan-a3f2"
-resource_policy = "8-core machine with 2 GPUs. Run up to 4 parallel evaluations. Keep GPUs saturated. Stay under 50 API calls/min."
+sub_agents = 4
+resource_policy = "18-core machine. Run 4 evaluations in parallel. Stay under 50 API calls/min."
 ```
 
 - `node_id` identifies the machine or worker. Keep it stable for the lifetime of that worker or agent session.
+- `sub_agents` is the number of theses this node should work on in parallel. Set it to the number of evaluations the hardware can run simultaneously without interference.
 - `resource_policy` is optional natural language guidance for that node only. It is not project state.
-- Set or update it with `polyresearch init --resource-policy "..."`.
+- Set or update both with `polyresearch init --sub-agents N --resource-policy "..."`.
 - `POLYRESEARCH_NODE_ID` overrides `node_id` for the current process. Use it when multiple agents share one checkout or when one GitHub login needs several concurrent nodes.
 - If `POLYRESEARCH_NODE_ID` is unset, the CLI falls back to `.polyresearch-node.toml`.
 
-If `resource_policy` is absent, the default policy applies:
+Sub-agents exist to improve hardware utilization. A contributor that works on one thesis at a time only runs one evaluation at a time. On a multi-core server or multi-GPU machine, the rest of the hardware sits idle. When `sub_agents` is greater than 1, the contributor should claim multiple theses, dispatch one sub-agent per thesis, and keep the hardware busy while still using one GitHub login and one visible contributor session.
 
-> Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.
+Without sub-agents (`sub_agents = 1` or absent), follow the normal contributor loop below.
 
-Run `polyresearch pace` regularly. It prints the effective resource policy alongside recent node activity so the agent can compare expectation vs reality and adjust parallelism or claim rate.
+With sub-agents (`sub_agents > 1`), the contributor still owns the work. The contributor claims multiple theses with `polyresearch batch-claim`, dispatches one sub-agent per thesis, waits for results, then posts all attempt records, submits improvements, and releases non-improvements. Sub-agents do not interact with GitHub directly.
+
+Run `polyresearch pace` regularly. It prints the node's `sub_agents` setting, optional `resource_policy`, and recent activity so the contributor can compare intent vs. reality and adjust throughput.
 
 ---
 
@@ -162,6 +166,25 @@ LOOP FOREVER:
 6. Repeat from step 0.
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
+
+### Contributor loop with sub-agents
+
+When `.polyresearch-node.toml` sets `sub_agents` greater than 1, use this variant instead of claiming one thesis at a time:
+
+1. Run `polyresearch duties` and resolve blocking items.
+2. Run `polyresearch pace`.
+3. Run `polyresearch batch-claim`. It claims up to `sub_agents` theses and creates one worktree per thesis.
+4. Dispatch one sub-agent per claimed thesis. Each sub-agent:
+   - Works only in its assigned worktree.
+   - Reads `PROGRAM.md` and `PREPARE.md`.
+   - Designs and runs experiments.
+   - Returns metrics, observations, and summaries to the contributor.
+   - Does not run `polyresearch` commands and does not talk to GitHub.
+5. Wait for all sub-agents to finish.
+6. For each returned result, run `polyresearch attempt`.
+7. If a thesis improved, run `polyresearch submit` for it immediately.
+8. If a thesis did not improve, run `polyresearch release` for it.
+9. Repeat from step 1.
 
 **NEVER STOP.** Once the loop has begun, do not pause to ask the human if you should continue. Do not ask "should I keep going?" or "is this a good stopping point?" The human might be asleep or away and expects you to work indefinitely until manually stopped. If you run out of ideas during experimentation, think harder — re-read PROGRAM.md, study results.tsv for patterns in what worked and failed, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you.
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ Do polyresearch on https://github.com/owner/repo.
 
 The agent clones the repo, claims work from the issue queue, runs experiments, and submits results in a loop until you stop it. Launch as many contributor agents as you have machines.
 
+### Hardware utilization
+
+A single contributor agent working on one thesis at a time only runs one evaluation at a time. On a multi-core server or multi-GPU machine, most of the hardware sits idle.
+
+Polyresearch can use sub-agents to keep that hardware busy. Set `sub_agents` in `.polyresearch-node.toml` to the number of evaluations the machine can run at once. The contributor then claims multiple theses, dispatches one sub-agent per thesis, and posts results in batches. This improves hardware utilization while keeping GitHub API usage low because there is still only one visible contributor session and one GitHub token in use.
+
 ### Run on a remote machine
 
-The agent runs on your local machine. The experiments run on a remote server (e.g. a cloud instance with GPUs). Set up the repo, CLI, and `gh` auth on the remote, then tell your agent:
+#### Pattern A: Remote evaluation over SSH
+
+The agent runs on your local machine. The experiments run on a remote server. Set up the repo, CLI, and `gh` auth on the remote, then tell your agent:
 
 ```
 Do polyresearch on https://github.com/owner/repo.
@@ -68,6 +76,21 @@ Run all evaluations and experiments over SSH on user@remote-host.
 ```
 
 Your local machine only needs the agent; the remote server does the compute.
+
+#### Pattern B: Run the agent on the server
+
+This is the recommended pattern for parallel sub-agents. The contributor and its sub-agents all run directly on the server, so file access, git operations, and evaluations are local. There is no SSH relay in the middle.
+
+Use `tmux` so the session survives disconnects:
+
+```bash
+ssh user@remote-host
+tmux new-session -s polyresearch
+claude -p "Do polyresearch on https://github.com/owner/repo."
+# Detach with Ctrl-B D. Reconnect with: tmux attach -t polyresearch
+```
+
+Detaching means the process keeps running after your SSH session closes. `tmux` creates a persistent terminal session on the server. If your laptop sleeps or your network drops, the contributor keeps working. Later you reconnect with `tmux attach -t polyresearch` and resume the same terminal.
 
 ## CLI
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,10 +80,10 @@ Initialize the local node identity once per repo:
 
 ```bash
 polyresearch init
-polyresearch init --resource-policy "2 GPUs, run up to 4 evals in parallel, stay under 50 API calls/min"
+polyresearch init --sub-agents 4 --resource-policy "Run 4 evals in parallel, stay under 50 API calls/min"
 ```
 
-This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` plus an optional natural-language `resource_policy`. If no policy is set, the protocol default is to maximize throughput.
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id`, a `sub_agents` count, and an optional natural-language `resource_policy`.
 
 Inspect the current state:
 
@@ -103,9 +103,12 @@ polyresearch claim 88
 polyresearch attempt 88 --metric 0.6244 --baseline 0.5000 --observation improved --summary "River all-in with two pair+"
 polyresearch submit 88
 polyresearch release 88 --reason no_improvement
+polyresearch batch-claim --count 4
 ```
 
 By default, `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. Pass `--no-worktree` only if you intentionally want the legacy single-working-tree checkout flow.
+
+`polyresearch batch-claim` is the parallel version for contributors using sub-agents. It claims multiple theses at once, creates one worktree per thesis, and returns them as a JSON array when used with `--json`.
 
 Review flow:
 
@@ -145,11 +148,12 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 ## Command summary
 
-- `polyresearch init` -- set node identity, optional resource policy, verify GitHub auth, detect repo
-- `polyresearch pace` -- show the effective resource policy alongside recent node throughput
+- `polyresearch init` -- set node identity, sub-agent count, optional resource policy, verify GitHub auth, detect repo
+- `polyresearch pace` -- show the configured sub-agent count, optional resource policy, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
 - `polyresearch claim` -- atomically claim a thesis and create the thesis worktree (or a branch with `--no-worktree`)
+- `polyresearch batch-claim` -- claim multiple theses at once and create one worktree per thesis
 - `polyresearch attempt` -- post a structured attempt comment from the current branch
 - `polyresearch release` -- release a claim with a structured reason
 - `polyresearch submit` -- push the branch and open a candidate PR

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -26,6 +26,7 @@ pub enum Commands {
     Pace,
     Status(StatusArgs),
     Claim(IssueArgs),
+    BatchClaim(BatchClaimArgs),
     Attempt(AttemptArgs),
     Annotate(AnnotateArgs),
     Release(ReleaseArgs),
@@ -49,6 +50,9 @@ pub struct InitArgs {
 
     #[arg(long)]
     pub resource_policy: Option<String>,
+
+    #[arg(long)]
+    pub sub_agents: Option<usize>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -60,6 +64,15 @@ pub struct StatusArgs {
 #[derive(Debug, Args, Clone)]
 pub struct IssueArgs {
     pub issue: u64,
+
+    #[arg(long)]
+    pub no_worktree: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct BatchClaimArgs {
+    #[arg(long)]
+    pub count: Option<usize>,
 
     #[arg(long)]
     pub no_worktree: bool,

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -1,0 +1,142 @@
+use color_eyre::eyre::{Result, eyre};
+use serde::Serialize;
+
+use crate::cli::BatchClaimArgs;
+use crate::commands::duties;
+use crate::commands::{
+    AppContext, create_thesis_branch, create_thesis_worktree, print_value, read_node_id, slugify,
+    thesis_worktree_path,
+};
+use crate::comments::ProtocolComment;
+use crate::state::{RepositoryState, ThesisPhase, ThesisState};
+
+#[derive(Debug, Serialize)]
+struct BatchClaimEntry {
+    issue: u64,
+    node: String,
+    branch: String,
+    worktree_path: Option<String>,
+}
+
+pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
+    let node = read_node_id(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+
+    let duty_report = duties::check(ctx, &repo_state)?;
+    let hard_blockers: Vec<_> = duty_report
+        .blocking
+        .iter()
+        .filter(|d| d.category != "claim")
+        .collect();
+    if !hard_blockers.is_empty() {
+        let items: Vec<String> = hard_blockers
+            .iter()
+            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
+            .collect();
+        return Err(eyre!(
+            "cannot batch-claim while blocking duties exist:\n{}",
+            items.join("\n")
+        ));
+    }
+
+    let requested = args.count.unwrap_or(repo_state_sub_agent_target(ctx));
+    let claim_count = requested.max(1);
+    let theses = select_claimable_theses(&repo_state, &node, claim_count);
+    if theses.is_empty() {
+        return Err(eyre!("no claimable theses available for node `{}`", node));
+    }
+
+    let mut entries = Vec::with_capacity(theses.len());
+    for thesis in theses {
+        let (branch, worktree_path) = if ctx.cli.dry_run {
+            let branch = format!(
+                "thesis/{}-{}",
+                thesis.issue.number,
+                slugify(&thesis.issue.title)
+            );
+            let worktree_path = (!args.no_worktree).then(|| {
+                thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)
+                    .display()
+                    .to_string()
+            });
+            (branch, worktree_path)
+        } else if args.no_worktree {
+            (
+                create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?,
+                None,
+            )
+        } else {
+            let workspace =
+                create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
+            (
+                workspace.branch,
+                Some(workspace.worktree_path.display().to_string()),
+            )
+        };
+
+        let comment = ProtocolComment::Claim {
+            thesis: thesis.issue.number,
+            node: node.clone(),
+        };
+        if !ctx.cli.dry_run {
+            ctx.github
+                .post_issue_comment(thesis.issue.number, &comment.render())?;
+        }
+
+        entries.push(BatchClaimEntry {
+            issue: thesis.issue.number,
+            node: node.clone(),
+            branch,
+            worktree_path,
+        });
+    }
+
+    print_value(ctx, &entries, |value| {
+        let header = if ctx.cli.dry_run {
+            format!(
+                "Would batch-claim {} theses as node `{}`:",
+                value.len(),
+                node
+            )
+        } else {
+            format!("Batch-claimed {} theses as node `{}`:", value.len(), node)
+        };
+        let lines = value
+            .iter()
+            .map(|entry| match &entry.worktree_path {
+                Some(path) => format!(
+                    "  - thesis #{} on branch `{}` in worktree `{}`",
+                    entry.issue, entry.branch, path
+                ),
+                None => format!("  - thesis #{} on branch `{}`", entry.issue, entry.branch),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("{header}\n{lines}")
+    })
+}
+
+fn repo_state_sub_agent_target(ctx: &AppContext) -> usize {
+    crate::commands::read_node_config(&ctx.repo_root)
+        .map(|config| config.sub_agents)
+        .unwrap_or(crate::config::DEFAULT_SUB_AGENTS)
+}
+
+fn select_claimable_theses<'a>(
+    repo_state: &'a RepositoryState,
+    node: &str,
+    count: usize,
+) -> Vec<&'a ThesisState> {
+    let mut theses = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| thesis.issue.state == "OPEN")
+        .filter(|thesis| thesis.approved)
+        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
+        .filter(|thesis| thesis.active_claims.is_empty())
+        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
+        .collect::<Vec<_>>();
+    theses.sort_by_key(|thesis| thesis.issue.number);
+    theses.truncate(count);
+    theses
+}

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -19,7 +19,7 @@ struct InitOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
-    let resource_policy = args
+    let requested_resource_policy = args
         .resource_policy
         .as_ref()
         .map(|value| value.trim())
@@ -30,9 +30,16 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let _ = ctx.github.auth_token()?;
     let machine_id = args.node.clone().unwrap_or_else(default_machine_id);
     let node = format!("{login}/{machine_id}");
-    let existing_sub_agents = read_node_config(&ctx.repo_root)
+    let existing_config = read_node_config(&ctx.repo_root).ok();
+    let existing_sub_agents = existing_config
+        .as_ref()
         .map(|config| config.sub_agents)
         .unwrap_or(DEFAULT_SUB_AGENTS);
+    let resource_policy = requested_resource_policy.or_else(|| {
+        existing_config
+            .as_ref()
+            .and_then(|config| config.resource_policy.clone())
+    });
     let sub_agents = args.sub_agents.unwrap_or(existing_sub_agents).max(1);
 
     if let Ok(false) = ctx.github.repo_has_issues() {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -6,8 +6,8 @@ use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::InitArgs;
-use crate::commands::{AppContext, print_value, write_node_config};
-use crate::config::DEFAULT_RESOURCE_POLICY;
+use crate::commands::{AppContext, print_value, read_node_config, write_node_config};
+use crate::config::DEFAULT_SUB_AGENTS;
 
 #[derive(Debug, Serialize)]
 struct InitOutput {
@@ -15,8 +15,7 @@ struct InitOutput {
     node: String,
     github_login: String,
     resource_policy: Option<String>,
-    effective_resource_policy: String,
-    is_default_policy: bool,
+    sub_agents: usize,
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
@@ -31,6 +30,10 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let _ = ctx.github.auth_token()?;
     let machine_id = args.node.clone().unwrap_or_else(default_machine_id);
     let node = format!("{login}/{machine_id}");
+    let existing_sub_agents = read_node_config(&ctx.repo_root)
+        .map(|config| config.sub_agents)
+        .unwrap_or(DEFAULT_SUB_AGENTS);
+    let sub_agents = args.sub_agents.unwrap_or(existing_sub_agents).max(1);
 
     if let Ok(false) = ctx.github.repo_has_issues() {
         eprintln!("Warning: Issues are disabled on this repository (common for forks).");
@@ -41,21 +44,20 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     }
 
     if !ctx.cli.dry_run {
-        write_node_config(&ctx.repo_root, &node, resource_policy.as_deref())?;
+        write_node_config(
+            &ctx.repo_root,
+            &node,
+            resource_policy.as_deref(),
+            Some(sub_agents),
+        )?;
     }
-
-    let (effective_resource_policy, is_default_policy) = match &resource_policy {
-        Some(policy) => (policy.clone(), false),
-        None => (DEFAULT_RESOURCE_POLICY.to_string(), true),
-    };
 
     let output = InitOutput {
         repo: ctx.repo.slug(),
         node,
         github_login: login,
         resource_policy,
-        effective_resource_policy,
-        is_default_policy,
+        sub_agents,
     };
 
     print_value(ctx, &output, |value| {
@@ -63,10 +65,11 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
             "Initialized polyresearch for {} as node `{}` (GitHub: {}).",
             value.repo, value.node, value.github_login
         );
-        if value.is_default_policy {
-            text.push_str(" Using the default resource policy.");
-        } else {
+        text.push_str(&format!(" Sub-agents: {}.", value.sub_agents));
+        if value.resource_policy.is_some() {
             text.push_str(" Saved the custom resource policy.");
+        } else {
+            text.push_str(" No resource policy set.");
         }
         text
     })

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -119,6 +119,10 @@ pub fn write_node_config(
     sub_agents: Option<usize>,
 ) -> Result<()> {
     let existing = NodeConfig::load(repo_root).ok();
+    let existing_resource_policy = existing
+        .as_ref()
+        .and_then(|config| config.resource_policy.as_deref())
+        .map(ToString::to_string);
     let existing_budget = existing
         .as_ref()
         .map(|config| config.api_budget)
@@ -129,7 +133,9 @@ pub fn write_node_config(
         .unwrap_or(crate::config::DEFAULT_SUB_AGENTS);
     NodeConfig::new(
         node.to_string(),
-        resource_policy.map(ToString::to_string),
+        resource_policy
+            .map(ToString::to_string)
+            .or(existing_resource_policy),
         existing_budget,
         sub_agents.unwrap_or(existing_sub_agents),
     )

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod annotate;
 pub mod attempt;
 pub mod audit;
+pub mod batch_claim;
 pub mod claim;
 pub mod decide;
 pub mod duties;
@@ -61,6 +62,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Pace => pace::run(&ctx).await,
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
+        Commands::BatchClaim(args) => batch_claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,
         Commands::Annotate(args) => annotate::run(&ctx, args).await,
         Commands::Release(args) => release::run(&ctx, args).await,
@@ -107,19 +109,29 @@ pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
 }
 
 pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
-    write_node_config(repo_root, node, None)
+    write_node_config(repo_root, node, None, None)
 }
 
 pub fn write_node_config(
     repo_root: &PathBuf,
     node: &str,
     resource_policy: Option<&str>,
+    sub_agents: Option<usize>,
 ) -> Result<()> {
-    let existing_budget = NodeConfig::load_api_budget(repo_root);
+    let existing = NodeConfig::load(repo_root).ok();
+    let existing_budget = existing
+        .as_ref()
+        .map(|config| config.api_budget)
+        .unwrap_or_else(|| NodeConfig::load_api_budget(repo_root));
+    let existing_sub_agents = existing
+        .as_ref()
+        .map(|config| config.sub_agents)
+        .unwrap_or(crate::config::DEFAULT_SUB_AGENTS);
     NodeConfig::new(
         node.to_string(),
         resource_policy.map(ToString::to_string),
         existing_budget,
+        sub_agents.unwrap_or(existing_sub_agents),
     )
     .save(repo_root)
 }

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -13,8 +13,8 @@ const RATE_LIMIT_EXIT_CODE: i32 = 75;
 pub struct PaceOutput {
     pub repo: String,
     pub node_id: String,
-    pub resource_policy: String,
-    pub is_default_policy: bool,
+    pub resource_policy: Option<String>,
+    pub sub_agents: usize,
     pub api_budget: u64,
     pub rate_limit: PaceRateLimit,
     pub attempts_last_hour: usize,
@@ -51,12 +51,13 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     );
 
     print_value(ctx, &output, |value| {
-        let resource_label = if value.is_default_policy {
-            "Resource policy (default)"
+        let mut rendered = format!("Sub-agents: {}", value.sub_agents);
+        if let Some(policy) = &value.resource_policy {
+            rendered.push_str("\n\n");
+            rendered.push_str(&format_wrapped_policy("Resource policy", policy));
         } else {
-            "Resource policy"
-        };
-        let mut rendered = format_wrapped_policy(resource_label, &value.resource_policy);
+            rendered.push_str("\n\nResource policy: No resource policy set.");
+        }
         let idle = value
             .idle_minutes
             .map(|minutes| minutes.to_string())
@@ -123,7 +124,7 @@ pub fn build_output(
     let one_hour_ago = now - Duration::hours(1);
     let four_hours_ago = now - Duration::hours(4);
     let node_id = node_config.node_id.clone();
-    let (resource_policy, is_default_policy) = node_config.effective_resource_policy();
+    let resource_policy = node_config.effective_resource_policy().map(str::to_string);
 
     let attempts = repo_state
         .theses
@@ -161,8 +162,8 @@ pub fn build_output(
     PaceOutput {
         repo,
         node_id,
-        resource_policy: resource_policy.to_string(),
-        is_default_policy,
+        resource_policy,
+        sub_agents: node_config.sub_agents,
         api_budget,
         rate_limit: PaceRateLimit {
             configured_budget: api_budget,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -8,8 +8,8 @@ use color_eyre::eyre::{Context, Result, eyre};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
 pub const DEFAULT_API_BUDGET: u64 = 5_000;
+pub const DEFAULT_SUB_AGENTS: usize = 1;
 pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -26,6 +26,8 @@ pub struct NodeConfig {
     pub resource_policy: Option<String>,
     #[serde(default = "default_api_budget")]
     pub api_budget: u64,
+    #[serde(default = "default_sub_agents")]
+    pub sub_agents: usize,
 }
 
 impl NodeConfig {
@@ -33,11 +35,13 @@ impl NodeConfig {
         node_id: impl Into<String>,
         resource_policy: Option<String>,
         api_budget: u64,
+        sub_agents: usize,
     ) -> Self {
         Self {
             node_id: node_id.into(),
             resource_policy: normalize_resource_policy(resource_policy),
             api_budget: normalize_api_budget(api_budget),
+            sub_agents: normalize_sub_agents(sub_agents),
         }
     }
 
@@ -76,7 +80,12 @@ impl NodeConfig {
             .map(|config| config.api_budget)
             .unwrap_or(DEFAULT_API_BUDGET);
 
-        Ok(Self::new(node_id, resource_policy, api_budget))
+        let sub_agents = file_config
+            .as_ref()
+            .map(|config| config.sub_agents)
+            .unwrap_or(DEFAULT_SUB_AGENTS);
+
+        Ok(Self::new(node_id, resource_policy, api_budget, sub_agents))
     }
 
     pub fn load_api_budget(repo_root: &Path) -> u64 {
@@ -104,11 +113,8 @@ impl NodeConfig {
             .filter(|value| !value.trim().is_empty())
     }
 
-    pub fn effective_resource_policy(&self) -> (&str, bool) {
-        match self.resource_policy() {
-            Some(policy) => (policy, false),
-            None => (DEFAULT_RESOURCE_POLICY, true),
-        }
+    pub fn effective_resource_policy(&self) -> Option<&str> {
+        self.resource_policy()
     }
 
     pub fn effective_api_budget(&self) -> u64 {
@@ -128,6 +134,10 @@ fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
 
 fn default_api_budget() -> u64 {
     DEFAULT_API_BUDGET
+}
+
+fn default_sub_agents() -> usize {
+    DEFAULT_SUB_AGENTS
 }
 
 fn node_id_override() -> Option<String> {
@@ -556,6 +566,7 @@ mod tests {
             r#"node_id = "node-7f83"
 resource_policy = "Run 4 evals in parallel."
 api_budget = 15000
+sub_agents = 6
 "#,
         )
         .unwrap();
@@ -567,6 +578,7 @@ api_budget = 15000
             Some("Run 4 evals in parallel.")
         );
         assert_eq!(config.api_budget, 15_000);
+        assert_eq!(config.sub_agents, 6);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -591,6 +603,7 @@ resource_policy = "Run 4 evals in parallel."
             config.resource_policy.as_deref(),
             Some("Run 4 evals in parallel.")
         );
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -604,6 +617,7 @@ resource_policy = "Run 4 evals in parallel."
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -619,22 +633,27 @@ resource_policy = "Run 4 evals in parallel."
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
     fn defaults_resource_policy_when_missing() {
-        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET);
-        let (policy, is_default) = config.effective_resource_policy();
-        assert!(is_default);
-        assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
+        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET, DEFAULT_SUB_AGENTS);
+        assert_eq!(config.effective_resource_policy(), None);
     }
 
     #[test]
     fn defaults_api_budget_when_missing() {
-        let config = NodeConfig::new("node-7f83", None, 0);
+        let config = NodeConfig::new("node-7f83", None, 0, DEFAULT_SUB_AGENTS);
         assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
+    }
+
+    #[test]
+    fn defaults_sub_agents_when_zero() {
+        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET, 0);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
     }
 
     #[test]
@@ -800,6 +819,13 @@ fn normalize_resource_policy(resource_policy: Option<String>) -> Option<String> 
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+fn normalize_sub_agents(sub_agents: usize) -> usize {
+    match sub_agents {
+        0 => DEFAULT_SUB_AGENTS,
+        value => value,
+    }
 }
 
 fn normalize_api_budget(api_budget: u64) -> u64 {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch_cli::cli::{
-    AttemptArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
+    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
 };
 use polyresearch_cli::commands;
 use polyresearch_cli::comments::{Observation, ReleaseReason};
@@ -234,7 +234,7 @@ struct NodeIdEnvGuard {
 
 impl NodeIdEnvGuard {
     fn lock_clean() -> Self {
-        let guard = env_lock().lock().unwrap();
+        let guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
         clear_node_id_env();
         Self { _guard: guard }
     }
@@ -277,6 +277,7 @@ async fn init_writes_node_identity() {
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
             resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
+            sub_agents: Some(4),
         }),
     );
 
@@ -285,6 +286,7 @@ async fn init_writes_node_identity() {
         &InitArgs {
             node: Some("test-node".to_string()),
             resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
+            sub_agents: Some(4),
         },
     )
     .await
@@ -298,6 +300,7 @@ async fn init_writes_node_identity() {
         Some("Use 2 GPUs and keep them busy.")
     );
     assert_eq!(config.api_budget, DEFAULT_API_BUDGET);
+    assert_eq!(config.sub_agents, 4);
 }
 
 #[tokio::test]
@@ -312,8 +315,13 @@ async fn env_override_uses_session_node_id() {
         HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
-    commands::write_node_config(&repo.path, "lead/file-node", Some("Keep CPUs saturated."))
-        .unwrap();
+    commands::write_node_config(
+        &repo.path,
+        "lead/file-node",
+        Some("Keep CPUs saturated."),
+        Some(6),
+    )
+    .unwrap();
     set_node_id_env("lead/env-node");
 
     let node_config = NodeConfig::load(&repo.path).unwrap();
@@ -329,8 +337,11 @@ async fn env_override_uses_session_node_id() {
     );
 
     assert_eq!(output.node_id, "lead/env-node");
-    assert_eq!(output.resource_policy, "Keep CPUs saturated.");
-    assert!(!output.is_default_policy);
+    assert_eq!(
+        output.resource_policy.as_deref(),
+        Some("Keep CPUs saturated.")
+    );
+    assert_eq!(output.sub_agents, 6);
     assert_eq!(output.rate_limit.configured_budget, DEFAULT_API_BUDGET);
 }
 
@@ -387,7 +398,8 @@ async fn pace_reports_default_policy_and_node_metrics() {
     );
 
     assert_eq!(output.node_id, "test-node");
-    assert!(output.is_default_policy);
+    assert_eq!(output.resource_policy, None);
+    assert_eq!(output.sub_agents, 1);
     assert_eq!(output.attempts_last_hour, 1);
     assert_eq!(output.attempts_last_4_hours, 1);
     assert_eq!(output.claimable_theses, 1);
@@ -483,6 +495,7 @@ async fn init_preserves_custom_api_budget() {
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
             resource_policy: None,
+            sub_agents: None,
         }),
     );
 
@@ -491,6 +504,7 @@ async fn init_preserves_custom_api_budget() {
         &InitArgs {
             node: Some("new-node".to_string()),
             resource_policy: None,
+            sub_agents: None,
         },
     )
     .await
@@ -499,6 +513,7 @@ async fn init_preserves_custom_api_budget() {
     let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
     assert_eq!(config.node_id, "lead/new-node");
     assert_eq!(config.api_budget, 1_000);
+    assert_eq!(config.sub_agents, 1);
 }
 
 #[tokio::test]
@@ -809,6 +824,71 @@ async fn claim_creates_worktree_by_default() {
         expected_branch
     );
     assert_eq!(mock.posted_issue_comments.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn batch_claim_claims_multiple_theses_and_creates_worktrees() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim");
+    init_git_repo(&repo.path);
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mut fixture_two = load_issue_fixture("acknowledged_invalid_issue.json");
+    fixture_two.issue.number = fixture_one.issue.number + 1;
+    fixture_two.issue.title = "Second thesis".to_string();
+    for comment in &mut fixture_two.comments {
+        comment.body = comment
+            .body
+            .replace("#14", "#15")
+            .replace("thesis: 14", "thesis: 15")
+            .replace("issue #14", "issue #15")
+            .replace("target: issue #14", "target: issue #15");
+    }
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
+        HashMap::from([
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: Some(2),
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+
+    commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: Some(2),
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let first_worktree = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture_one.issue.number,
+        commands::slugify(&fixture_one.issue.title)
+    ));
+    let second_worktree = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture_two.issue.number,
+        commands::slugify(&fixture_two.issue.title)
+    ));
+
+    assert!(first_worktree.exists());
+    assert!(second_worktree.exists());
+    assert_eq!(mock.posted_issue_comments.lock().unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -517,6 +517,56 @@ async fn init_preserves_custom_api_budget() {
 }
 
 #[tokio::test]
+async fn init_preserves_existing_resource_policy_when_not_specified() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("init-resource-policy");
+    let toml_path = repo.path.join(".polyresearch-node.toml");
+    fs::write(
+        &toml_path,
+        "node_id = \"old/node\"\nresource_policy = \"Keep CPUs saturated.\"\nsub_agents = 2\n",
+    )
+    .unwrap();
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Init(InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+            sub_agents: Some(8),
+        }),
+    );
+
+    commands::init::run(
+        &ctx,
+        &InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+            sub_agents: Some(8),
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
+    assert_eq!(config.node_id, "lead/new-node");
+    assert_eq!(
+        config.resource_policy.as_deref(),
+        Some("Keep CPUs saturated.")
+    );
+    assert_eq!(config.sub_agents, 8);
+}
+
+#[tokio::test]
 async fn status_and_audit_succeed_on_fixture_snapshot() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("status-audit");

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -27,9 +27,12 @@ description: >-
 7. Identify your role from your instructions or `PROGRAM.md`:
    - If told "you are the lead," follow the lead loop.
    - Otherwise, follow the contributor loop.
-8. If the repo is a fork and issues are disabled:
+8. Read `sub_agents` from `.polyresearch-node.toml` if it exists:
+   - If absent or `1`, follow the contributor loop exactly as written.
+   - If greater than `1`, use the "Contributor loop with sub-agents" section below.
+9. If the repo is a fork and issues are disabled:
    `gh api repos/{owner}/{name} --method PATCH -f has_issues=true`
-9. For any CLI command details: `polyresearch <command> --help`
+10. For any CLI command details: `polyresearch <command> --help`
 
 `POLYRESEARCH_NODE_ID` takes precedence over `.polyresearch-node.toml` for the current session. This is required when multiple agents share one checkout or when one GitHub login runs several workers in parallel.
 
@@ -110,6 +113,43 @@ LOOP FOREVER:
   5. Repeat from step 0.
 ```
 
+## Contributor loop with sub-agents
+
+Use this variant when `.polyresearch-node.toml` sets `sub_agents` greater than 1.
+
+```
+LOOP FOREVER:
+
+  0. polyresearch duties
+     Resolve BLOCKING items before continuing.
+
+  1. polyresearch pace
+     Read the current `sub_agents` setting and recent throughput.
+
+  2. polyresearch batch-claim
+     Claims up to sub_agents theses. Creates one worktree per thesis.
+
+  3. For each claimed thesis, dispatch one sub-agent:
+     - Give it the issue number and worktree path.
+     - Tell it to read PROGRAM.md and PREPARE.md.
+     - Tell it to work only in its assigned worktree.
+     - Tell it to return metric, baseline, observation, and summary.
+     - Tell it NOT to run polyresearch CLI commands.
+     - Tell it NOT to talk to GitHub.
+
+  4. Wait for all sub-agents to complete.
+
+  5. For each sub-agent result:
+     - polyresearch attempt <issue> --metric <val> --baseline <val> \
+         --observation <obs> --summary "<summary>"
+     - If observation was improved:
+         polyresearch submit <issue>
+     - Otherwise:
+         polyresearch release <issue> --reason no_improvement
+
+  6. Repeat from step 0.
+```
+
 ## The lead loop
 
 The lead runs a separate management loop from the repository root worktree,
@@ -158,16 +198,19 @@ LOOP FOREVER:
 ## Resource pacing
 
 Run `polyresearch pace` regularly. It prints your effective resource policy
-and recent throughput. If `.polyresearch-node.toml` sets a `resource_policy`,
-treat it as a real constraint. See `POLYRESEARCH.md` "Node configuration" for
-the default policy and details.
+and recent throughput. It also prints the configured `sub_agents` value. Treat
+`sub_agents` as the number of theses you should work on in parallel. If
+`.polyresearch-node.toml` sets a `resource_policy`, treat it as an additional
+constraint. See `POLYRESEARCH.md` "Node configuration" for details.
 
 ## Critical rules
 
 These rules are extracted from `POLYRESEARCH.md`. The protocol is authoritative
 if any wording differs.
 
-- Post `polyresearch attempt` after EVERY experiment. Never batch.
+- Without sub-agents, post `polyresearch attempt` after every experiment.
+- With sub-agents, post attempts after sub-agents complete. Sub-agents do not
+  post to GitHub directly.
 - Run `polyresearch submit` immediately when you observe `improved`.
   Do not "keep trying."
 - After `submit` or `release`, finish cleanup and then continue the loop from


### PR DESCRIPTION
## Summary
- add `sub_agents` node configuration and a new `polyresearch batch-claim` command for contributors using parallel sub-agents
- update `init`, `pace`, and CLI docs to reflect explicit sub-agent configuration instead of vague default resource-policy behavior
- document the hardware-utilization motivation and the two remote execution patterns in `README.md`, `POLYRESEARCH.md`, and the polyresearch skill

## Test plan
- [x] `cargo fmt`
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new contributor-side workflow that can claim and comment on multiple theses in one command, and changes node configuration semantics (`sub_agents`, resource policy optional). Moderate risk due to new protocol state mutations and updated persistence behavior for `.polyresearch-node.toml`.
> 
> **Overview**
> Adds **parallel sub-agent support** by introducing `sub_agents` in `.polyresearch-node.toml`, extending `polyresearch init` to persist/retain this value (and preserve existing `resource_policy`), and updating `polyresearch pace` output to report sub-agent count with an optional policy instead of implying a default policy.
> 
> Introduces `polyresearch batch-claim`, which selects up to N claimable approved theses, posts `polyresearch:claim` comments for each, and creates per-thesis branches/worktrees (with `--count` and `--no-worktree`), plus accompanying e2e/tests.
> 
> Updates protocol/docs (`POLYRESEARCH.md`, `README.md`, `cli/README.md`, skill) to describe the new sub-agent contributor loop and recommended remote execution patterns for keeping multi-core/GPU hardware utilized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c7377c03fb54f705793cc06e7952e2eba5ebb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->