### PR TITLE
Add multi-thesis contributor parallelism with sub-agents

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -89,20 +89,24 @@ Each node keeps a local `.polyresearch-node.toml` file at the repo root:
 
 ```toml
 node_id = "alice/mac.lan-a3f2"
-resource_policy = "8-core machine with 2 GPUs. Run up to 4 parallel evaluations. Keep GPUs saturated. Stay under 50 API calls/min."
+sub_agents = 4
+resource_policy = "18-core machine. Run 4 evaluations in parallel. Stay under 50 API calls/min."
 ```
 
 - `node_id` identifies the machine or worker. Keep it stable for the lifetime of that worker or agent session.
+- `sub_agents` is the maximum number of theses this node may work on in parallel. It should match the number of evaluations the hardware can run simultaneously without interference.
 - `resource_policy` is optional natural language guidance for that node only. It is not project state.
-- Set or update it with `polyresearch init --resource-policy "..."`.
+- Set or update it with `polyresearch init --sub-agents N --resource-policy "..."`.
 - `POLYRESEARCH_NODE_ID` overrides `node_id` for the current process. Use it when multiple agents share one checkout or when one GitHub login needs several concurrent nodes.
 - If `POLYRESEARCH_NODE_ID` is unset, the CLI falls back to `.polyresearch-node.toml`.
 
-If `resource_policy` is absent, the default policy applies:
+Sub-agents exist to improve hardware utilization. A contributor that works on one thesis at a time only runs one evaluation at a time. On a multi-core or multi-GPU machine, the rest of the hardware sits idle. When `sub_agents` is greater than 1, the contributor should keep up to that many theses in flight, one sub-agent per thesis, one worktree per thesis.
 
-> Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.
+Without sub-agents (`sub_agents = 1` or absent), follow the normal contributor loop below.
 
-Run `polyresearch pace` regularly. It prints the effective resource policy alongside recent node activity so the agent can compare expectation vs reality and adjust parallelism or claim rate.
+With sub-agents (`sub_agents > 1`), the contributor still owns the work. The contributor claims multiple theses, dispatches one sub-agent per thesis, waits for results, then posts attempt records, submits improvements, and releases non-improvements. Sub-agents do not interact with GitHub directly.
+
+Run `polyresearch pace` regularly. It prints the configured `sub_agents`, active claims, free slots, optional `resource_policy`, and recent activity so the contributor can compare intent vs. reality and adjust throughput.
 
 ---
 
@@ -120,12 +124,11 @@ Run `polyresearch duties` at the start of every loop iteration and after complet
 
 Blocking duties exist when:
 
-- A node has an active claim with no posted attempts.
 - A node has an improved attempt with no submit or release.
 - (Lead) Decidable PRs have not been decided.
 - (Lead) Open PRs have not been policy-checked.
 
-This mechanism exists because GitHub visibility is a shared resource. Other contributors, the lead, and the maintainer cannot see local-only work. A node that runs experiments without posting results is invisible to the project.
+This mechanism exists because GitHub visibility is a shared resource. Other contributors, the lead, and the maintainer cannot see local-only work. A contributor may hold up to `sub_agents` active claims. Claims with zero posted attempts are advisory, not blocking, because the claim comment itself makes the work visible on GitHub.
 
 ---
 
@@ -162,6 +165,25 @@ LOOP FOREVER:
 6. Repeat from step 0.
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
+
+### Contributor loop with sub-agents
+
+When `.polyresearch-node.toml` sets `sub_agents` greater than 1, use this variant instead of working one thesis at a time:
+
+1. Run `polyresearch duties` and resolve blocking items.
+2. Run `polyresearch pace`.
+3. Run `polyresearch batch-claim`. It fills free thesis slots up to `sub_agents` and creates one worktree per thesis.
+4. Dispatch one sub-agent per claimed thesis. Each sub-agent:
+   - Works only in its assigned worktree.
+   - Reads `PROGRAM.md` and `PREPARE.md`.
+   - Designs and runs experiments for that thesis.
+   - Returns all completed attempts, metrics, observations, and summaries to the contributor.
+   - Does not run `polyresearch` commands and does not talk to GitHub.
+5. As each sub-agent finishes its thesis, immediately post every returned attempt with `polyresearch attempt`.
+6. If a thesis improved, run `polyresearch submit` for it immediately.
+7. If a thesis did not improve, run `polyresearch release` for it.
+8. Run `git worktree remove` for finished thesis worktrees.
+9. Repeat from step 1.
 
 **NEVER STOP.** Once the loop has begun, do not pause to ask the human if you should continue. Do not ask "should I keep going?" or "is this a good stopping point?" The human might be asleep or away and expects you to work indefinitely until manually stopped. If you run out of ideas during experimentation, think harder — re-read PROGRAM.md, study results.tsv for patterns in what worked and failed, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you.
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ Do polyresearch on https://github.com/owner/repo.
 
 The agent clones the repo, claims work from the issue queue, runs experiments, and submits results in a loop until you stop it. Launch as many contributor agents as you have machines.
 
+### Hardware utilization
+
+A single contributor agent working on one thesis at a time only runs one evaluation at a time. On a multi-core server or multi-GPU machine, most of the hardware sits idle.
+
+Polyresearch can use sub-agents to keep that hardware busy. Set `sub_agents` in `.polyresearch-node.toml` to the number of evaluations the machine can run at once. The contributor then keeps up to that many theses in flight, one sub-agent per thesis, and posts results as each thesis finishes. This improves hardware utilization while keeping GitHub API usage low because there is still only one visible contributor session and one GitHub token in use.
+
 ### Run on a remote machine
 
-The agent runs on your local machine. The experiments run on a remote server (e.g. a cloud instance with GPUs). Set up the repo, CLI, and `gh` auth on the remote, then tell your agent:
+#### Pattern A: Remote evaluation over SSH
+
+The contributor runs on your local machine. The experiments run on a remote server. Set up the repo, CLI, and `gh` auth on the remote, then tell your agent:
 
 ```
 Do polyresearch on https://github.com/owner/repo.
@@ -68,6 +76,21 @@ Run all evaluations and experiments over SSH on user@remote-host.
 ```
 
 Your local machine only needs the agent; the remote server does the compute.
