### PR TITLE
Close exhausted theses and gate lead mutations on current results.tsv

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -218,7 +218,7 @@ You are the sole writer. This step runs first on every lead-loop iteration. Do n
 2. The CLI reconciles canonical attempt history against `results.tsv`, appends any missing rows, and commits the updated `results.tsv` on `main`.
 3. Canonical history may ignore invalid raw GitHub events. Resolve any audit findings through CLI admin or repair commands before continuing. A dirty audit blocks `policy-check`, `decide`, and `generate`.
 
-Only after results.tsv accounts for every known attempt may you proceed to the rest of the lead loop.
+Only after results.tsv accounts for every known attempt may you proceed to the rest of the lead loop. The CLI enforces this: `decide`, `policy-check`, and `generate` refuse to run when `results.tsv` is stale.
 
 After any new thesis resolution later in the same iteration, append those rows before the next iteration begins.
 
@@ -329,7 +329,7 @@ Scan the comment trail on the issue to reconstruct the current state:
 
 No mutable labels to get out of sync. The comment trail is the truth.
 
-Exhausted theses stay open for history, but they are not claimable and do not count toward queue depth.
+The CLI closes exhausted theses automatically. They do not count toward queue depth. Use `polyresearch admin reopen-thesis` to reverse if needed.
 
 When `auto_approve` is `false`, a generated thesis stays in **Submitted** until the maintainer comments `/approve`.
 

--- a/cli/src/commands/admin.rs
+++ b/cli/src/commands/admin.rs
@@ -7,8 +7,8 @@ use crate::cli::{
 };
 use crate::commands::guards::{ensure_lead, find_thesis};
 use crate::commands::{AppContext, print_value};
-use crate::comments::ProtocolComment;
-use crate::state::RepositoryState;
+use crate::comments::{ProtocolComment, ReleaseReason};
+use crate::state::{RepositoryState, ThesisPhase};
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
@@ -58,6 +58,15 @@ async fn release_claim(ctx: &AppContext, args: &AdminReleaseClaimArgs) -> Result
         };
         ctx.github
             .post_issue_comment(args.issue, &release.render())?;
+
+        if args.reason == ReleaseReason::NoImprovement {
+            let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+            if let Some(t) = updated.theses.iter().find(|t| t.issue.number == args.issue) {
+                if matches!(t.phase, ThesisPhase::Exhausted) {
+                    ctx.github.close_issue(args.issue)?;
+                }
+            }
+        }
     }
 
     let output = AdminOutput::ReleaseClaim {

--- a/cli/src/commands/admin.rs
+++ b/cli/src/commands/admin.rs
@@ -5,10 +5,10 @@ use crate::cli::{
     AdminAcknowledgeInvalidArgs, AdminArgs, AdminCommands, AdminReleaseClaimArgs,
     AdminReopenThesisArgs,
 };
-use crate::commands::guards::{ensure_lead, find_thesis};
+use crate::commands::guards::{close_if_exhausted, ensure_lead, find_thesis};
 use crate::commands::{AppContext, print_value};
-use crate::comments::{ProtocolComment, ReleaseReason};
-use crate::state::{RepositoryState, ThesisPhase};
+use crate::comments::ProtocolComment;
+use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
@@ -58,15 +58,7 @@ async fn release_claim(ctx: &AppContext, args: &AdminReleaseClaimArgs) -> Result
         };
         ctx.github
             .post_issue_comment(args.issue, &release.render())?;
