### PR TITLE
Bump CLI version to 0.3.3 for release

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.3.2
+cli_version: 0.3.3
 
 ## Goal
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch-cli"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 repository = "https://github.com/superagent-ai/polyresearch"
 


### PR DESCRIPTION
## Summary
- Bump `cli/Cargo.toml` version from 0.3.2 to 0.3.3
- Update `cli_version` in `PROGRAM.md` to match

## After merge
Tag and push to trigger the release workflow:
```bash
git tag v0.3.3
git push origin v0.3.3
```

## Test plan
- [x] `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version metadata update only; no runtime logic changes.
> 
> **Overview**
> Bumps the CLI release version from `0.3.2` to `0.3.3` in both `cli/Cargo.toml` and `PROGRAM.md` so the documented `cli_version` matches the crate version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b65a5f3e51682f9e132c1e8911ca9591f2fef0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->