+
+#### Pattern B: Run the contributor on the server
+
+This is the recommended pattern for sub-agents. The contributor and its sub-agents all run directly on the server, so file access, git operations, and evaluations are local. There is no SSH relay in the middle.
+
+Use `tmux` so the session survives disconnects:
+
+```bash
+ssh user@remote-host
+tmux new-session -s polyresearch
+claude -p "Do polyresearch on https://github.com/owner/repo."
+# Detach with Ctrl-B D. Reconnect with: tmux attach -t polyresearch
+```
+
+Detaching means the process keeps running after your SSH session closes. `tmux` creates a persistent terminal session on the server. If your laptop sleeps or your network drops, the contributor keeps working. Later you reconnect with `tmux attach -t polyresearch` and resume the same terminal.
 
 ## CLI
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,10 +80,10 @@ Initialize the local node identity once per repo:
 
 ```bash
 polyresearch init
-polyresearch init --resource-policy "2 GPUs, run up to 4 evals in parallel, stay under 50 API calls/min"
+polyresearch init --sub-agents 4 --resource-policy "Run 4 evals in parallel, stay under 50 API calls/min"
 ```
 
-This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` plus an optional natural-language `resource_policy`. If no policy is set, the protocol default is to maximize throughput.
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id`, a `sub_agents` limit, and an optional natural-language `resource_policy`.
 
 Inspect the current state:
 
@@ -103,9 +103,12 @@ polyresearch claim 88
 polyresearch attempt 88 --metric 0.6244 --baseline 0.5000 --observation improved --summary "River all-in with two pair+"
 polyresearch submit 88
 polyresearch release 88 --reason no_improvement
+polyresearch batch-claim
 ```
 
 By default, `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. Pass `--no-worktree` only if you intentionally want the legacy single-working-tree checkout flow.
+
+`polyresearch batch-claim` is the multi-thesis version for contributors using sub-agents. It fills the node's free thesis slots up to `sub_agents`, creates one worktree per thesis, and requires worktrees for parallel execution.
 
 Review flow:
 
@@ -145,11 +148,12 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 ## Command summary
 
-- `polyresearch init` -- set node identity, optional resource policy, verify GitHub auth, detect repo
-- `polyresearch pace` -- show the effective resource policy alongside recent node throughput
+- `polyresearch init` -- set node identity, sub-agent limit, optional resource policy, verify GitHub auth, detect repo
+- `polyresearch pace` -- show configured sub-agents, active claims, free slots, effective resource policy, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
 - `polyresearch claim` -- atomically claim a thesis and create the thesis worktree (or a branch with `--no-worktree`)