-
-        if args.reason == ReleaseReason::NoImprovement {
-            let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-            if let Some(t) = updated.theses.iter().find(|t| t.issue.number == args.issue) {
-                if matches!(t.phase, ThesisPhase::Exhausted) {
-                    ctx.github.close_issue(args.issue)?;
-                }
-            }
-        }
+        close_if_exhausted(ctx, args.issue, args.reason).await?;
     }
 
     let output = AdminOutput::ReleaseClaim {

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::PrArgs;
-use crate::commands::guards::{ensure_clean_audit, ensure_lead, require_decidable_pr};
+use crate::commands::guards::{ensure_lead_ready, require_decidable_pr};
 use crate::commands::{AppContext, print_value};
 use crate::comments::{Observation, Outcome, ProtocolComment};
 use crate::ledger::Ledger;
@@ -19,9 +19,8 @@ struct DecideOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
-    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_clean_audit(&repo_state, "decide PRs")?;
+    ensure_lead_ready(ctx, &repo_state)?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     let (thesis, pr_state) = require_decidable_pr(&repo_state, args.pr)?;
 

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -20,8 +20,7 @@ struct DecideOutput {
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_lead_ready(ctx, &repo_state)?;
-    let ledger = Ledger::load(&ctx.repo_root)?;
+    let (_login, ledger) = ensure_lead_ready(ctx, &repo_state)?;
     let (thesis, pr_state) = require_decidable_pr(&repo_state, args.pr)?;
 
     let candidate_sha = pr_state.pr.head_ref_oid.clone().unwrap_or_default();

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::PrArgs;
-use crate::commands::guards::{ensure_lead_ready, require_decidable_pr};
+use crate::commands::guards::{ensure_current_ledger, ensure_lead, require_decidable_pr};
 use crate::commands::{AppContext, print_value};
 use crate::comments::{Observation, Outcome, ProtocolComment};
 use crate::ledger::Ledger;
@@ -19,8 +19,9 @@ struct DecideOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
+    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let (_login, ledger) = ensure_lead_ready(ctx, &repo_state)?;
+    let ledger = ensure_current_ledger(ctx, &repo_state)?;
     let (thesis, pr_state) = require_decidable_pr(&repo_state, args.pr)?;
 
     let candidate_sha = pr_state.pr.head_ref_oid.clone().unwrap_or_default();

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::cli::GenerateArgs;
 use crate::commands::duties;
-use crate::commands::guards::ensure_lead_ready;
+use crate::commands::guards::{ensure_current_ledger, ensure_lead};
 use crate::commands::{AppContext, print_value};
 use crate::comments::ProtocolComment;
 use crate::state::RepositoryState;
@@ -18,8 +18,9 @@ struct GenerateOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
+    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let _ = ensure_lead_ready(ctx, &repo_state)?;
+    let _ = ensure_current_ledger(ctx, &repo_state)?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
     let lead_blocking: Vec<_> = duty_report

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -3,10 +3,9 @@ use serde::Serialize;
 
 use crate::cli::GenerateArgs;
 use crate::commands::duties;
-use crate::commands::guards::{ensure_clean_audit, ensure_lead};
+use crate::commands::guards::ensure_lead_ready;
 use crate::commands::{AppContext, print_value};
 use crate::comments::ProtocolComment;
-use crate::ledger::Ledger;
 use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
@@ -19,9 +18,8 @@ struct GenerateOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
-    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_clean_audit(&repo_state, "generate theses")?;
+    ensure_lead_ready(ctx, &repo_state)?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
     let lead_blocking: Vec<_> = duty_report
@@ -37,12 +35,6 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         return Err(eyre!(
             "cannot generate theses while PRs need processing:\n{}",
             items.join("\n")
-        ));
-    }
-    let ledger = Ledger::load(&ctx.repo_root)?;
-    if !ledger.is_current(&repo_state) {
-        return Err(eyre!(
-            "results.tsv is stale; run `polyresearch sync` before generating new theses"
         ));
     }
 

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -19,7 +19,7 @@ struct GenerateOutput {
 
 pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_lead_ready(ctx, &repo_state)?;
+    let _ = ensure_lead_ready(ctx, &repo_state)?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
     let lead_blocking: Vec<_> = duty_report

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{Result, eyre};
 
 use crate::commands::AppContext;
+use crate::comments::ReleaseReason;
 use crate::ledger::Ledger;
 use crate::state::{PullRequestState, RepositoryState, ThesisPhase, ThesisState};
 
@@ -151,4 +152,23 @@ pub fn ensure_lead_ready(ctx: &AppContext, repo_state: &RepositoryState) -> Resu
         ));
     }
     Ok(login)
+}
+
+/// After a release with `no_improvement`, re-derive state and close the issue
+/// if the thesis has become Exhausted (no remaining active claims).
+pub async fn close_if_exhausted(
+    ctx: &AppContext,
+    issue: u64,
+    reason: ReleaseReason,
+) -> Result<()> {
+    if reason != ReleaseReason::NoImprovement {
+        return Ok(());
+    }
+    let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    if let Some(t) = updated.theses.iter().find(|t| t.issue.number == issue) {
+        if matches!(t.phase, ThesisPhase::Exhausted) {
+            ctx.github.close_issue(issue)?;
+        }
+    }
+    Ok(())
 }

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -142,7 +142,10 @@ pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<
     Ok(())
 }
 
