### PR TITLE
Remove --no-worktree so contributors never hijack the main worktree

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -158,12 +158,13 @@ LOOP FOREVER:
 4. **Check for review work.** Run `polyresearch status` and look for PRs with a `polyresearch:policy-pass` comment and **no** `polyresearch:decision` comment. These need peer review. Skip PRs you authored.
 5. **If a reviewable PR exists:**
   a. Run `polyresearch review-claim <pr-number>`.
-   b. Check out the **candidate SHA** (the PR head).
+   b. Create a review worktree at the **candidate SHA** and change into it: `git worktree add .worktrees/review-<pr-number> <candidate-sha>`.
    c. Run the evaluation per PREPARE.md. Record the candidate metric.
-   d. Check out the **base SHA** (the PR's merge base on `main`).
+   d. In the same review worktree, check out the **base SHA** (the PR's merge base on `main`): `git checkout <base-sha>`. The review worktree is detached and disposable, so this is safe.
    e. Run the same evaluation. Record the baseline metric.
    f. If `.polyresearch/` exists, compute its content hash: `find .polyresearch/ -type f | sort | xargs sha256sum | sha256sum`.
    g. Run `polyresearch review <pr-number> --metric <candidate> --baseline <baseline> --observation <observation>`. Your `baseline_metric` is your own measurement. Do not copy it from results.tsv or the candidate's self-report.
+   h. Remove the review worktree: `git worktree remove .worktrees/review-<pr-number>`.
 6. Repeat from step 0.
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
@@ -342,7 +343,8 @@ repo-root/                                 (main worktree on `main`)
   ├── .git
   ├── .worktrees/                          (gitignored)
   │     ├── 12-rmsnorm/                    (worktree on `thesis/12-rmsnorm`)
-  │     └── 12-rmsnorm-attempt-2/          (optional parallel attempt worktree)
+  │     ├── 12-rmsnorm-attempt-2/          (optional parallel attempt worktree)
+  │     └── review-47/                     (disposable review worktree)
   └── ...                                  (lead stays here)
 ```
 
@@ -351,10 +353,12 @@ repo-root/                                 (main worktree on `main`)
 - Each claim creates a thesis worktree under `.worktrees/<issue-number>-<slug>/` on branch `thesis/<issue-number>-<slug>`.
 - Each attempt gets its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`, forked from the thesis branch.
 - When running attempts in parallel, create one worktree per active attempt.
+- Reviews use a disposable worktree under `.worktrees/review-<pr-number>/` for candidate and base SHA checkouts.
 - The candidate PR merges the best attempt's sub-branch into `main`.
 - Discarded attempts stay as unmerged branches. They are data, not waste.
-- Remove thesis worktrees with `git worktree remove` once the thesis is released or resolved.
-- Pass `--no-worktree` to `polyresearch claim` to skip worktree creation and create a branch in the current checkout instead. Useful in sandboxed environments that restrict worktree creation.
+- Remove thesis and review worktrees with `git worktree remove` once the work is done.
+
+**Main worktree invariant.** The repository root worktree stays on `main` at all times. Contributors must never change HEAD in the main worktree: no `git checkout`, no `git switch`, no `polyresearch claim` without a worktree. All thesis work happens in `.worktrees/<issue>-<slug>/` and all review checkouts happen in `.worktrees/review-<pr>/`. This invariant is what lets the lead run `sync`, `decide`, `generate`, and `policy-check` reliably while contributors work in parallel on the same checkout.
 
 ---
 
@@ -550,7 +554,7 @@ When `required_confirmations` is greater than 0, candidate PRs go through peer r
 
 1. **Policy check.** The lead diffs the candidate against the editable surface. If it touches files outside the CAN list: `outcome: policy_rejection`, PR closed. Otherwise: `polyresearch:policy-pass` posted.
 2. **Review claiming.** Contributors (who did not author the PR) find PRs with `polyresearch:policy-pass` and no `polyresearch:decision`. They post `polyresearch:review-claim`.
-3. **Evaluation.** The reviewer checks out the candidate SHA, runs the evaluation per PREPARE.md. Then checks out the base SHA, runs the same evaluation. Both metrics are measured independently.
+3. **Evaluation.** The reviewer creates a disposable review worktree at the candidate SHA (`git worktree add .worktrees/review-<pr> <candidate-sha>`), runs the evaluation per PREPARE.md, then checks out the base SHA in the same review worktree and runs it again. Both metrics are measured independently. The review worktree is removed when done.
 4. **Review record.** The reviewer posts a `polyresearch:review` comment with both metrics, observation, environment hash, and timestamp.
 5. **Maintainer gate.** If `auto_approve` is `false`, the lead waits for a maintainer `/approve` before deciding. The PR should be assigned to `maintainer_github_login` while it is waiting.
 6. **Decision.** When the reviewer requirements are satisfied, and the maintainer gate is satisfied when enabled, the lead evaluates and posts `polyresearch:decision`. Merges or closes the PR.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"

--- a/cli/README.md
+++ b/cli/README.md
@@ -118,7 +118,7 @@ polyresearch release 88 --reason no_improvement
 polyresearch batch-claim
 ```
 
-By default, `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. Pass `--no-worktree` only if you intentionally want the legacy single-working-tree checkout flow.
+`polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. The main worktree stays on `main` so the lead can sync, decide, and generate without races from concurrent contributors.
 
 `polyresearch batch-claim` is the multi-thesis version for contributors using sub-agents. It fills the node's free thesis slots up to `sub_agents`, creates one worktree per thesis, and requires worktrees for parallel execution.
 
@@ -164,7 +164,7 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 - `polyresearch pace` -- show configured sub-agents, active claims, free slots, effective resource policy, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
-- `polyresearch claim` -- atomically claim a thesis and create the thesis worktree (or a branch with `--no-worktree`)
+- `polyresearch claim` -- atomically claim a thesis and create the thesis worktree at `.worktrees/<issue>-<slug>/`
 - `polyresearch batch-claim` -- claim up to the node's free thesis slots and create one worktree per thesis
 - `polyresearch attempt` -- post a structured attempt comment from the current branch
 - `polyresearch release` -- release a claim with a structured reason

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -64,18 +64,12 @@ pub struct StatusArgs {
 #[derive(Debug, Args, Clone)]
 pub struct IssueArgs {
     pub issue: u64,
-
-    #[arg(long)]
-    pub no_worktree: bool,
 }
 
 #[derive(Debug, Args, Clone)]
 pub struct BatchClaimArgs {
     #[arg(long)]
     pub count: Option<usize>,
-
-    #[arg(long)]
-    pub no_worktree: bool,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -20,12 +20,6 @@ struct BatchClaimOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
-    if args.no_worktree {
-        return Err(eyre!(
-            "batch-claim requires separate worktrees; `--no-worktree` is not supported"
-        ));
-    }
-
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
@@ -88,7 +82,7 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
 
     let mut claims = Vec::with_capacity(theses.len());
     for thesis in theses {
-        match claim_selected_thesis(ctx, thesis, &node, false) {
+        match claim_selected_thesis(ctx, thesis, &node) {
             Ok(claim) => claims.push(claim),
             Err(error) => {
                 if claims.is_empty() {
@@ -136,12 +130,7 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
             .map(|entry| {
                 format!(
                     "  - thesis #{} on branch `{}` in worktree `{}`",
-                    entry.issue,
-                    entry.branch,
-                    entry
-                        .worktree_path
-                        .as_deref()
-                        .unwrap_or("<missing worktree>")
+                    entry.issue, entry.branch, entry.worktree_path
                 )
             })
             .collect::<Vec<_>>()

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -5,8 +5,8 @@ use crate::cli::IssueArgs;
 use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
 use crate::commands::{
-    AppContext, configured_sub_agents, create_thesis_branch, create_thesis_worktree,
-    node_active_claims, print_value, read_node_id, slugify, thesis_worktree_path,
+    AppContext, configured_sub_agents, create_thesis_worktree, node_active_claims, print_value,
+    read_node_id, slugify, thesis_worktree_path,
 };
 use crate::comments::ProtocolComment;
 use crate::state::{RepositoryState, ThesisState};
@@ -16,7 +16,7 @@ pub(crate) struct ClaimOutput {
     pub issue: u64,
     pub node: String,
     pub branch: String,
-    pub worktree_path: Option<String>,
+    pub worktree_path: String,
 }
 
 pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
@@ -60,26 +60,19 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
 
-    let output = claim_selected_thesis(ctx, thesis, &node, args.no_worktree)?;
+    let output = claim_selected_thesis(ctx, thesis, &node)?;
 
     print_value(ctx, &output, |value| {
-        match (&value.worktree_path, ctx.cli.dry_run) {
-            (Some(path), true) => format!(
+        if ctx.cli.dry_run {
+            format!(
                 "Would claim thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
-                value.issue, value.node, value.branch, path
-            ),
-            (Some(path), false) => format!(
+                value.issue, value.node, value.branch, value.worktree_path
+            )
+        } else {
+            format!(
                 "Claimed thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
-                value.issue, value.node, value.branch, path
-            ),
-            (None, true) => format!(
-                "Would claim thesis #{} as node `{}` on branch `{}`.",
-                value.issue, value.node, value.branch
-            ),
-            (None, false) => format!(
-                "Claimed thesis #{} as node `{}` on branch `{}`.",
-                value.issue, value.node, value.branch
-            ),
+                value.issue, value.node, value.branch, value.worktree_path
+            )
         }
     })
 }
@@ -88,7 +81,6 @@ pub(crate) fn claim_selected_thesis(
     ctx: &AppContext,
     thesis: &ThesisState,
     node: &str,
-    no_worktree: bool,
 ) -> Result<ClaimOutput> {
     let (branch, worktree_path) = if ctx.cli.dry_run {
         let branch = format!(
@@ -96,23 +88,17 @@ pub(crate) fn claim_selected_thesis(
             thesis.issue.number,
             slugify(&thesis.issue.title)
         );
-        let worktree_path = (!no_worktree).then(|| {
+        let worktree_path =
             thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)
                 .display()
-                .to_string()
-        });
+                .to_string();
         (branch, worktree_path)
-    } else if no_worktree {
-        (
-            create_thesis_branch(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?,
-            None,
-        )
     } else {
         let workspace =
             create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
         (
             workspace.branch,
-            Some(workspace.worktree_path.display().to_string()),
+            workspace.worktree_path.display().to_string(),
         )
     };
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -199,17 +199,6 @@ pub struct ThesisWorkspace {
     pub worktree_path: PathBuf,
 }
 
-pub fn create_thesis_branch(repo_root: &PathBuf, issue_number: u64, title: &str) -> Result<String> {
-    let slug = slugify(title);
-    let branch = format!("thesis/{issue_number}-{slug}");
-    run_git(repo_root, &["checkout", "main"])?;
-    if run_git(repo_root, &["rev-parse", "--verify", &branch]).is_ok() {
-        run_git(repo_root, &["branch", "-D", &branch])?;
-    }
-    run_git(repo_root, &["checkout", "-b", &branch])?;
-    Ok(branch)
-}
-
 pub fn thesis_worktree_path(repo_root: &PathBuf, issue_number: u64, title: &str) -> PathBuf {
     let slug = slugify(title);
     repo_root

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -661,7 +661,6 @@ async fn claim_rejects_already_claimed_thesis() {
         false,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "node-b").unwrap();
@@ -670,7 +669,6 @@ async fn claim_rejects_already_claimed_thesis() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -697,7 +695,6 @@ async fn claim_rejects_closed_thesis() {
         false,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "server").unwrap();
@@ -706,7 +703,6 @@ async fn claim_rejects_closed_thesis() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -833,7 +829,6 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
         true,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "node-a").unwrap();
@@ -842,7 +837,6 @@ async fn valid_claim_succeeds_in_dry_run_without_writing() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -871,7 +865,6 @@ async fn claim_creates_worktree_by_default() {
         false,
         Commands::Claim(IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_id(&repo.path, "node-a").unwrap();
@@ -880,7 +873,6 @@ async fn claim_creates_worktree_by_default() {
         &ctx,
         &IssueArgs {
             issue: fixture.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -951,22 +943,13 @@ async fn batch_claim_fills_remaining_capacity_only() {
         mock.clone(),
         &fixture_one.lead_github_login,
         false,
-        Commands::BatchClaim(BatchClaimArgs {
-            count: None,
-            no_worktree: false,
-        }),
+        Commands::BatchClaim(BatchClaimArgs { count: None }),
     );
     commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
 
-    commands::batch_claim::run(
-        &ctx,
-        &BatchClaimArgs {
-            count: None,
-            no_worktree: false,
-        },
-    )
-    .await
-    .unwrap();
+    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: None })
+        .await
+        .unwrap();
 
     let first_worktree = repo.path.join(".worktrees").join(format!(
         "{}-{}",
@@ -1019,22 +1002,13 @@ async fn batch_claim_reports_partial_success_when_later_claim_fails() {
         mock.clone(),
         &fixture_one.lead_github_login,
         false,
-        Commands::BatchClaim(BatchClaimArgs {
-            count: Some(2),
-            no_worktree: false,
-        }),
+        Commands::BatchClaim(BatchClaimArgs { count: Some(2) }),
     );
     commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
 
-    let error = commands::batch_claim::run(
-        &ctx,
-        &BatchClaimArgs {
-            count: Some(2),
-            no_worktree: false,
-        },
-    )
-    .await
-    .unwrap_err();
+    let error = commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(2) })
+        .await
+        .unwrap_err();
 
     assert!(error.to_string().contains("partially succeeded"));
     assert!(
@@ -1055,43 +1029,6 @@ async fn batch_claim_reports_partial_success_when_later_claim_fails() {
 }
 
 #[tokio::test]
-async fn batch_claim_rejects_no_worktree() {
-    let _guard = NodeIdEnvGuard::lock_clean();
-    let repo = TestRepo::new("batch-claim-no-worktree");
-    init_git_repo(&repo.path);
-    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
-    let mock = Arc::new(MockGitHubClient::new(
-        "alice",
-        vec![fixture.issue.clone()],
-        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
-        vec![],
-        HashMap::new(),
-    ));
-    let ctx = make_ctx(
-        repo.path.clone(),
-        mock,
-        &fixture.lead_github_login,
-        true,
-        Commands::BatchClaim(BatchClaimArgs {
-            count: Some(1),
-            no_worktree: true,
-        }),
-    );
-    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
-
-    let error = commands::batch_claim::run(
-        &ctx,
-        &BatchClaimArgs {
-            count: Some(1),
-            no_worktree: true,
-        },
-    )
-    .await
-    .unwrap_err();
-    assert!(error.to_string().contains("requires separate worktrees"));
-}
-
-#[tokio::test]
 async fn batch_claim_rejects_zero_count() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("batch-claim-zero");
@@ -1109,22 +1046,13 @@ async fn batch_claim_rejects_zero_count() {
         mock,
         &fixture.lead_github_login,
         true,
-        Commands::BatchClaim(BatchClaimArgs {
-            count: Some(0),
-            no_worktree: false,
-        }),
+        Commands::BatchClaim(BatchClaimArgs { count: Some(0) }),
     );
     commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
 
-    let error = commands::batch_claim::run(
-        &ctx,
-        &BatchClaimArgs {
-            count: Some(0),
-            no_worktree: false,
-        },
-    )
-    .await
-    .unwrap_err();
+    let error = commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(0) })
+        .await
+        .unwrap_err();
     assert!(error.to_string().contains("count must be at least 1"));
 }
 
@@ -1152,22 +1080,13 @@ async fn batch_claim_noops_when_already_at_capacity() {
         mock.clone(),
         &fixture_open.lead_github_login,
         false,
-        Commands::BatchClaim(BatchClaimArgs {
-            count: None,
-            no_worktree: false,
-        }),
+        Commands::BatchClaim(BatchClaimArgs { count: None }),
     );
     commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
 
-    commands::batch_claim::run(
-        &ctx,
-        &BatchClaimArgs {
-            count: None,
-            no_worktree: false,
-        },
-    )
-    .await
-    .unwrap();
+    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: None })
+        .await
+        .unwrap();
 
     assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
 }
@@ -1609,7 +1528,6 @@ async fn claim_allows_additional_claims_under_sub_agent_capacity() {
         true,
         Commands::Claim(IssueArgs {
             issue: fixture_open.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
@@ -1618,7 +1536,6 @@ async fn claim_allows_additional_claims_under_sub_agent_capacity() {
         &ctx,
         &IssueArgs {
             issue: fixture_open.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -1651,7 +1568,6 @@ async fn claim_blocks_when_already_at_sub_agent_capacity() {
         true,
         Commands::Claim(IssueArgs {
             issue: fixture_open.issue.number,
-            no_worktree: false,
         }),
     );
     commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
@@ -1660,7 +1576,6 @@ async fn claim_blocks_when_already_at_sub_agent_capacity() {
         &ctx,
         &IssueArgs {
             issue: fixture_open.issue.number,
-            no_worktree: false,
         },
     )
     .await
@@ -1799,13 +1714,7 @@ async fn duties_reports_idle_advisory_when_queue_empty_for_contributor() {
         vec![],
         HashMap::new(),
     ));
-    let ctx = make_ctx(
-        repo.path.clone(),
-        mock,
-        "lead-bot",
-        false,
-        Commands::Duties,
-    );
+    let ctx = make_ctx(repo.path.clone(), mock, "lead-bot", false, Commands::Duties);
     commands::write_node_id(&repo.path, "contributor-bot/node-1").unwrap();
 
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
@@ -1813,8 +1722,10 @@ async fn duties_reports_idle_advisory_when_queue_empty_for_contributor() {
         .unwrap();
     let report = commands::duties::check(&ctx, &repo_state).unwrap();
     assert!(
-        report.advisory.iter().any(|d| d.category == "idle"
-            && d.message.contains("Do not assume lead duties")),
+        report
+            .advisory
+            .iter()
+            .any(|d| d.category == "idle" && d.message.contains("Do not assume lead duties")),
         "should warn idle contributor not to assume lead duties, got: {:?}",
         report.advisory
     );

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -108,9 +108,14 @@ LOOP FOREVER:
   4. Check for review work (PRs with policy-pass, no decision,
      not authored by you):
      a. polyresearch review-claim <pr>
-     b. Evaluate candidate SHA and base SHA per PREPARE.md.
-     c. polyresearch review <pr> --metric <candidate> --baseline <base> \
+     b. Create a disposable review worktree at the candidate SHA:
+        git worktree add .worktrees/review-<pr> <candidate-sha>
+        cd into it. Evaluate per PREPARE.md.
+     c. In the same review worktree: git checkout <base-sha>
+        Evaluate per PREPARE.md.
+     d. polyresearch review <pr> --metric <candidate> --baseline <base> \
           --observation <obs>
+     e. git worktree remove .worktrees/review-<pr>
 
   5. Repeat from step 0.
 ```
@@ -208,6 +213,11 @@ contributor may work on in parallel. If `.polyresearch-node.toml` sets a
 These rules are extracted from `POLYRESEARCH.md`. The protocol is authoritative
 if any wording differs.
 
+- The main worktree stays on `main`. Never run `git checkout`, `git switch`, or
+  any other HEAD-changing command in the repo root. All thesis work happens in
+  `.worktrees/<issue>-<slug>/` and all review checkouts happen in
+  `.worktrees/review-<pr>/`. Breaking this invariant breaks the lead loop for
+  every concurrent agent on the same checkout.
 - Without sub-agents, post `polyresearch attempt` after every experiment.
 - With sub-agents, post every returned attempt as each sub-agent finishes its
   thesis. Sub-agents do not post to GitHub directly.


### PR DESCRIPTION
## Problem

When multiple contributor agents share one repo checkout, they switch HEAD away from \`main\` in the shared main worktree. This breaks every lead CLI operation (\`sync\`, \`decide\`, \`generate\`, \`policy-check\`) which require being on \`main\`. The race is unwinnable -- even chaining \`git checkout --force main &&\` before every lead command can't protect against another agent switching branches between any two commands.

## Root cause

Two code paths in the CLI/protocol mutate HEAD in the shared checkout:

1. **\`polyresearch claim --no-worktree\`** ran \`git checkout main\` + \`git checkout -b thesis/...\` directly in the repo root via \`create_thesis_branch()\`.
2. **The review workflow** told reviewers to \`git checkout <candidate-sha>\` and \`git checkout <base-sha>\` with no worktree.

Both violate the one-worktree-per-concurrent-process pattern the rest of polyresearch already follows (main worktree for lead, \`.worktrees/<issue>-<slug>/\` per claim via \`batch-claim\`, parallel-attempt worktrees).

## Fix (subtractive)

- **Delete \`--no-worktree\`** from \`IssueArgs\` and \`BatchClaimArgs\`, simplify \`claim_selected_thesis\` to always create a worktree, remove the now-unreachable \`batch-claim\` rejection check, and delete the \`create_thesis_branch\` helper.
- **Update \`POLYRESEARCH.md\`** review steps (5b-5h) to create a disposable \`.worktrees/review-<pr>/\` worktree for candidate/base SHA checkouts, and add an explicit **main-worktree invariant** so agents know the rule.
- **Bump to \`0.4.0\`** (breaking CLI change).
- **Update \`cli/README.md\`** to match.

Net: 52 insertions, 179 deletions across 9 files. No new guards, no new helpers -- the fix removes the two code paths that could cause the bug.

## Caveat

\`--no-worktree\` existed for environments where \`git worktree add\` is restricted. Users relying on it must switch to separate git clones per agent or stop running multiple concurrent agents on one checkout (which was never safe anyway). This is a deliberate tradeoff of the \`0.4.0\` version bump.

## Test plan

- [x] \`cargo build\` succeeds
- [x] \`cargo test\` -- all 42 e2e tests pass
- [x] \`cargo fmt -- --check\` clean on modified files
- [x] Obsolete \`batch_claim_rejects_no_worktree\` test removed
- [ ] Manual smoke test: run \`polyresearch claim <issue>\` from main worktree -- verifies \`.worktrees/<issue>-<slug>/\` created and main worktree HEAD unchanged
- [ ] Bump \`cli_version\` in downstream project \`PROGRAM.md\` files (postcss, eslint) after release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI change that removes a previously supported workflow and alters how claim/batch-claim operate, which could disrupt existing automation or constrained environments. Implementation is mostly subtractive and covered by updated e2e tests, keeping runtime risk moderate.
> 
> **Overview**
> This PR removes the `--no-worktree` escape hatch so `polyresearch claim`/`batch-claim` always create per-thesis worktrees and never mutate HEAD in the repo root; the internal `create_thesis_branch` path is deleted and claim outputs now always include a worktree path.
> 
> It also updates the protocol/docs to enforce a **main-worktree invariant** and to run peer review in a disposable `.worktrees/review-<pr>/` worktree for candidate/base SHA checkouts, and bumps the CLI version to `0.4.0` (breaking change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c01a04734cd9e3d9578362e2997be389757166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->