### PR TITLE
Bump CLI version to 0.4.1 for release

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.3.4
+cli_version: 0.4.1
 
 ## Goal
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `cli/Cargo.toml` from `0.4.0` to `0.4.1`
- Bump `PROGRAM.md` `cli_version` from `0.3.4` to `0.4.1` (was stale)
- Refresh `cli/Cargo.lock`

First release that includes the throttle + jittered retries from #53, which is additive (no breaking CLI surface changes since 0.4.0), hence a patch bump.

## Release workflow

The release workflow triggers on `v*.*.*` tag push, not on merge. After this PR merges, a `v0.4.1` tag needs to be pushed on `main` to kick off `.github/workflows/release.yml`.

## Test plan

- [x] `cargo test` passes (65 unit + 43 e2e)
- [ ] After merge: `git tag v0.4.1 <merge-sha> && git push origin v0.4.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/metadata bump with a lockfile refresh; no functional code changes are introduced in this diff.
> 
> **Overview**
> Prepares a `0.4.1` CLI release by bumping the `polyresearch` crate version in `cli/Cargo.toml` (and syncing `cli/Cargo.lock`).
> 
> Updates `PROGRAM.md` to set `cli_version: 0.4.1`, aligning the program metadata with the released CLI version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae89221571f2afc5ad2911853d6ccb2295b3e079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->