### PR TITLE
Bump CLI version to 0.3.4

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump CLI version from 0.3.3 to 0.3.4

## Release checklist

- [ ] Merge this PR
- [ ] Tag `v0.3.4` on the merge commit and push the tag
- [ ] Verify GitHub Actions release workflow succeeds (builds + GitHub Release)
- [ ] Verify the new `publish-crate` job publishes to crates.io automatically
- [ ] Confirm `cargo install polyresearch` installs 0.3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only bumps the CLI crate version in `Cargo.toml` and updates the corresponding entry in `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Bumps the CLI crate `polyresearch` version from `0.3.3` to `0.3.4` in `cli/Cargo.toml`, and updates the matching `polyresearch` package version in `cli/Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025438c72cf3aac74ea089d4963ce8ba811088ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->