### PR TITLE
Prevent contributor agents from self-promoting to lead

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -34,7 +34,7 @@ cli_version: 0.3.2
 - `required_confirmations` — Number of independent review records needed before the lead decides a PR. `0` means the lead decides without peer review. Default: `0`.
 - `metric_tolerance` — Maximum allowed divergence between reviewer metrics for agreement. No default — the maintainer must set this based on the domain and hardware variance.
 - `metric_direction` — `lower_is_better` or `higher_is_better`.
-- `lead_github_login` — GitHub login that is authorized to perform lead-only actions such as approval, sync, policy checks, decisions, and admin repairs.
+- `lead_github_login` — GitHub account the CLI trusts for lead-only commands (generate, sync, decide, policy-check, admin) and uses to validate structured comments during audit. This field controls CLI authorization, not role assignment. An agent whose login matches this field is not the lead unless its launch instructions say so.
 - `maintainer_github_login` — GitHub login for the human maintainer who can `/approve` or `/reject` thesis issues and candidate PRs when human review is enabled.
 - `auto_approve` — If `true`, the lead auto-approves generated theses and decides PRs without waiting for a maintainer slash command. If `false`, the maintainer must `/approve` first. Default: `true`.
 - `assignment_timeout` — Time before an uncompleted claim expires and the thesis returns to the queue. Default: `24h`.
@@ -54,6 +54,8 @@ The parameter definitions live here. Concrete project values live in `PROGRAM.md
 **Contributor.** A machine running an agent. Claims theses, runs experiments, submits candidates, and reviews others' work. You are a contributor unless told otherwise.
 
 **Lead.** A machine running an agent dedicated to project management. The lead generates theses from results history, runs policy checks on candidate PRs, decides PRs (merge or close), and maintains `results.tsv` as sole writer. One per project. The lead does not claim theses, run experiments, submit candidates, or participate in peer review. If your instructions say "you are the lead," follow the lead loop only.
+
+`lead_github_login` does not define who the lead is. It tells the CLI which GitHub account is allowed to run lead-only commands and which structured comments to trust as lead actions during audit. Role is assigned by the maintainer through launch instructions, not by config fields. An empty queue is not a reason to assume the lead role.
 
 When `auto_approve` is `false`, `lead_github_login` and `maintainer_github_login` must be different GitHub accounts. Human-in-the-loop review does not work if the lead and the maintainer share the same GitHub identity.
 
@@ -79,7 +81,7 @@ When you start, before doing anything else:
    ```
 
 7. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"`. The CLI writes the fallback file used when `POLYRESEARCH_NODE_ID` is unset and records any optional node-specific `resource_policy`.
-8. Identify your role. If your instructions say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop.
+8. Identify your role. If your instructions explicitly say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop. Do not infer your role from `lead_github_login`, queue state, or any other signal. Role comes from launch instructions only.
 
 ---
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -288,7 +288,15 @@ fn check_contributor_idle_state(
     has_review_work: bool,
     advisory: &mut Vec<DutyItem>,
 ) -> Result<()> {
-    if has_review_work || repo_state.queue_depth == 0 {
+    if has_review_work {
+        return Ok(());
+    }
+    if repo_state.queue_depth == 0 {
+        advisory.push(DutyItem {
+            category: "idle".to_string(),
+            message: "Queue is empty. Wait for the lead to generate theses. Do not assume lead duties.".to_string(),
+            command: "sleep 60 && polyresearch duties".to_string(),
+        });
         return Ok(());
     }
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1754,6 +1754,38 @@ fn make_submitted_thesis(number: u64) -> ThesisState {
     }
 }
 
+#[tokio::test]
+async fn duties_reports_idle_advisory_when_queue_empty_for_contributor() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("duties-idle-contributor");
+    let mock = Arc::new(MockGitHubClient::new(
+        "contributor-bot",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead-bot",
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_id(&repo.path, "contributor-bot/node-1").unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let report = commands::duties::check(&ctx, &repo_state).unwrap();
+    assert!(
+        report.advisory.iter().any(|d| d.category == "idle"
+            && d.message.contains("Do not assume lead duties")),
+        "should warn idle contributor not to assume lead duties, got: {:?}",
+        report.advisory
+    );
+}
+
 fn load_issue_fixture(name: &str) -> IssueFixture {
     serde_json::from_str(include_fixture(name)).unwrap()
 }

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -24,9 +24,11 @@ description: >-
 4. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"` to create the fallback file.
 5. If `.polyresearch/` exists, run its setup. Otherwise follow `PREPARE.md`.
 6. Check your GitHub identity: the `LOGIN` above must match the GitHub user you were asked to operate as.
-7. Identify your role from your instructions or `PROGRAM.md`:
+7. Identify your role solely from your launch instructions:
    - If told "you are the lead," follow the lead loop.
    - Otherwise, follow the contributor loop.
+   - Matching `lead_github_login` does NOT make you the lead. An empty
+     queue does NOT make you the lead.
 8. Read `sub_agents` from `.polyresearch-node.toml` if it exists:
    - If absent or `1`, follow the contributor loop exactly as written.
    - If greater than `1`, use the "Contributor loop with sub-agents" section below.


### PR DESCRIPTION
## Summary

- Closes a contributor self-promotion bug where an agent with a matching `lead_github_login` rationalizes becoming the lead when the queue is empty.
- Tightens documentation in `POLYRESEARCH.md` and `SKILL.md` to make role assignment unambiguous: role comes solely from launch instructions, not from config fields or queue state.
- Adds an idle contributor advisory in the CLI (`polyresearch duties`) so agents see "Do not assume lead duties" when the queue is empty, right at the moment they would otherwise rationalize self-promotion.

## Changes

**POLYRESEARCH.md** (3 edits):
- Roles section: added paragraph clarifying `lead_github_login` is a CLI authorization field, not a role assignment.
- Starting a session step 8: strengthened to "Role comes from launch instructions only."
- Configuration `lead_github_login` description: rewritten to clarify it controls CLI authorization, not role assignment.

**skills/polyresearch/SKILL.md**:
- Step 7 rewritten: removed "or `PROGRAM.md`" (the direct cause), added explicit "Matching `lead_github_login` does NOT make you the lead."

**cli/src/commands/duties.rs**:
- `check_contributor_idle_state` now emits an advisory when queue is empty instead of returning silently.

**cli/tests/e2e.rs**:
- New test `duties_reports_idle_advisory_when_queue_empty_for_contributor`.

## Test plan

- [x] All 85 existing tests pass (47 unit + 38 e2e)
- [x] New test verifies the idle advisory is emitted for contributors with an empty queue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and an additional non-blocking `duties` advisory plus a new e2e test; no protocol state transitions or auth rules are modified.
> 
> **Overview**
> Prevents contributors from “self-promoting” to lead by **clarifying role assignment**: `POLYRESEARCH.md` and `skills/polyresearch/SKILL.md` now state that `lead_github_login` is only for CLI authorization/trusted comments and that *role comes solely from launch instructions*, even when the queue is empty.
> 
> Updates `polyresearch duties` so contributors with no review work and `queue_depth == 0` get an explicit *idle advisory* (“Do not assume lead duties”), and adds an e2e test covering this case. Bumps `polyresearch-cli` version in `Cargo.lock` to `0.3.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1202c8fc2a7135076bcedee15b42499196735354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->