### PR TITLE
Rename crate to polyresearch and prepare for crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          archive="target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz"
+          archive="target/distrib/polyresearch-${{ matrix.target }}.tar.xz"
           tmpdir="$(mktemp -d)"
           tar -xJf "$archive" -C "$tmpdir"
-          archive_root="$tmpdir/polyresearch-cli-${{ matrix.target }}"
+          archive_root="$tmpdir/polyresearch-${{ matrix.target }}"
 
           "$archive_root/polyresearch" --help >/dev/null
 
@@ -112,8 +112,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist-artifacts
-          cp "target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz" dist-artifacts/
-          cp "target/distrib/polyresearch-cli-${{ matrix.target }}.tar.xz.sha256" dist-artifacts/
+          cp "target/distrib/polyresearch-${{ matrix.target }}.tar.xz" dist-artifacts/
+          cp "target/distrib/polyresearch-${{ matrix.target }}.tar.xz.sha256" dist-artifacts/
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,3 +191,17 @@ jobs:
               --generate-notes \
               "${prerelease_flag[@]}"
           fi
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        run: cargo publish --manifest-path cli/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Contributors pick up theses from the GitHub Issues queue, run experiments, and s
 
 Two steps:
 
-1. **Install the CLI.** Download the binary and put it on your `PATH`. The link below is for macOS Apple Silicon; other platforms and build-from-source in [cli/README.md](cli/README.md).
+1. **Install the CLI.** If you have Rust, `cargo install polyresearch`. Otherwise, download the binary and put it on your `PATH`. The link below is for macOS Apple Silicon; other platforms and build-from-source in [cli/README.md](cli/README.md).
 
 ```bash
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-aarch64-apple-darwin.tar.xz
 ```
 
 1. **Install the agent skill.** Copy `skills/polyresearch/SKILL.md` from this repo into your agent's skill directory (e.g. `~/.claude/skills/polyresearch/`, or equivalent for your agent). The skill teaches agents the full protocol -- bootstrapping, the lead loop, the contributor loop, and all CLI usage.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -316,7 +316,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -481,7 +481,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1010,7 +1010,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1064,6 +1064,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1165,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1175,7 +1181,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1361,12 +1366,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1426,9 +1431,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1491,9 +1496,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1507,7 +1512,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1545,9 +1550,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -1616,7 +1621,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2014,7 +2019,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyresearch-cli"