-pub fn ensure_lead_ready(ctx: &AppContext, repo_state: &RepositoryState) -> Result<String> {
+pub fn ensure_lead_ready(
+    ctx: &AppContext,
+    repo_state: &RepositoryState,
+) -> Result<(String, Ledger)> {
     let login = ensure_lead(ctx)?;
     ensure_clean_audit(repo_state, "proceed")?;
     let ledger = Ledger::load(&ctx.repo_root)?;
@@ -151,7 +154,7 @@ pub fn ensure_lead_ready(ctx: &AppContext, repo_state: &RepositoryState) -> Resu
             "results.tsv is stale; run `polyresearch sync` before proceeding"
         ));
     }
-    Ok(login)
+    Ok((login, ledger))
 }
 
 /// After a release with `no_improvement`, re-derive state and close the issue

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -142,11 +142,12 @@ pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<
     Ok(())
 }
 
-pub fn ensure_lead_ready(
+/// Checks that the audit is clean and results.tsv is current.
+/// Call after `ensure_lead` and `RepositoryState::derive`.
+pub fn ensure_current_ledger(
     ctx: &AppContext,
     repo_state: &RepositoryState,
-) -> Result<(String, Ledger)> {
-    let login = ensure_lead(ctx)?;
+) -> Result<Ledger> {
     ensure_clean_audit(repo_state, "proceed")?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     if !ledger.is_current(repo_state) {
@@ -154,7 +155,7 @@ pub fn ensure_lead_ready(
             "results.tsv is stale; run `polyresearch sync` before proceeding"
         ));
     }
-    Ok((login, ledger))
+    Ok(ledger)
 }
 
 /// After a release with `no_improvement`, re-derive state and close the issue

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{Result, eyre};
 
 use crate::commands::AppContext;
+use crate::ledger::Ledger;
 use crate::state::{PullRequestState, RepositoryState, ThesisPhase, ThesisState};
 
 pub fn ensure_lead(ctx: &AppContext) -> Result<String> {
@@ -138,4 +139,16 @@ pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<
         ));
     }
     Ok(())
+}
+
+pub fn ensure_lead_ready(ctx: &AppContext, repo_state: &RepositoryState) -> Result<String> {
+    let login = ensure_lead(ctx)?;
+    ensure_clean_audit(repo_state, "proceed")?;
+    let ledger = Ledger::load(&ctx.repo_root)?;
+    if !ledger.is_current(repo_state) {
+        return Err(eyre!(
+            "results.tsv is stale; run `polyresearch sync` before proceeding"
+        ));
+    }
+    Ok(login)
 }

--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::PrArgs;
-use crate::commands::guards::{ensure_lead_ready, require_pull_request};
+use crate::commands::guards::{ensure_current_ledger, ensure_lead, require_pull_request};
 use crate::commands::{AppContext, print_value};
 use crate::comments::{Outcome, ProtocolComment};
 use crate::state::{RepositoryState, parse_thesis_number_from_branch};
@@ -16,8 +16,9 @@ struct PolicyCheckOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
+    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let _ = ensure_lead_ready(ctx, &repo_state)?;
+    let _ = ensure_current_ledger(ctx, &repo_state)?;
     let pr = ctx.github.get_pull_request(args.pr)?;
     let thesis_number = parse_thesis_number_from_branch(&pr.head_ref_name);
 

--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::PrArgs;
-use crate::commands::guards::{ensure_clean_audit, ensure_lead, require_pull_request};
+use crate::commands::guards::{ensure_lead_ready, require_pull_request};
 use crate::commands::{AppContext, print_value};
 use crate::comments::{Outcome, ProtocolComment};
 use crate::state::{RepositoryState, parse_thesis_number_from_branch};
@@ -16,9 +16,8 @@ struct PolicyCheckOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
-    ensure_lead(ctx)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_clean_audit(&repo_state, "policy-check PRs")?;
+    ensure_lead_ready(ctx, &repo_state)?;
     let pr = ctx.github.get_pull_request(args.pr)?;
     let thesis_number = parse_thesis_number_from_branch(&pr.head_ref_name);
 