+- `polyresearch batch-claim` -- claim up to the node's free thesis slots and create one worktree per thesis
 - `polyresearch attempt` -- post a structured attempt comment from the current branch
 - `polyresearch release` -- release a claim with a structured reason
 - `polyresearch submit` -- push the branch and open a candidate PR

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -26,6 +26,7 @@ pub enum Commands {
     Pace,
     Status(StatusArgs),
     Claim(IssueArgs),
+    BatchClaim(BatchClaimArgs),
     Attempt(AttemptArgs),
     Annotate(AnnotateArgs),
     Release(ReleaseArgs),
@@ -49,6 +50,9 @@ pub struct InitArgs {
 
     #[arg(long)]
     pub resource_policy: Option<String>,
+
+    #[arg(long)]
+    pub sub_agents: Option<usize>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -60,6 +64,15 @@ pub struct StatusArgs {
 #[derive(Debug, Args, Clone)]
 pub struct IssueArgs {
     pub issue: u64,
+
+    #[arg(long)]
+    pub no_worktree: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct BatchClaimArgs {
+    #[arg(long)]
+    pub count: Option<usize>,
 
     #[arg(long)]
     pub no_worktree: bool,

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -45,6 +45,9 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
     let sub_agents = configured_sub_agents(&ctx.repo_root);
     let active_claims = node_active_claims(&repo_state, &node);
     let available_slots = sub_agents.saturating_sub(active_claims);
+    if matches!(args.count, Some(0)) {
+        return Err(eyre!("batch-claim count must be at least 1"));
+    }
     let requested = args.count.unwrap_or(available_slots);
     let claim_count = requested.min(available_slots);
 

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -88,7 +88,25 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
 
     let mut claims = Vec::with_capacity(theses.len());
     for thesis in theses {
-        claims.push(claim_selected_thesis(ctx, thesis, &node, false)?);
+        match claim_selected_thesis(ctx, thesis, &node, false) {
+            Ok(claim) => claims.push(claim),
+            Err(error) => {
+                if claims.is_empty() {
+                    return Err(error);
+                }
+                let claimed = claims
+                    .iter()
+                    .map(|claim| format!("#{}", claim.issue))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(eyre!(
+                    "batch-claim partially succeeded; claimed theses {} before failing on thesis #{}: {}",
+                    claimed,
+                    thesis.issue.number,
+                    error
+                ));
+            }
+        }
     }
 
     let output = BatchClaimOutput {

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -1,0 +1,153 @@
+use color_eyre::eyre::{Result, eyre};
+use serde::Serialize;
+
+use crate::cli::BatchClaimArgs;
+use crate::commands::claim::{ClaimOutput, claim_selected_thesis};
+use crate::commands::duties;
+use crate::commands::{
+    AppContext, configured_sub_agents, node_active_claims, print_value, read_node_id,
+};
+use crate::state::{RepositoryState, ThesisPhase, ThesisState};
+
+#[derive(Debug, Serialize)]
+struct BatchClaimOutput {
+    node: String,
+    sub_agents: usize,
+    active_claims: usize,
+    claimed_count: usize,
+    free_slots: usize,
+    claims: Vec<ClaimOutput>,
+}
+
+pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
+    if args.no_worktree {
+        return Err(eyre!(
+            "batch-claim requires separate worktrees; `--no-worktree` is not supported"
+        ));
+    }
+
+    let node = read_node_id(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+
+    let duty_report = duties::check(ctx, &repo_state)?;
+    if !duty_report.blocking.is_empty() {
+        let items: Vec<String> = duty_report
+            .blocking
+            .iter()
+            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
+            .collect();
+        return Err(eyre!(
+            "cannot batch-claim while blocking duties exist:\n{}",
+            items.join("\n")
+        ));
+    }
+
+    let sub_agents = configured_sub_agents(&ctx.repo_root);
+    let active_claims = node_active_claims(&repo_state, &node);
+    let available_slots = sub_agents.saturating_sub(active_claims);
+    let requested = args.count.unwrap_or(available_slots);
+    let claim_count = requested.min(available_slots);
+
+    if claim_count == 0 {
+        let output = BatchClaimOutput {
+            node: node.clone(),
+            sub_agents,
+            active_claims,
+            claimed_count: 0,
+            free_slots: 0,
+            claims: Vec::new(),
+        };
+        return print_value(ctx, &output, |value| {
+            format!(
+                "Node `{}` is already at capacity ({}/{} active claims). No new theses claimed.",
+                value.node, value.active_claims, value.sub_agents
+            )
+        });
+    }
+
+    let theses = select_claimable_theses(&repo_state, &node, claim_count);
+    if theses.is_empty() {
+        let output = BatchClaimOutput {
+            node: node.clone(),
+            sub_agents,
+            active_claims,
+            claimed_count: 0,
+            free_slots: available_slots,
+            claims: Vec::new(),
+        };
+        return print_value(ctx, &output, |value| {
+            format!(
+                "No claimable theses available for node `{}`. Free slots remaining: {}.",
+                value.node, value.free_slots
+            )
+        });
+    }
+
+    let mut claims = Vec::with_capacity(theses.len());
+    for thesis in theses {
+        claims.push(claim_selected_thesis(ctx, thesis, &node, false)?);
+    }
+
+    let output = BatchClaimOutput {
+        node: node.clone(),
+        sub_agents,
+        active_claims,
+        claimed_count: claims.len(),
+        free_slots: available_slots.saturating_sub(claims.len()),
+        claims,
+    };
+
+    print_value(ctx, &output, |value| {
+        let header = if ctx.cli.dry_run {
+            format!(
+                "Would claim {} thesis slots for node `{}` ({} active, {} free after).",
+                value.claimed_count, value.node, value.active_claims, value.free_slots
+            )
+        } else {
+            format!(
+                "Claimed {} thesis slots for node `{}` ({} active before, {} free after).",
+                value.claimed_count, value.node, value.active_claims, value.free_slots
+            )
+        };
+        let lines = value
+            .claims
+            .iter()
+            .map(|entry| {
+                format!(
+                    "  - thesis #{} on branch `{}` in worktree `{}`",
+                    entry.issue,
+                    entry.branch,
+                    entry
+                        .worktree_path
+                        .as_deref()
+                        .unwrap_or("<missing worktree>")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if lines.is_empty() {
+            header
+        } else {
+            format!("{header}\n{lines}")
+        }
+    })
+}
+
+fn select_claimable_theses<'a>(
+    repo_state: &'a RepositoryState,
+    node: &str,
+    count: usize,
+) -> Vec<&'a ThesisState> {
+    let mut theses = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| thesis.issue.state == "OPEN")
+        .filter(|thesis| thesis.approved)
+        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
+        .filter(|thesis| thesis.active_claims.is_empty())
+        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
+        .collect::<Vec<_>>();
+    theses.sort_by_key(|thesis| thesis.issue.number);
+    theses.truncate(count);
+    theses
+}

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -5,18 +5,18 @@ use crate::cli::IssueArgs;
 use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
 use crate::commands::{
-    AppContext, create_thesis_branch, create_thesis_worktree, print_value, read_node_id, slugify,
-    thesis_worktree_path,
+    AppContext, configured_sub_agents, create_thesis_branch, create_thesis_worktree,
+    node_active_claims, print_value, read_node_id, slugify, thesis_worktree_path,
 };
 use crate::comments::ProtocolComment;
-use crate::state::RepositoryState;
+use crate::state::{RepositoryState, ThesisState};
 
 #[derive(Debug, Serialize)]
-struct ClaimOutput {
-    issue: u64,
-    node: String,
-    branch: String,
-    worktree_path: Option<String>,
+pub(crate) struct ClaimOutput {
+    pub issue: u64,
+    pub node: String,
+    pub branch: String,
+    pub worktree_path: Option<String>,
 }
 
 pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
@@ -36,6 +36,16 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
     let thesis = require_claimable_thesis(&repo_state, args.issue)?;
+    let active_claims = node_active_claims(&repo_state, &node);
+    let sub_agents = configured_sub_agents(&ctx.repo_root);
+    if active_claims >= sub_agents {
+        return Err(eyre!(
+            "node `{}` is already at configured sub-agent capacity ({}/{} active claims)",
+            node,
+            active_claims,
+            sub_agents
+        ));
+    }
     if !thesis.active_claims.is_empty() {
         let nodes = thesis
             .active_claims
@@ -50,47 +60,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
 
-    let (branch, worktree_path) = if ctx.cli.dry_run {
-        let branch = format!(
-            "thesis/{}-{}",
-            thesis.issue.number,
-            slugify(&thesis.issue.title)
-        );
-        let worktree_path = (!args.no_worktree).then(|| {
-            thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)
-                .display()
-                .to_string()
-        });
-        (branch, worktree_path)
-    } else if args.no_worktree {
-        (
-            create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?,
-            None,
-        )
-    } else {
-        let workspace =
-            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
-        (
-            workspace.branch,
-            Some(workspace.worktree_path.display().to_string()),
-        )
-    };
-
-    let comment = ProtocolComment::Claim {
-        thesis: thesis.issue.number,
-        node: node.clone(),
-    };
-    if !ctx.cli.dry_run {
-        ctx.github
-            .post_issue_comment(thesis.issue.number, &comment.render())?;
-    }
-
-    let output = ClaimOutput {
-        issue: thesis.issue.number,
-        node,
-        branch,
-        worktree_path,
-    };
+    let output = claim_selected_thesis(ctx, thesis, &node, args.no_worktree)?;
 
     print_value(ctx, &output, |value| {
         match (&value.worktree_path, ctx.cli.dry_run) {
@@ -111,5 +81,54 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
                 value.issue, value.node, value.branch
             ),
         }
+    })
+}
+
+pub(crate) fn claim_selected_thesis(
+    ctx: &AppContext,
+    thesis: &ThesisState,
+    node: &str,
+    no_worktree: bool,
+) -> Result<ClaimOutput> {
+    let (branch, worktree_path) = if ctx.cli.dry_run {
+        let branch = format!(
+            "thesis/{}-{}",
+            thesis.issue.number,
+            slugify(&thesis.issue.title)
+        );
+        let worktree_path = (!no_worktree).then(|| {
+            thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)
+                .display()
+                .to_string()
+        });
+        (branch, worktree_path)
+    } else if no_worktree {
+        (
+            create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?,
+            None,
+        )
+    } else {
+        let workspace =
+            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
+        (
+            workspace.branch,
+            Some(workspace.worktree_path.display().to_string()),
+        )
+    };
+
+    let comment = ProtocolComment::Claim {
+        thesis: thesis.issue.number,
+        node: node.to_string(),
+    };
+    if !ctx.cli.dry_run {
+        ctx.github
+            .post_issue_comment(thesis.issue.number, &comment.render())?;
+    }
+
+    Ok(ClaimOutput {
+        issue: thesis.issue.number,
+        node: node.to_string(),
+        branch,
+        worktree_path,
     })
 }

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -1,7 +1,9 @@
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
-use crate::commands::{AppContext, print_value, read_node_id};
+use crate::commands::{
+    AppContext, configured_sub_agents, node_active_claims, print_value, read_node_id,
+};
 use crate::comments::Observation;
 use crate::ledger::Ledger;
 use crate::state::{RepositoryState, ThesisPhase};
@@ -32,6 +34,12 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
 
     let mut blocking = Vec::new();
     let mut advisory = Vec::new();
+    let sub_agents = configured_sub_agents(&ctx.repo_root);
+    let active_claims = if node_id.is_empty() {
+        0
+    } else {
+        node_active_claims(repo_state, &node_id)
+    };
 
     for thesis in &repo_state.theses {
         if thesis.issue.state != "OPEN" {
@@ -55,10 +63,10 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
             .collect();
 
         if my_attempts.is_empty() {
-            blocking.push(DutyItem {
-                category: "claim".to_string(),
+            advisory.push(DutyItem {
+                category: "attempt".to_string(),
                 message: format!(
-                    "Thesis #{}: claimed with 0 attempts posted.",
+                    "Thesis #{}: claimed with 0 attempts posted yet.",
                     thesis.issue.number
                 ),
                 command: format!(
@@ -90,6 +98,13 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
 
     let has_review_work = check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
     if !is_lead {
+        add_contributor_capacity_advisory(
+            repo_state,
+            &node_id,
+            sub_agents,
+            active_claims,
+            &mut advisory,
+        );
         check_contributor_idle_state(ctx, repo_state, &node_id, has_review_work, &mut advisory)?;
     }
 
@@ -349,6 +364,48 @@ fn check_contributor_idle_state(
     }
 
     Ok(())
+}
+
+fn add_contributor_capacity_advisory(
+    repo_state: &RepositoryState,
+    node_id: &str,
+    sub_agents: usize,
+    active_claims: usize,
+    advisory: &mut Vec<DutyItem>,
+) {
+    if node_id.is_empty() || sub_agents <= 1 {
+        return;
+    }
+
+    let free_slots = sub_agents.saturating_sub(active_claims);
+    if free_slots == 0 {
+        return;
+    }
+
+    let claimable_for_me = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| thesis.issue.state == "OPEN")
+        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
+        .filter(|thesis| {
+            !thesis
+                .releases
+                .iter()
+                .any(|release| release.node == node_id)
+        })
+        .count();
+    if claimable_for_me == 0 {
+        return;
+    }
+
+    advisory.push(DutyItem {
+        category: "capacity".to_string(),
+        message: format!(
+            "Free parallel slots: {} ({} active claims, sub_agents = {}).",
+            free_slots, active_claims, sub_agents
+        ),
+        command: format!("polyresearch batch-claim --count {}", free_slots),
+    });
 }
 
 fn metric_floor_info(ctx: &AppContext, repo_state: &RepositoryState) -> Option<(f64, f64)> {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -6,8 +6,8 @@ use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::InitArgs;
-use crate::commands::{AppContext, print_value, write_node_config};
-use crate::config::DEFAULT_RESOURCE_POLICY;
+use crate::commands::{AppContext, print_value, read_node_config, write_node_config};
+use crate::config::{DEFAULT_RESOURCE_POLICY, DEFAULT_SUB_AGENTS};
 
 #[derive(Debug, Serialize)]
 struct InitOutput {
@@ -17,10 +17,11 @@ struct InitOutput {
     resource_policy: Option<String>,
     effective_resource_policy: String,
     is_default_policy: bool,
+    sub_agents: usize,
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
-    let resource_policy = args
+    let requested_resource_policy = args
         .resource_policy
         .as_ref()
         .map(|value| value.trim())
@@ -31,6 +32,17 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let _ = ctx.github.auth_token()?;
     let machine_id = args.node.clone().unwrap_or_else(default_machine_id);
     let node = format!("{login}/{machine_id}");
+    let existing_config = read_node_config(&ctx.repo_root).ok();
+    let resource_policy = requested_resource_policy.or_else(|| {
+        existing_config
+            .as_ref()
+            .and_then(|config| config.resource_policy.clone())
+    });
+    let existing_sub_agents = existing_config
+        .as_ref()
+        .map(|config| config.sub_agents)
+        .unwrap_or(DEFAULT_SUB_AGENTS);
+    let sub_agents = args.sub_agents.unwrap_or(existing_sub_agents).max(1);
 
     if let Ok(false) = ctx.github.repo_has_issues() {
         eprintln!("Warning: Issues are disabled on this repository (common for forks).");
@@ -41,7 +53,12 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     }
 
     if !ctx.cli.dry_run {
-        write_node_config(&ctx.repo_root, &node, resource_policy.as_deref())?;
+        write_node_config(
+            &ctx.repo_root,
+            &node,
+            resource_policy.as_deref(),
+            Some(sub_agents),
+        )?;
     }
 
     let (effective_resource_policy, is_default_policy) = match &resource_policy {
@@ -56,6 +73,7 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
         resource_policy,
         effective_resource_policy,
         is_default_policy,
+        sub_agents,
     };
 
     print_value(ctx, &output, |value| {
@@ -68,6 +86,7 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
         } else {
             text.push_str(" Saved the custom resource policy.");
         }
+        text.push_str(&format!(" Sub-agents: {}.", value.sub_agents));
         text
     })
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod annotate;
 pub mod attempt;
 pub mod audit;
+pub mod batch_claim;
 pub mod claim;
 pub mod decide;
 pub mod duties;
@@ -27,8 +28,9 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
+use crate::config::{DEFAULT_SUB_AGENTS, NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
+use crate::state::RepositoryState;
 
 #[derive(Clone)]
 pub struct AppContext {
@@ -61,6 +63,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Pace => pace::run(&ctx).await,
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
+        Commands::BatchClaim(args) => batch_claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,
         Commands::Annotate(args) => annotate::run(&ctx, args).await,
         Commands::Release(args) => release::run(&ctx, args).await,
@@ -107,21 +110,52 @@ pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
 }
 
 pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
-    write_node_config(repo_root, node, None)
+    write_node_config(repo_root, node, None, None)
 }
 
 pub fn write_node_config(
     repo_root: &PathBuf,
     node: &str,
     resource_policy: Option<&str>,
+    sub_agents: Option<usize>,
 ) -> Result<()> {
-    let existing_budget = NodeConfig::load_api_budget(repo_root);
+    let existing = NodeConfig::load(repo_root).ok();
+    let existing_resource_policy = existing
+        .as_ref()
+        .and_then(|config| config.resource_policy.as_deref())
+        .map(ToString::to_string);
+    let existing_budget = existing
+        .as_ref()
+        .map(|config| config.api_budget)
+        .unwrap_or_else(|| NodeConfig::load_api_budget(repo_root));
+    let existing_sub_agents = existing
+        .as_ref()
+        .map(|config| config.sub_agents)
+        .unwrap_or(DEFAULT_SUB_AGENTS);
     NodeConfig::new(
         node.to_string(),
-        resource_policy.map(ToString::to_string),
+        resource_policy
+            .map(ToString::to_string)
+            .or(existing_resource_policy),
         existing_budget,
+        sub_agents.unwrap_or(existing_sub_agents),
     )
     .save(repo_root)
+}
+
+pub fn configured_sub_agents(repo_root: &PathBuf) -> usize {
+    read_node_config(repo_root)
+        .map(|config| config.sub_agents)
+        .unwrap_or(DEFAULT_SUB_AGENTS)
+}
+
+pub fn node_active_claims(repo_state: &RepositoryState, node_id: &str) -> usize {
+    repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| thesis.active_claims.iter())
+        .filter(|claim| claim.node == node_id)
+        .count()
 }
 
 pub fn current_branch(repo_root: &PathBuf) -> Result<String> {

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Duration, Utc};
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
-use crate::commands::{AppContext, exit_with, print_value, read_node_config};
+use crate::commands::{AppContext, exit_with, node_active_claims, print_value, read_node_config};
 use crate::config::NodeConfig;
 use crate::github::RateLimitStatus;
 use crate::state::{RepositoryState, ThesisPhase};
@@ -15,6 +15,7 @@ pub struct PaceOutput {
     pub node_id: String,
     pub resource_policy: String,
     pub is_default_policy: bool,
+    pub sub_agents: usize,
     pub api_budget: u64,
     pub rate_limit: PaceRateLimit,
     pub attempts_last_hour: usize,
@@ -22,6 +23,7 @@ pub struct PaceOutput {
     pub idle_minutes: Option<i64>,
     pub claimable_theses: usize,
     pub active_claims: usize,
+    pub free_slots: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,7 +72,7 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             })
             .unwrap_or_else(|| "unknown".to_string());
         rendered.push_str(&format!(
-            "\n\nAPI budget:\n  Configured budget:           {}/hr\n  GitHub core limit:           {}/hr\n  Remaining quota:             {}\n  Used quota:                  {}\n  Resets at:                   {}\n  Cost per command:            {} calls ({} issues + {} PRs + 2 lists)\n  Commands left:               ~{}\n  Near limit:                  {}\n\nThroughput ({}):\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}\n  Active claims:               {}",
+            "\n\nAPI budget:\n  Configured budget:           {}/hr\n  GitHub core limit:           {}/hr\n  Remaining quota:             {}\n  Used quota:                  {}\n  Resets at:                   {}\n  Cost per command:            {} calls ({} issues + {} PRs + 2 lists)\n  Commands left:               ~{}\n  Near limit:                  {}\n\nThroughput ({}):\n  Configured sub-agents:       {}\n  Active claims:               {}\n  Free slots:                  {}\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}",
             value.rate_limit.configured_budget,
             value.rate_limit.limit,
             value.rate_limit.remaining,
@@ -82,11 +84,13 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             value.rate_limit.commands_left,
             if value.rate_limit.is_low { "yes" } else { "no" },
             value.node_id,
+            value.sub_agents,
+            value.active_claims,
+            value.free_slots,
             value.attempts_last_hour,
             value.attempts_last_4_hours,
             idle,
-            value.claimable_theses,
-            value.active_claims
+            value.claimable_theses
         ));
         rendered
     })?;
@@ -146,12 +150,8 @@ pub fn build_output(
             thesis.issue.state == "OPEN" && matches!(thesis.phase, ThesisPhase::Approved)
         })
         .count();
-    let active_claims = repo_state
-        .theses
-        .iter()
-        .flat_map(|thesis| thesis.active_claims.iter())
-        .filter(|claim| claim.node == node_id)
-        .count();
+    let active_claims = node_active_claims(repo_state, &node_id);
+    let free_slots = node_config.sub_agents.saturating_sub(active_claims);
     let idle_minutes = last_activity(repo_state, &node_id)
         .map(|timestamp| now.signed_duration_since(timestamp).num_minutes().max(0));
     let issue_count = repo_state.theses.len();
@@ -163,6 +163,7 @@ pub fn build_output(
         node_id,
         resource_policy: resource_policy.to_string(),
         is_default_policy,
+        sub_agents: node_config.sub_agents,
         api_budget,
         rate_limit: PaceRateLimit {
             configured_budget: api_budget,
@@ -181,6 +182,7 @@ pub fn build_output(
         idle_minutes,
         claimable_theses,
         active_claims,
+        free_slots,
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
 pub const DEFAULT_API_BUDGET: u64 = 5_000;
+pub const DEFAULT_SUB_AGENTS: usize = 1;
 pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -26,6 +27,8 @@ pub struct NodeConfig {
     pub resource_policy: Option<String>,
     #[serde(default = "default_api_budget")]
     pub api_budget: u64,
+    #[serde(default = "default_sub_agents")]
+    pub sub_agents: usize,
 }
 
 impl NodeConfig {
@@ -33,11 +36,13 @@ impl NodeConfig {
         node_id: impl Into<String>,
         resource_policy: Option<String>,
         api_budget: u64,
+        sub_agents: usize,
     ) -> Self {
         Self {
             node_id: node_id.into(),
             resource_policy: normalize_resource_policy(resource_policy),
             api_budget: normalize_api_budget(api_budget),
+            sub_agents: normalize_sub_agents(sub_agents),
         }
     }
 
@@ -75,8 +80,12 @@ impl NodeConfig {
             .as_ref()
             .map(|config| config.api_budget)
             .unwrap_or(DEFAULT_API_BUDGET);
+        let sub_agents = file_config
+            .as_ref()
+            .map(|config| config.sub_agents)
+            .unwrap_or(DEFAULT_SUB_AGENTS);
 
-        Ok(Self::new(node_id, resource_policy, api_budget))
+        Ok(Self::new(node_id, resource_policy, api_budget, sub_agents))
     }
 
     pub fn load_api_budget(repo_root: &Path) -> u64 {
@@ -128,6 +137,10 @@ fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
 
 fn default_api_budget() -> u64 {
     DEFAULT_API_BUDGET
+}
+
+fn default_sub_agents() -> usize {
+    DEFAULT_SUB_AGENTS
 }
 
 fn node_id_override() -> Option<String> {
@@ -556,6 +569,7 @@ mod tests {
             r#"node_id = "node-7f83"
 resource_policy = "Run 4 evals in parallel."
 api_budget = 15000
+sub_agents = 6
 "#,
         )
         .unwrap();
@@ -567,6 +581,7 @@ api_budget = 15000
             Some("Run 4 evals in parallel.")
         );
         assert_eq!(config.api_budget, 15_000);
+        assert_eq!(config.sub_agents, 6);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -591,6 +606,7 @@ resource_policy = "Run 4 evals in parallel."
             config.resource_policy.as_deref(),
             Some("Run 4 evals in parallel.")
         );
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -604,6 +620,7 @@ resource_policy = "Run 4 evals in parallel."
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -619,13 +636,14 @@ resource_policy = "Run 4 evals in parallel."
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
         assert_eq!(config.resource_policy, None);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
     fn defaults_resource_policy_when_missing() {
-        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET);
+        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET, DEFAULT_SUB_AGENTS);
         let (policy, is_default) = config.effective_resource_policy();
         assert!(is_default);
         assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
@@ -633,8 +651,14 @@ resource_policy = "Run 4 evals in parallel."
 
     #[test]
     fn defaults_api_budget_when_missing() {
-        let config = NodeConfig::new("node-7f83", None, 0);
+        let config = NodeConfig::new("node-7f83", None, 0, DEFAULT_SUB_AGENTS);
         assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
+    }
+
+    #[test]
+    fn defaults_sub_agents_when_zero() {
+        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET, 0);
+        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
     }
 
     #[test]
@@ -800,6 +824,13 @@ fn normalize_resource_policy(resource_policy: Option<String>) -> Option<String> 
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+fn normalize_sub_agents(sub_agents: usize) -> usize {
+    match sub_agents {
+        0 => DEFAULT_SUB_AGENTS,
+        value => value,
+    }
 }
 
 fn normalize_api_budget(api_budget: u64) -> u64 {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -948,6 +948,79 @@ async fn batch_claim_fills_remaining_capacity_only() {
 }
 
 #[tokio::test]
+async fn batch_claim_reports_partial_success_when_later_claim_fails() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim-partial");
+    init_git_repo(&repo.path);
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mut fixture_two = load_issue_fixture("acknowledged_invalid_issue.json");
+    fixture_two.issue.number = fixture_one.issue.number + 1;
+    fixture_two.issue.title = "Second thesis".to_string();
+    for comment in &mut fixture_two.comments {
+        comment.body = comment
+            .body
+            .replace("#14", "#15")
+            .replace("thesis: 14", "thesis: 15")
+            .replace("issue #14", "issue #15")
+            .replace("target: issue #14", "target: issue #15");
+    }
+    let blocking_worktree = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture_two.issue.number,
+        commands::slugify(&fixture_two.issue.title)
+    ));
+    fs::create_dir_all(&blocking_worktree).unwrap();
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
+        HashMap::from([
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: Some(2),
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+
+    let error = commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: Some(2),
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("partially succeeded"));
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("#{}", fixture_one.issue.number))
+    );
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("#{}", fixture_two.issue.number))
+    );
+    assert_eq!(
+        mock.posted_issue_comments.lock().unwrap().len(),
+        1,
+        "first claim should have been posted before the second claim failed"
+    );
+}
+
+#[tokio::test]
 async fn batch_claim_rejects_no_worktree() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("batch-claim-no-worktree");

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -985,6 +985,43 @@ async fn batch_claim_rejects_no_worktree() {
 }
 
 #[tokio::test]
+async fn batch_claim_rejects_zero_count() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim-zero");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        true,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: Some(0),
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+
+    let error = commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: Some(0),
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("count must be at least 1"));
+}
+
+#[tokio::test]
 async fn batch_claim_noops_when_already_at_capacity() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("batch-claim-capacity");

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch_cli::cli::{
-    AttemptArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
+    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
 };
 use polyresearch_cli::commands;
 use polyresearch_cli::comments::{Observation, ReleaseReason};
@@ -234,7 +234,7 @@ struct NodeIdEnvGuard {
 
 impl NodeIdEnvGuard {
     fn lock_clean() -> Self {
-        let guard = env_lock().lock().unwrap();
+        let guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
         clear_node_id_env();
         Self { _guard: guard }
     }
@@ -277,6 +277,7 @@ async fn init_writes_node_identity() {
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
             resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
+            sub_agents: Some(4),
         }),
     );
 
@@ -285,6 +286,7 @@ async fn init_writes_node_identity() {
         &InitArgs {
             node: Some("test-node".to_string()),
             resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
+            sub_agents: Some(4),
         },
     )
     .await
@@ -298,6 +300,7 @@ async fn init_writes_node_identity() {
         Some("Use 2 GPUs and keep them busy.")
     );
     assert_eq!(config.api_budget, DEFAULT_API_BUDGET);
+    assert_eq!(config.sub_agents, 4);
 }
 
 #[tokio::test]
@@ -312,8 +315,13 @@ async fn env_override_uses_session_node_id() {
         HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
-    commands::write_node_config(&repo.path, "lead/file-node", Some("Keep CPUs saturated."))
-        .unwrap();
+    commands::write_node_config(
+        &repo.path,
+        "lead/file-node",
+        Some("Keep CPUs saturated."),
+        Some(6),
+    )
+    .unwrap();
     set_node_id_env("lead/env-node");
 
     let node_config = NodeConfig::load(&repo.path).unwrap();
@@ -331,6 +339,8 @@ async fn env_override_uses_session_node_id() {
     assert_eq!(output.node_id, "lead/env-node");
     assert_eq!(output.resource_policy, "Keep CPUs saturated.");
     assert!(!output.is_default_policy);
+    assert_eq!(output.sub_agents, 6);
+    assert_eq!(output.free_slots, 6);
     assert_eq!(output.rate_limit.configured_budget, DEFAULT_API_BUDGET);
 }
 
@@ -392,6 +402,8 @@ async fn pace_reports_default_policy_and_node_metrics() {
     assert_eq!(output.attempts_last_4_hours, 1);
     assert_eq!(output.claimable_theses, 1);
     assert_eq!(output.active_claims, 2);
+    assert_eq!(output.sub_agents, 1);
+    assert_eq!(output.free_slots, 0);
     assert_eq!(output.idle_minutes, Some(0));
     assert_eq!(output.rate_limit.derive_cost, 5);
     assert_eq!(output.rate_limit.commands_left, 769);
@@ -483,6 +495,7 @@ async fn init_preserves_custom_api_budget() {
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
             resource_policy: None,
+            sub_agents: None,
         }),
     );
 
@@ -491,6 +504,7 @@ async fn init_preserves_custom_api_budget() {
         &InitArgs {
             node: Some("new-node".to_string()),
             resource_policy: None,
+            sub_agents: None,
         },
     )
     .await
@@ -499,6 +513,57 @@ async fn init_preserves_custom_api_budget() {
     let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
     assert_eq!(config.node_id, "lead/new-node");
     assert_eq!(config.api_budget, 1_000);
+    assert_eq!(config.sub_agents, 1);
+}
+
+#[tokio::test]
+async fn init_preserves_existing_resource_policy_and_updates_sub_agents() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("init-resource-policy");
+    let toml_path = repo.path.join(".polyresearch-node.toml");
+    fs::write(
+        &toml_path,
+        "node_id = \"old/node\"\nresource_policy = \"Keep CPUs saturated.\"\nsub_agents = 2\n",
+    )
+    .unwrap();
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Init(InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+            sub_agents: Some(8),
+        }),
+    );
+
+    commands::init::run(
+        &ctx,
+        &InitArgs {
+            node: Some("new-node".to_string()),
+            resource_policy: None,
+            sub_agents: Some(8),
+        },
+    )
+    .await
+    .unwrap();
+
+    let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
+    assert_eq!(config.node_id, "lead/new-node");
+    assert_eq!(
+        config.resource_policy.as_deref(),
+        Some("Keep CPUs saturated.")
+    );
+    assert_eq!(config.sub_agents, 8);
 }
 
 #[tokio::test]
