### PR TITLE
Make cargo install the default install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ Contributors pick up theses from the GitHub Issues queue, run experiments, and s
 
 Two steps:
 
-1. **Install the CLI.** If you have Rust, `cargo install polyresearch`. Otherwise, download the binary and put it on your `PATH`. The link below is for macOS Apple Silicon; other platforms and build-from-source in [cli/README.md](cli/README.md).
+1. **Install the CLI.**
 
 ```bash
-curl -LO https://github.com/superagent-ai/polyresearch/releases/latest/download/polyresearch-aarch64-apple-darwin.tar.xz
+cargo install polyresearch
 ```
 
-1. **Install the agent skill.** Copy `skills/polyresearch/SKILL.md` from this repo into your agent's skill directory (e.g. `~/.claude/skills/polyresearch/`, or equivalent for your agent). The skill teaches agents the full protocol -- bootstrapping, the lead loop, the contributor loop, and all CLI usage.
+Don't have Rust? See [other install options](cli/README.md#other-install-options).
+
+2. **Install the agent skill.** Copy `skills/polyresearch/SKILL.md` from this repo into your agent's skill directory (e.g. `~/.claude/skills/polyresearch/`, or equivalent for your agent). The skill teaches agents the full protocol -- bootstrapping, the lead loop, the contributor loop, and all CLI usage.
 
 ## Usage
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,16 @@ This CLI centralizes that logic so every machine uses the same implementation an
 
 ## Install
 
-The default install path is to download a pre-built archive from [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
+```bash
+cargo install polyresearch
+```
+
+### Other install options
+
+<details>
+<summary>Download a pre-built binary</summary>
+
+Pre-built archives are available from [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
 
 | OS | Architecture | Archive |
 | --- | --- | --- |
@@ -51,19 +60,18 @@ tar -xJf polyresearch-x86_64-unknown-linux-gnu.tar.xz
 sudo cp polyresearch-x86_64-unknown-linux-gnu/polyresearch /usr/local/bin/
 ```
 
-### Install from crates.io
+</details>
 
-```bash
-cargo install polyresearch
-```
-
-### Build from source
+<details>
+<summary>Build from source</summary>
 
 From the repo root:
 
 ```bash
 cargo install --path cli
 ```
+
+</details>
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- Make `cargo install polyresearch` the primary install instruction in both READMEs
- Move binary download and build-from-source options into collapsible `<details>` sections in `cli/README.md`
- Main `README.md` install section is now a clean one-liner with a link to other options

## Test plan

- [ ] Verify README rendering on GitHub (collapsible sections, anchor link)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust install instructions and README layout; low risk aside from potential broken links/formatting in rendered markdown.
> 
> **Overview**
> Makes `cargo install polyresearch` the primary installation instruction in both top-level `README.md` and `cli/README.md`.
> 
> Moves pre-built binary download and source-build guidance in `cli/README.md` into collapsible `details` sections, and adds a link from `README.md` to *other install options* for users without Rust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed7bedbae046d457b1701d48eedbc5de1a89666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->