--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -17,7 +17,7 @@ struct PolicyCheckOutput {
 
 pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    ensure_lead_ready(ctx, &repo_state)?;
+    let _ = ensure_lead_ready(ctx, &repo_state)?;
     let pr = ctx.github.get_pull_request(args.pr)?;
     let thesis_number = parse_thesis_number_from_branch(&pr.head_ref_name);
 

--- a/cli/src/commands/release.rs
+++ b/cli/src/commands/release.rs
@@ -2,10 +2,10 @@ use color_eyre::eyre::Result;
 use serde::Serialize;
 
 use crate::cli::ReleaseArgs;
-use crate::commands::guards::require_claimed_thesis;
+use crate::commands::guards::{close_if_exhausted, require_claimed_thesis};
 use crate::commands::{AppContext, print_value, read_node_id};
-use crate::comments::{ProtocolComment, ReleaseReason};
-use crate::state::{RepositoryState, ThesisPhase};
+use crate::comments::ProtocolComment;
+use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
 struct ReleaseOutput {
@@ -27,15 +27,7 @@ pub async fn run(ctx: &AppContext, args: &ReleaseArgs) -> Result<()> {
     if !ctx.cli.dry_run {
         ctx.github
             .post_issue_comment(args.issue, &comment.render())?;
-
-        if args.reason == ReleaseReason::NoImprovement {
-            let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-            if let Some(t) = updated.theses.iter().find(|t| t.issue.number == args.issue) {
-                if matches!(t.phase, ThesisPhase::Exhausted) {
-                    ctx.github.close_issue(args.issue)?;
-                }
-            }
-        }
+        close_if_exhausted(ctx, args.issue, args.reason).await?;
     }
 
     let output = ReleaseOutput {

--- a/cli/src/commands/release.rs
+++ b/cli/src/commands/release.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 use crate::cli::ReleaseArgs;
 use crate::commands::guards::require_claimed_thesis;
 use crate::commands::{AppContext, print_value, read_node_id};
-use crate::comments::ProtocolComment;
-use crate::state::RepositoryState;
+use crate::comments::{ProtocolComment, ReleaseReason};
+use crate::state::{RepositoryState, ThesisPhase};
 
 #[derive(Debug, Serialize)]
 struct ReleaseOutput {
@@ -27,6 +27,15 @@ pub async fn run(ctx: &AppContext, args: &ReleaseArgs) -> Result<()> {
     if !ctx.cli.dry_run {
         ctx.github
             .post_issue_comment(args.issue, &comment.render())?;
+
+        if args.reason == ReleaseReason::NoImprovement {
+            let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+            if let Some(t) = updated.theses.iter().find(|t| t.issue.number == args.issue) {
+                if matches!(t.phase, ThesisPhase::Exhausted) {
+                    ctx.github.close_issue(args.issue)?;
+                }
+            }
+        }
     }
 
     let output = ReleaseOutput {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -8,7 +8,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch::cli::{
-    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, StatusArgs,
+    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, PrArgs,
+    ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
 use polyresearch::comments::{Observation, ReleaseReason};
@@ -48,6 +49,7 @@ struct MockGitHubClient {
     pull_requests: Vec<PullRequest>,
     pr_comments: HashMap<u64, Vec<IssueComment>>,
     posted_issue_comments: Mutex<Vec<(u64, String)>>,
+    closed_issues: Mutex<Vec<u64>>,
 }
 
 impl MockGitHubClient {
@@ -65,6 +67,7 @@ impl MockGitHubClient {
             pull_requests,
             pr_comments,
             posted_issue_comments: Mutex::new(Vec::new()),
+            closed_issues: Mutex::new(Vec::new()),
         }
     }
 }
@@ -95,11 +98,31 @@ impl GitHubApi for MockGitHubClient {
     }
 
     fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>> {
-        Ok(self
+        let mut comments = self
             .issue_comments
             .get(&issue_number)
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        let latest = comments
+            .iter()
+            .map(|c| c.created_at)
+            .max()
+            .unwrap_or_else(chrono::Utc::now);
+        let posted = self.posted_issue_comments.lock().unwrap();
+        for (idx, (num, body)) in posted.iter().enumerate() {
+            if *num == issue_number {
+                comments.push(IssueComment {
+                    id: 50_000 + idx as u64,
+                    body: body.clone(),
+                    user: CommentUser {
+                        login: self.current_login.clone(),
+                    },
+                    created_at: latest + chrono::Duration::seconds(1 + idx as i64),
+                    updated_at: None,
+                });
+            }
+        }
+        Ok(comments)
     }
 
     fn create_issue(&self, _title: &str, _body: &str, _labels: &[&str]) -> Result<Issue> {
@@ -126,8 +149,19 @@ impl GitHubApi for MockGitHubClient {
         Ok(())
     }
 
-    fn close_issue(&self, _issue_number: u64) -> Result<Issue> {
-        Err(eyre!("unexpected close_issue call in test"))
+    fn close_issue(&self, issue_number: u64) -> Result<Issue> {
+        self.closed_issues.lock().unwrap().push(issue_number);
+        Ok(Issue {
+            number: issue_number,
+            title: String::new(),
+            body: None,
+            state: "CLOSED".to_string(),
+            labels: vec![],
+            created_at: chrono::Utc::now(),
+            closed_at: Some(chrono::Utc::now()),
+            author: None,
+            url: None,
+        })
     }
 
     fn reopen_issue(&self, _issue_number: u64) -> Result<Issue> {
@@ -759,7 +793,7 @@ async fn generate_is_blocked_by_dirty_audit() {
     assert!(
         error
             .to_string()
-            .contains("cannot generate theses while audit findings are present")
+            .contains("cannot proceed while audit findings are present")
     );
 }
 
@@ -1786,6 +1820,192 @@ async fn duties_reports_idle_advisory_when_queue_empty_for_contributor() {
     );
 }
 
+// --- Release closes exhausted thesis ---
+
+#[tokio::test]
+async fn release_closes_exhausted_thesis_on_no_improvement() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("release-close-exhausted");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::release::run(
+        &ctx,
+        &ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        },
+    )
+    .await
+    .unwrap();
+
+    let closed = mock.closed_issues.lock().unwrap();
+    assert_eq!(
+        closed.as_slice(),
+        &[fixture.issue.number],
+        "release with no_improvement should close the exhausted thesis"
+    );
+}
+
+#[tokio::test]
+async fn release_does_not_close_on_timeout() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("release-no-close-timeout");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::Timeout,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::release::run(
+        &ctx,
+        &ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::Timeout,
+        },
+    )
+    .await
+    .unwrap();
+
+    let closed = mock.closed_issues.lock().unwrap();
+    assert!(
+        closed.is_empty(),
+        "release with timeout should not close the thesis"
+    );
+}
+
+#[tokio::test]
+async fn release_does_not_close_on_infra_failure() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("release-no-close-infra");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::InfraFailure,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::release::run(
+        &ctx,
+        &ReleaseArgs {
+            issue: fixture.issue.number,
+            reason: ReleaseReason::InfraFailure,
+        },
+    )
+    .await
+    .unwrap();
+
+    let closed = mock.closed_issues.lock().unwrap();
+    assert!(
+        closed.is_empty(),
+        "release with infra_failure should not close the thesis"
+    );
+}
+
+// --- Lead commands reject stale ledger ---
+
+#[tokio::test]
+async fn decide_rejects_stale_ledger() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("decide-stale-ledger");
+    let fixture = load_issue_fixture("released_with_attempt_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        true,
+        Commands::Decide(PrArgs { pr: 99 }),
+    );
+
+    let error = commands::decide::run(&ctx, &PrArgs { pr: 99 })
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("results.tsv is stale"),
+        "decide should reject when results.tsv is stale, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn policy_check_rejects_stale_ledger() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("policy-check-stale-ledger");
+    let fixture = load_issue_fixture("released_with_attempt_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        true,
+        Commands::PolicyCheck(PrArgs { pr: 99 }),
+    );
+
+    let error = commands::policy_check::run(&ctx, &PrArgs { pr: 99 })
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("results.tsv is stale"),
+        "policy-check should reject when results.tsv is stale, got: {error}"
+    );
+}
+
 fn load_issue_fixture(name: &str) -> IssueFixture {
     serde_json::from_str(include_fixture(name)).unwrap()
 }
@@ -1806,6 +2026,12 @@ fn include_fixture(name: &str) -> &'static str {
         }
         "claimed_no_attempts_issue.json" => {
             include_str!("fixtures/claimed_no_attempts_issue.json")
+        }
+        "exhausted_thesis_issue.json" => {
+            include_str!("fixtures/exhausted_thesis_issue.json")
+        }
+        "released_with_attempt_issue.json" => {
+            include_str!("fixtures/released_with_attempt_issue.json")
         }
         "improved_no_submit_issue.json" => {
             include_str!("fixtures/improved_no_submit_issue.json")

--- a/cli/tests/fixtures/released_with_attempt_issue.json
+++ b/cli/tests/fixtures/released_with_attempt_issue.json
@@ -1,0 +1,44 @@
+{
+  "leadGithubLogin": "lead",
+  "issue": {
+    "number": 30,
+    "title": "Released with attempt fixture",
+    "body": "Thesis with an attempt then released as no_improvement",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/30"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "Polyresearch approval: thesis #30.\n\n<!-- polyresearch:approval\nthesis: 30\n-->",
+      "user": { "login": "lead" },
+      "created_at": "2099-04-08T00:01:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 2,
+      "body": "Polyresearch claim: thesis #30 by node `test-node`.\n\n<!-- polyresearch:claim\nthesis: 30\nnode: test-node\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:02:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 3,
+      "body": "Polyresearch attempt: thesis #30, branch `thesis/30-test-attempt-1`, metric `0.5000`, observation `no_improvement`.\n\n<!-- polyresearch:attempt\nthesis: 30\nbranch: thesis/30-test-attempt-1\nmetric: 0.5000\nbaseline_metric: 0.5000\nobservation: no_improvement\nsummary: No improvement found\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:03:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 4,
+      "body": "Polyresearch release: thesis #30 by node `test-node` (`reason: no_improvement`).\n\n<!-- polyresearch:release\nthesis: 30\nnode: test-node\nreason: no_improvement\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:04:00Z",
+      "updated_at": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Introduces `ensure_lead_ready` guard that bundles lead identity + clean audit + current ledger checks. Replaces the ad-hoc `ensure_lead` + `ensure_clean_audit` pattern in `decide`, `policy-check`, and `generate`.
- `release` now closes the GitHub issue when the thesis becomes Exhausted (reason: `no_improvement`). Does not close on `timeout` or `infra_failure` (those return to Approved for re-claiming).
- `admin release-claim` gets the same close-on-exhausted behavior.
- Updates POLYRESEARCH.md to reflect both changes.

## Context

Bug report from [alanzabihi/postcss](https://github.com/alanzabihi/postcss): 12 theses were released with `no_improvement` but their GitHub issues remained open, and `results.tsv` was never populated. Root cause: the CLI had no unified concept of terminal-state management. `decide` closed issues but didn't require a current ledger; `release` didn't close issues at all.

The fix applies two principles uniformly:
1. Close the issue at every terminal boundary (Exhausted via release, Resolved via decide).
2. Gate all lead mutations on a single `ensure_lead_ready` precondition, which includes a stale-ledger check. After `decide` closes a thesis, `results.tsv` becomes stale, blocking the next `decide`/`policy-check`/`generate` until `sync` runs.

## Test plan

- [x] `release_closes_exhausted_thesis_on_no_improvement` — verifies `close_issue` called
- [x] `release_does_not_close_on_timeout` — verifies `close_issue` NOT called
- [x] `release_does_not_close_on_infra_failure` — verifies `close_issue` NOT called
- [x] `decide_rejects_stale_ledger` — verifies error when `results.tsv` is stale
- [x] `policy_check_rejects_stale_ledger` — verifies error when `results.tsv` is stale
- [x] All 43 e2e tests + 47 unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lead-facing command guards and issue-closing behavior, which can block `decide`/`policy-check`/`generate` and automatically close thesis issues on release; mistakes could disrupt project workflow or prematurely close issues.
> 
> **Overview**
> **Tightens lead command preconditions** by introducing `ensure_current_ledger` (clean audit + `results.tsv` freshness) and wiring it into `decide`, `policy-check`, and `generate`, replacing the prior audit-only checks and centralizing the stale-ledger error message.
> 
> **Automatically closes exhausted theses**: after `release` or `admin release-claim` with `reason: no_improvement`, the CLI re-derives state and closes the thesis issue if it is now `Exhausted` (but not for `timeout`/`infra_failure`).
> 
> Updates `POLYRESEARCH.md` to document the enforced stale-ledger gating and the new exhausted-thesis auto-close behavior, and extends e2e tests/fixtures to cover both behaviors (including mock support for `close_issue`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96fe02975a5b526f82687fa27ae1a10568061b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->