@@ -812,6 +877,158 @@ async fn claim_creates_worktree_by_default() {
 }
 
 #[tokio::test]
+async fn batch_claim_fills_remaining_capacity_only() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim");
+    init_git_repo(&repo.path);
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mut fixture_two = load_issue_fixture("acknowledged_invalid_issue.json");
+    fixture_two.issue.number = fixture_one.issue.number + 1;
+    fixture_two.issue.title = "Second thesis".to_string();
+    for comment in &mut fixture_two.comments {
+        comment.body = comment
+            .body
+            .replace("#14", "#15")
+            .replace("thesis: 14", "thesis: 15")
+            .replace("issue #14", "issue #15")
+            .replace("target: issue #14", "target: issue #15");
+    }
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![
+            fixture_claimed.issue.clone(),
+            fixture_one.issue.clone(),
+            fixture_two.issue.clone(),
+        ],
+        HashMap::from([
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: None,
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
+
+    commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: None,
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let first_worktree = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture_one.issue.number,
+        commands::slugify(&fixture_one.issue.title)
+    ));
+    assert!(first_worktree.exists());
+    assert_eq!(
+        mock.posted_issue_comments.lock().unwrap().len(),
+        1,
+        "should only claim one additional thesis because one slot was already occupied"
+    );
+}
+
+#[tokio::test]
+async fn batch_claim_rejects_no_worktree() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim-no-worktree");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        true,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: Some(1),
+            no_worktree: true,
+        }),
+    );
+    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+
+    let error = commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: Some(1),
+            no_worktree: true,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("requires separate worktrees"));
+}
+
+#[tokio::test]
+async fn batch_claim_noops_when_already_at_capacity() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("batch-claim-capacity");
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
+        HashMap::from([
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
+            (fixture_open.issue.number, fixture_open.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_open.lead_github_login,
+        false,
+        Commands::BatchClaim(BatchClaimArgs {
+            count: None,
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
+
+    commands::batch_claim::run(
+        &ctx,
+        &BatchClaimArgs {
+            count: None,
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn prune_removes_empty_stale_worktree_directories() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("prune-worktrees");
@@ -939,7 +1156,7 @@ fn observation_value_enum_accepts_snake_case() {
 // --- B5: Duties command ---
 
 #[tokio::test]
-async fn duties_reports_blocking_when_claim_has_no_attempts() {
+async fn duties_reports_advisory_when_claim_has_no_attempts() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-claim");
     let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
@@ -963,10 +1180,9 @@ async fn duties_reports_blocking_when_claim_has_no_attempts() {
         .await
         .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
-    assert!(!report.clean, "should have blocking duties");
     assert!(
-        report.blocking.iter().any(|d| d.category == "claim"),
-        "should report a claim-related blocking duty"
+        report.advisory.iter().any(|d| d.category == "attempt"),
+        "should report a claim-without-attempt advisory"
     );
 }
 
@@ -1028,6 +1244,50 @@ async fn duties_clean_on_no_claims() {
         .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
     assert!(report.clean, "should have no blocking duties");
+}
+
+#[tokio::test]
+async fn duties_reports_free_slots_when_under_capacity() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("duties-capacity");
+    let approved_fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let claimed_fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![
+            approved_fixture.issue.clone(),
+            claimed_fixture.issue.clone(),
+        ],
+        HashMap::from([
+            (
+                approved_fixture.issue.number,
+                approved_fixture.comments.clone(),
+            ),
+            (
+                claimed_fixture.issue.number,
+                claimed_fixture.comments.clone(),
+            ),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &approved_fixture.lead_github_login,
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_config(&repo.path, "test-node", None, Some(3)).unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+    assert!(
+        report.advisory.iter().any(|d| d.category == "capacity"),
+        "should report free slots under configured sub-agent capacity"
+    );
 }
 
 #[tokio::test]
@@ -1179,9 +1439,10 @@ async fn duties_reports_waiting_for_approval_when_queue_has_only_submitted_these
 // --- B6: Duty gate on claim ---
 
 #[tokio::test]
-async fn claim_blocked_by_outstanding_duties() {
+async fn claim_allows_additional_claims_under_sub_agent_capacity() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-gate");
+    init_git_repo(&repo.path);
     let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
     let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
     let mock = Arc::new(MockGitHubClient::new(
@@ -1207,7 +1468,49 @@ async fn claim_blocked_by_outstanding_duties() {
             no_worktree: false,
         }),
     );
-    commands::write_node_id(&repo.path, "test-node").unwrap();
+    commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
+
+    commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture_open.issue.number,
+            no_worktree: false,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn claim_blocks_when_already_at_sub_agent_capacity() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("claim-capacity");
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
+        HashMap::from([
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
+            (fixture_open.issue.number, fixture_open.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture_claimed.lead_github_login,
+        true,
+        Commands::Claim(IssueArgs {
+            issue: fixture_open.issue.number,
+            no_worktree: false,
+        }),
+    );
+    commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
 
     let error = commands::claim::run(
         &ctx,
@@ -1219,8 +1522,8 @@ async fn claim_blocked_by_outstanding_duties() {
     .await
     .unwrap_err();
     assert!(
-        error.to_string().contains("blocking duties"),
-        "claim should be blocked by outstanding duties, got: {error}"
+        error.to_string().contains("configured sub-agent capacity"),
+        "claim should be blocked by capacity, got: {error}"
     );
 }
 

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -27,9 +27,12 @@ description: >-
 7. Identify your role from your instructions or `PROGRAM.md`:
    - If told "you are the lead," follow the lead loop.
    - Otherwise, follow the contributor loop.
-8. If the repo is a fork and issues are disabled:
+8. Read `sub_agents` from `.polyresearch-node.toml` if it exists:
+   - If absent or `1`, follow the contributor loop exactly as written.
+   - If greater than `1`, use the "Contributor loop with sub-agents" section below.
+9. If the repo is a fork and issues are disabled:
    `gh api repos/{owner}/{name} --method PATCH -f has_issues=true`
-9. For any CLI command details: `polyresearch <command> --help`
+10. For any CLI command details: `polyresearch <command> --help`
 
 `POLYRESEARCH_NODE_ID` takes precedence over `.polyresearch-node.toml` for the current session. This is required when multiple agents share one checkout or when one GitHub login runs several workers in parallel.
 
@@ -110,6 +113,40 @@ LOOP FOREVER:
   5. Repeat from step 0.
 ```
 
+## Contributor loop with sub-agents
+
+Use this variant when `.polyresearch-node.toml` sets `sub_agents` greater than 1.
+
+```
+LOOP FOREVER:
+
+  0. polyresearch duties
+     Resolve BLOCKING items before continuing.
+
+  1. polyresearch pace
+     Read the current `sub_agents` setting, active claims, and free slots.
+
+  2. polyresearch batch-claim
+     Claims up to the node's free thesis slots. Creates one worktree per thesis.
+
+  3. For each claimed thesis, dispatch one sub-agent:
+     - Give it the issue number and worktree path.
+     - Tell it to read PROGRAM.md and PREPARE.md.
+     - Tell it to work only in its assigned worktree.
+     - Tell it to return every completed attempt with metric, baseline,
+       observation, and summary.
+     - Tell it NOT to run polyresearch CLI commands.
+     - Tell it NOT to talk to GitHub.
+
+  4. As each sub-agent finishes its thesis:
+     - post every returned attempt with `polyresearch attempt`
+     - if any attempt improved, `polyresearch submit <issue>`
+     - otherwise, `polyresearch release <issue> --reason no_improvement`
+     - remove the finished thesis worktree
+
+  5. Repeat from step 0.
+```
+
 ## The lead loop
 
 The lead runs a separate management loop from the repository root worktree,
@@ -158,16 +195,20 @@ LOOP FOREVER:
 ## Resource pacing
 
 Run `polyresearch pace` regularly. It prints your effective resource policy
-and recent throughput. If `.polyresearch-node.toml` sets a `resource_policy`,
-treat it as a real constraint. See `POLYRESEARCH.md` "Node configuration" for
-the default policy and details.
+and recent throughput. It also prints the configured `sub_agents`, current
+active claims, and free slots. Treat `sub_agents` as the number of theses the
+contributor may work on in parallel. If `.polyresearch-node.toml` sets a
+`resource_policy`, treat it as an additional constraint. See `POLYRESEARCH.md`
+"Node configuration" for details.
 
 ## Critical rules
 
 These rules are extracted from `POLYRESEARCH.md`. The protocol is authoritative
 if any wording differs.
 
-- Post `polyresearch attempt` after EVERY experiment. Never batch.
+- Without sub-agents, post `polyresearch attempt` after every experiment.
+- With sub-agents, post every returned attempt as each sub-agent finishes its
+  thesis. Sub-agents do not post to GitHub directly.
 - Run `polyresearch submit` immediately when you observe `improved`.
   Do not "keep trying."
 - After `submit` or `release`, finish cleanup and then continue the loop from


### PR DESCRIPTION
## Summary
- add explicit `sub_agents` node configuration and a new `polyresearch batch-claim` command that fills a contributor's free thesis slots
- redesign contributor duties and claim semantics so one contributor can keep multiple theses in flight while still posting attempts, submits, and releases to GitHub
- update the protocol, skill, and README docs to describe the thesis-parallel sub-agent model and server-native execution for better hardware utilization

## Test plan
- [x] `cargo fmt`
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-claim workflow and changes claim/duties gating based on `sub_agents`, which can affect how many theses a node can hold and when work is considered blocking. Risk is moderated by extensive new e2e tests but touches core contributor coordination logic.
> 
> **Overview**
> Enables *single-contributor parallelism* via configurable `sub_agents` in `.polyresearch-node.toml`, letting one contributor keep multiple theses in flight (one worktree per thesis) while still centralizing GitHub interactions.
> 
> Adds `polyresearch batch-claim` to automatically claim up to the node’s remaining capacity and create worktrees, and updates `claim` to enforce the `sub_agents` capacity limit. Updates `duties`/`pace` output and semantics so “claimed but no attempts yet” is **advisory** (not blocking) and surfaces free-slot capacity prompts.
> 
> Documentation (`POLYRESEARCH.md`, `skills/polyresearch/SKILL.md`, `README.md`, `cli/README.md`) is updated to describe the sub-agent model and recommended server/tmux execution, and tests are expanded to cover init/config persistence, capacity enforcement, and batch-claim edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9bd88f75bdd48d71c3428311bddb1ee4dee1b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->