+name = "polyresearch"
 version = "0.3.3"
 dependencies = [
  "chrono",
@@ -2132,7 +2137,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2156,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2180,7 +2185,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -2232,7 +2237,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -2251,7 +2256,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2348,7 +2353,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2357,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -2393,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2467,7 +2472,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2837,7 +2842,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2965,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3076,7 +3081,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3317,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3330,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3340,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3353,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3388,7 +3393,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3713,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
-name = "polyresearch-cli"
+name = "polyresearch"
 version = "0.3.3"
 edition = "2024"
+description = "Distributed autoresearch across multiple machines and contributors"
+license = "MIT"
 repository = "https://github.com/superagent-ai/polyresearch"
+homepage = "https://github.com/superagent-ai/polyresearch"
+keywords = ["ai", "research", "distributed", "agents", "experiments"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "polyresearch"

--- a/cli/README.md
+++ b/cli/README.md
@@ -21,34 +21,40 @@ The default install path is to download a pre-built archive from [GitHub Release
 
 | OS | Architecture | Archive |
 | --- | --- | --- |
-| macOS | Apple Silicon | `polyresearch-cli-aarch64-apple-darwin.tar.xz` |
-| macOS | Intel | `polyresearch-cli-x86_64-apple-darwin.tar.xz` |
-| Linux | x86_64 (glibc) | `polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz` |
+| macOS | Apple Silicon | `polyresearch-aarch64-apple-darwin.tar.xz` |
+| macOS | Intel | `polyresearch-x86_64-apple-darwin.tar.xz` |
+| Linux | x86_64 (glibc) | `polyresearch-x86_64-unknown-linux-gnu.tar.xz` |
 
 Each archive expands to a directory containing `polyresearch` and `README.md`. Move `polyresearch` somewhere on your `PATH`, such as `~/.local/bin` or `/usr/local/bin`.
 
 **macOS (Apple Silicon):**
 
 ```bash
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-aarch64-apple-darwin.tar.xz
-tar -xJf polyresearch-cli-aarch64-apple-darwin.tar.xz
-sudo cp polyresearch-cli-aarch64-apple-darwin/polyresearch /usr/local/bin/
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-aarch64-apple-darwin.tar.xz
+tar -xJf polyresearch-aarch64-apple-darwin.tar.xz
+sudo cp polyresearch-aarch64-apple-darwin/polyresearch /usr/local/bin/
 ```
 
 **macOS (Intel):**
 
 ```bash
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-x86_64-apple-darwin.tar.xz
-tar -xJf polyresearch-cli-x86_64-apple-darwin.tar.xz
-sudo cp polyresearch-cli-x86_64-apple-darwin/polyresearch /usr/local/bin/
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-x86_64-apple-darwin.tar.xz
+tar -xJf polyresearch-x86_64-apple-darwin.tar.xz
+sudo cp polyresearch-x86_64-apple-darwin/polyresearch /usr/local/bin/
 ```
 
 **Linux (x86_64):**
 
 ```bash
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz
-tar -xJf polyresearch-cli-x86_64-unknown-linux-gnu.tar.xz
-sudo cp polyresearch-cli-x86_64-unknown-linux-gnu/polyresearch /usr/local/bin/
+curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-x86_64-unknown-linux-gnu.tar.xz
+tar -xJf polyresearch-x86_64-unknown-linux-gnu.tar.xz
+sudo cp polyresearch-x86_64-unknown-linux-gnu/polyresearch /usr/local/bin/
+```
+
+### Install from crates.io
+
+```bash
+cargo install polyresearch
 ```
 
 ### Build from source
@@ -58,8 +64,6 @@ From the repo root:
 ```bash
 cargo install --path cli
 ```
-
-That installs the `polyresearch` binary from [cli/Cargo.toml](cli/Cargo.toml).
 
 ## Requirements
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use clap::Parser;
 use color_eyre::eyre::{Context, Result};
-use polyresearch_cli::cli::Cli;
-use polyresearch_cli::commands;
-use polyresearch_cli::commands::AppContext;
-use polyresearch_cli::config::{NodeConfig, ProgramSpec, ProtocolConfig};
-use polyresearch_cli::github::{GitHubApi, GitHubClient, RepoRef};
+use polyresearch::cli::Cli;
+use polyresearch::commands;
+use polyresearch::commands::AppContext;
+use polyresearch::config::{NodeConfig, ProgramSpec, ProtocolConfig};
+use polyresearch::github::{GitHubApi, GitHubClient, RepoRef};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -7,23 +7,23 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
-use polyresearch_cli::cli::{
+use polyresearch::cli::{
     AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
 };
-use polyresearch_cli::commands;
-use polyresearch_cli::comments::{Observation, ReleaseReason};
-use polyresearch_cli::config::{
+use polyresearch::commands;
+use polyresearch::comments::{Observation, ReleaseReason};
+use polyresearch::config::{
     DEFAULT_API_BUDGET, MetricDirection, NodeConfig, ProgramSpec, ProtocolConfig,
 };
-use polyresearch_cli::github::{
+use polyresearch::github::{
     CommentUser, GitHubApi, Issue, IssueComment, IssueListState, PullRequest, PullRequestFile,
     PullRequestListState, RateLimitBucket, RateLimitResources, RateLimitStatus, RepoRef,
 };
-use polyresearch_cli::state::{ReleaseRecord, RepositoryState, ThesisPhase, ThesisState};
+use polyresearch::state::{ReleaseRecord, RepositoryState, ThesisPhase, ThesisState};
 use serde::Deserialize;
 
 #[allow(unused_imports)]
-use polyresearch_cli::commands::duties;
+use polyresearch::commands::duties;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -248,13 +248,13 @@ impl Drop for NodeIdEnvGuard {
 
 fn set_node_id_env(value: &str) {
     unsafe {
-        env::set_var(polyresearch_cli::config::NODE_ID_ENV_VAR, value);
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, value);
     }
 }
 
 fn clear_node_id_env() {
     unsafe {
-        env::remove_var(polyresearch_cli::config::NODE_ID_ENV_VAR);
+        env::remove_var(polyresearch::config::NODE_ID_ENV_VAR);
     }
 }
 
@@ -1217,7 +1217,7 @@ fn pull_request_deserializes_state_case_insensitive() {
 
 #[test]
 fn comment_parser_skips_email_quoted_blocks() {
-    use polyresearch_cli::comments::ProtocolComment;
+    use polyresearch::comments::ProtocolComment;
 
     let quoted_body = r#"On Tue, Apr 8, 2026, Alice wrote:
 
@@ -1237,7 +1237,7 @@ fn comment_parser_skips_email_quoted_blocks() {
 
 #[test]
 fn comment_parser_handles_malformed_fields_gracefully() {
-    use polyresearch_cli::comments::ProtocolComment;
+    use polyresearch::comments::ProtocolComment;
 
     let body = "<!-- polyresearch:claim\ngarbage line with no colon\n-->";
     let result = ProtocolComment::parse(body).unwrap();
@@ -1252,7 +1252,7 @@ fn comment_parser_handles_malformed_fields_gracefully() {
 #[test]
 fn observation_value_enum_accepts_snake_case() {
     use clap::ValueEnum;
-    use polyresearch_cli::comments::Observation;
+    use polyresearch::comments::Observation;
 
     let variants: Vec<_> = Observation::value_variants()
         .iter()


### PR DESCRIPTION
## Summary

- Rename crate from `polyresearch-cli` to `polyresearch` so users can `cargo install polyresearch`
- Add required crates.io metadata: `description`, `license`, `homepage`, `keywords`, `categories`
- Update all Rust imports from `polyresearch_cli::` to `polyresearch::`
- Update archive names in release workflow and READMEs from `polyresearch-cli-*` to `polyresearch-*`
- Add `cargo install polyresearch` as an install option in both READMEs

## Test plan

- [x] `cargo publish --dry-run --allow-dirty` passes cleanly
- [x] All 85 tests pass (47 unit + 38 e2e)
- [ ] After merge, publish to crates.io with `cargo publish` from `cli/`
- [ ] Verify `cargo install polyresearch` works from a clean machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames the Rust crate/package and distribution artifact names, which can break downstream integrations and release automation if any references were missed. Adds an automated `cargo publish` step, introducing risk around credential/CI configuration and publishing the correct manifest/version.
> 
> **Overview**
> Renames the Rust crate/package from `polyresearch-cli` to `polyresearch`, updating internal imports and tests accordingly and adding crates.io metadata in `cli/Cargo.toml`.
> 
> Updates release artifact naming and install docs to use `polyresearch-*` archives (and mentions `cargo install polyresearch`), and extends the GitHub Actions release workflow to **publish the crate to crates.io** after creating the GitHub Release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3c765c8deb33f021a314d6fc7a3fe71447d2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->