### PR TITLE
Replace sub_agents/resource_policy node config with capacity percent

### DIFF
--- a/POLYRESEARCH.md
+++ b/POLYRESEARCH.md
@@ -80,7 +80,7 @@ When you start, before doing anything else:
    export POLYRESEARCH_NODE_ID="${LOGIN}/${MACHINE_ID}"
    ```
 
-7. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"`. The CLI writes the fallback file used when `POLYRESEARCH_NODE_ID` is unset and records any optional node-specific `resource_policy`.
+7. If `.polyresearch-node.toml` does not exist yet, run `polyresearch init --node "$MACHINE_ID"`. The CLI writes the fallback file used when `POLYRESEARCH_NODE_ID` is unset and records any optional node-specific `capacity`.
 8. Identify your role. If your instructions explicitly say "you are the lead," follow the lead loop. Otherwise, follow the contributor loop. Do not infer your role from `lead_github_login`, queue state, or any other signal. Role comes from launch instructions only.
 
 ---
@@ -91,28 +91,22 @@ Each node keeps a local `.polyresearch-node.toml` file at the repo root:
 
 ```toml
 node_id = "alice/mac.lan-a3f2"
-sub_agents = 4
-resource_policy = "18-core machine. Run 4 evaluations in parallel. Stay under 50 API calls/min."
+capacity = 50
 api_budget = 5000
 request_delay_ms = 100
 ```
 
 - `node_id` identifies the machine or worker. Keep it stable for the lifetime of that worker or agent session.
-- `sub_agents` is the maximum number of theses this node may work on in parallel. It should match the number of evaluations the hardware can run simultaneously without interference.
-- `resource_policy` is optional natural language guidance for that node only. It is not project state.
+- `capacity` is an integer from 1 to 100 giving the percent of **total machine** resources this project may use. Honor-system: the CLI does not enforce OS-level isolation. Default `75` if absent, which leaves roughly 25% for the OS, disk I/O, monitoring, and the agent process itself. When multiple polyresearch projects share a host, set each project's `capacity` so the sum stays safe (for example, two projects at 35% each, or one primary at 50% + one secondary at 25%).
 - `api_budget` is the hourly budget that `polyresearch pace` uses for warnings and backoff guidance. It does not change GitHub's actual quota.
 - `request_delay_ms` is the minimum delay the CLI inserts between GitHub requests across local `polyresearch` processes. Increase it when multiple agents on the same machine and GitHub login are tripping secondary rate limits.
-- Set or update `node_id`, `sub_agents`, and `resource_policy` with `polyresearch init --sub-agents N --resource-policy "..."`. Edit `.polyresearch-node.toml` directly for `api_budget` and `request_delay_ms`.
+- Set or update `node_id` and `capacity` with `polyresearch init --capacity N`. Edit `.polyresearch-node.toml` directly for `api_budget` and `request_delay_ms`.
 - `POLYRESEARCH_NODE_ID` overrides `node_id` for the current process. Use it when multiple agents share one checkout or when one GitHub login needs several concurrent nodes.
 - If `POLYRESEARCH_NODE_ID` is unset, the CLI falls back to `.polyresearch-node.toml`.
 
-Sub-agents exist to improve hardware utilization. A contributor that works on one thesis at a time only runs one evaluation at a time. On a multi-core or multi-GPU machine, the rest of the hardware sits idle. When `sub_agents` is greater than 1, the contributor should keep up to that many theses in flight, one sub-agent per thesis, one worktree per thesis.
+The contributor is responsible for deciding how many theses to keep in flight at once. Run `polyresearch pace` regularly: it probes the machine, shows the `capacity`-derived hardware budget (cores, memory, GPUs), a live-free snapshot of current load and available memory, and the node's active claims. Read PROGRAM.md and PREPARE.md to learn each evaluation's resource footprint, then choose how many parallel evaluations fit inside the tighter of the two numbers (`Your max` and `Live free`). On a single-core or single-GPU-bottlenecked eval you will run one thesis at a time; on a smaller CPU-bound eval you may run several in parallel, one worktree per thesis.
 
-Without sub-agents (`sub_agents = 1` or absent), follow the normal contributor loop below.
-
-With sub-agents (`sub_agents > 1`), the contributor still owns the work. The contributor claims multiple theses, dispatches one sub-agent per thesis, waits for results, then posts attempt records, submits improvements, and releases non-improvements. Sub-agents do not interact with GitHub directly.
-
-Run `polyresearch pace` regularly. It prints the configured `sub_agents`, active claims, free slots, optional `resource_policy`, and recent activity so the contributor can compare intent vs. reality and adjust throughput.
+Any legacy `sub_agents` or `resource_policy` keys in an existing `.polyresearch-node.toml` are ignored and will be dropped on the next `polyresearch init`. The CLI prints a one-time warning when it encounters them.
 
 ---
 
@@ -134,7 +128,7 @@ Blocking duties exist when:
 - (Lead) Decidable PRs have not been decided.
 - (Lead) Open PRs have not been policy-checked.
 
-This mechanism exists because GitHub visibility is a shared resource. Other contributors, the lead, and the maintainer cannot see local-only work. A contributor may hold up to `sub_agents` active claims. Claims with zero posted attempts are advisory, not blocking, because the claim comment itself makes the work visible on GitHub.
+This mechanism exists because GitHub visibility is a shared resource. Other contributors, the lead, and the maintainer cannot see local-only work. Claims with zero posted attempts are advisory, not blocking, because the claim comment itself makes the work visible on GitHub.
 
 ---
 
@@ -143,13 +137,13 @@ This mechanism exists because GitHub visibility is a shared resource. Other cont
 LOOP FOREVER:
 
 0. **Check duties.** Run `polyresearch duties`. If any blocking items are reported, resolve each one before continuing. The CLI will also block `claim` if duties are outstanding.
-1. **Check pace.** Run `polyresearch pace`. Compare the effective resource policy against recent throughput and adjust how many experiments you run in parallel.
+1. **Check pace.** Run `polyresearch pace`. Compare your configured `capacity` share (`Your max`) and the live-free signal against your current active claims and recent throughput, then pick how many theses you will keep in flight this iteration. Your effective parallelism is the tighter of `Your max` and `Live free`, divided by each eval's resource footprint (from PREPARE.md).
 2. **Check for theses.** Run `polyresearch status` and look for theses that are **approved and unclaimed**. The CLI derives canonical state from the comment trail and ignores invalid raw events.
 3. **If a claimable thesis exists:**
-  a. Run `polyresearch claim <issue-number>`.
-   b. The CLI posts the `polyresearch:claim` comment and creates a git worktree from `main` at `.worktrees/<issue-number>-<slug>/` on branch `thesis/<issue-number>-<slug>`. Change into that worktree before editing.
+  a. To work a single thesis, run `polyresearch claim <issue-number>`. To run several theses in parallel on the same node, run `polyresearch batch-claim --count N` instead, where `N` is the number you decided in step 1. Either way the CLI posts the `polyresearch:claim` comment and creates one git worktree per claimed thesis.
+   b. Each claim creates a worktree from `main` at `.worktrees/<issue-number>-<slug>/` on branch `thesis/<issue-number>-<slug>`. Change into that worktree (or dispatch one sub-agent per worktree) before editing.
    c. Read PROGRAM.md for direction and constraints.
-   d. Run experiments from inside that thesis worktree. Each attempt uses its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`. If you run attempts in parallel, use one worktree per active attempt.
+   d. Run experiments from inside each thesis worktree. Each attempt uses its own sub-branch: `thesis/<issue-number>-<slug>-attempt-<n>`. If you run attempts in parallel for a single thesis, use one worktree per active attempt.
    e. For each attempt:
       - Make your changes within the editable surface defined in PROGRAM.md.
       - Commit your changes.
@@ -173,24 +167,7 @@ LOOP FOREVER:
 
 If there are no theses to claim and no PRs to review, wait briefly and check again.
 
-### Contributor loop with sub-agents
-
-When `.polyresearch-node.toml` sets `sub_agents` greater than 1, use this variant instead of working one thesis at a time:
-
-1. Run `polyresearch duties` and resolve blocking items.
-2. Run `polyresearch pace`.
-3. Run `polyresearch batch-claim`. It fills free thesis slots up to `sub_agents` and creates one worktree per thesis.
-4. Dispatch one sub-agent per claimed thesis. Each sub-agent:
-   - Works only in its assigned worktree.
-   - Reads `PROGRAM.md` and `PREPARE.md`.
-   - Designs and runs experiments for that thesis.
-   - Returns all completed attempts, metrics, observations, and summaries to the contributor.
-   - Does not run `polyresearch` commands and does not talk to GitHub.
-5. As each sub-agent finishes its thesis, immediately post every returned attempt with `polyresearch attempt`.
-6. If a thesis improved, run `polyresearch submit` for it immediately.
-7. If a thesis did not improve, run `polyresearch release` for it.
-8. Run `git worktree remove` for finished thesis worktrees.
-9. Repeat from step 1.
+**Parallelism via sub-agents.** When `polyresearch pace` shows that your `capacity` budget allows more than one concurrent evaluation, claim several theses at once with `polyresearch batch-claim --count N` and dispatch one sub-agent per claimed worktree. Each sub-agent works only in its assigned worktree, reads `PROGRAM.md` and `PREPARE.md`, designs and runs experiments for that thesis, and returns all completed attempts (metrics, observations, summaries) to the contributor. Sub-agents do not run `polyresearch` commands and do not talk to GitHub. As each sub-agent finishes its thesis, post every returned attempt with `polyresearch attempt`, then `polyresearch submit` if it improved or `polyresearch release` if it did not, and `git worktree remove` the finished worktree. Continue from step 0 in the loop above.
 
 **NEVER STOP.** Once the loop has begun, do not pause to ask the human if you should continue. Do not ask "should I keep going?" or "is this a good stopping point?" The human might be asleep or away and expects you to work indefinitely until manually stopped. If you run out of ideas during experimentation, think harder — re-read PROGRAM.md, study results.tsv for patterns in what worked and failed, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you.
 
@@ -207,7 +184,7 @@ The lead runs a separate management loop from the repository root worktree, whic
 **Priority order within each iteration.** GitHub-visible duties run first, in this order:
 
 0. `polyresearch duties` — resolve any blocking items (decidable PRs, stale results.tsv, etc.).
-1. `polyresearch pace` — compare your effective resource policy against recent node throughput.
+1. `polyresearch pace` — inspect the hardware budget and recent node throughput. The lead's `capacity` only matters if the lead is also evaluating review PRs locally; the lead's main job is coordination.
 2. `polyresearch sync` (always before other lead actions).
 3. Process open PRs: `policy-check` and `decide` any that are ready. When `auto_approve` is `false`, assign ready PRs to `maintainer_github_login` and wait for `/approve`.
 4. Check queue depth; `generate` if below `min_queue_depth`.

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.4.0
+cli_version: 0.4.1
 
 ## Goal
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The agent clones the repo, claims work from the issue queue, runs experiments, a
 
 A single contributor agent working on one thesis at a time only runs one evaluation at a time. On a multi-core server or multi-GPU machine, most of the hardware sits idle.
 
-Polyresearch can use sub-agents to keep that hardware busy. Set `sub_agents` in `.polyresearch-node.toml` to the number of evaluations the machine can run at once. The contributor then keeps up to that many theses in flight, one sub-agent per thesis, and posts results as each thesis finishes. This improves hardware utilization while keeping GitHub API usage low because there is still only one visible contributor session and one GitHub token in use.
+Polyresearch can use sub-agents to keep that hardware busy. Set `capacity` in `.polyresearch-node.toml` to the percent of the total machine this project may use (default 75). `polyresearch pace` probes the machine and prints your share (cores, memory, GPUs) alongside a live-free load snapshot; the contributor divides that by each eval's resource footprint from PREPARE.md, claims that many theses via `polyresearch batch-claim --count N`, dispatches one sub-agent per worktree, and posts results as each thesis finishes. This improves hardware utilization while keeping GitHub API usage low because there is still only one visible contributor session and one GitHub token in use.
 
 ### Run on a remote machine
 
@@ -116,7 +116,7 @@ Full command reference in [cli/README.md](cli/README.md).
 
 **Failed experiments are data.** Every attempt gets a row in `results.tsv` and stays as an unmerged branch. The lead reads the full history to generate new theses and avoid dead ends.
 
-**Resource pacing.** Each node can set a natural-language `resource_policy`. The `polyresearch pace` command compares the policy against recent throughput so agents can adjust their parallelism.
+**Resource pacing.** Each node sets a `capacity` percentage in `.polyresearch-node.toml` (default 75). The `polyresearch pace` command probes the hardware, prints the project's share plus live load, and lets the agent pick how many theses to run in parallel given each eval's footprint. Multi-project coexistence on one machine is honor-system: set each project's `capacity` so the sum stays safe.
 
 ## Examples
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -476,6 +476,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,7 +1256,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1639,6 +1664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2034,6 +2068,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sysinfo",
  "tokio",
  "toml",
  "walkdir",
@@ -2248,6 +2283,26 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2811,6 +2866,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -3514,16 +3583,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3531,6 +3633,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3553,6 +3666,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-result"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"
@@ -26,6 +26,7 @@ regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
+sysinfo = "0.32"
 tokio = { version = "1.51.0", features = ["full"] }
 toml = "1.1.2"
 walkdir = "2.5.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -92,10 +92,10 @@ Initialize the local node identity once per repo:
 
 ```bash
 polyresearch init
-polyresearch init --sub-agents 4 --resource-policy "Run 4 evals in parallel, stay under 50 API calls/min"
+polyresearch init --capacity 50
 ```
 
-This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id`, a `sub_agents` limit, and an optional natural-language `resource_policy`. Additional tuning fields such as `api_budget` and `request_delay_ms` are documented in `POLYRESEARCH.md`.
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` and a `capacity` percentage (1..=100) giving the share of the total machine this project may use. Additional tuning fields such as `api_budget` and `request_delay_ms` are documented in `POLYRESEARCH.md`.
 
 Inspect the current state:
 
@@ -127,7 +127,7 @@ polyresearch batch-claim
 
 `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. The main worktree stays on `main` so the lead can sync, decide, and generate without races from concurrent contributors.
 
-`polyresearch batch-claim` is the multi-thesis version for contributors using sub-agents. It fills the node's free thesis slots up to `sub_agents`, creates one worktree per thesis, and requires worktrees for parallel execution.
+`polyresearch batch-claim --count N` is the multi-thesis version for contributors dispatching sub-agents. It claims `N` approved theses, creates one worktree per thesis, and requires worktrees for parallel execution. Pick `N` from `polyresearch pace` after dividing your effective hardware budget by each eval's resource footprint.
 
 Review flow:
 
@@ -167,8 +167,8 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 ## Command summary
 
-- `polyresearch init` -- set node identity, sub-agent limit, optional resource policy, verify GitHub auth, detect repo
-- `polyresearch pace` -- show configured sub-agents, active claims, free slots, effective resource policy, and recent node throughput
+- `polyresearch init` -- set node identity and `capacity` (percent of total machine), verify GitHub auth, detect repo
+- `polyresearch pace` -- show the hardware budget (machine, your max, live free), GitHub API budget, active claims, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
 - `polyresearch claim` -- atomically claim a thesis and create the thesis worktree at `.worktrees/<issue>-<slug>/`

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -51,11 +51,8 @@ pub struct InitArgs {
     #[arg(long)]
     pub node: Option<String>,
 
-    #[arg(long)]
-    pub resource_policy: Option<String>,
-
-    #[arg(long)]
-    pub sub_agents: Option<usize>,
+    #[arg(long, value_parser = clap::value_parser!(u8).range(1..=100))]
+    pub capacity: Option<u8>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -4,18 +4,15 @@ use serde::Serialize;
 use crate::cli::BatchClaimArgs;
 use crate::commands::claim::{ClaimOutput, claim_selected_thesis};
 use crate::commands::duties;
-use crate::commands::{
-    AppContext, configured_sub_agents, node_active_claims, print_value, read_node_id,
-};
+use crate::commands::{AppContext, node_active_claims, print_value, read_node_id};
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
 
 #[derive(Debug, Serialize)]
 struct BatchClaimOutput {
     node: String,
-    sub_agents: usize,
     active_claims: usize,
     claimed_count: usize,
-    free_slots: usize,
+    requested_count: usize,
     claims: Vec<ClaimOutput>,
 }
 
@@ -36,46 +33,26 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
         ));
     }
 
-    let sub_agents = configured_sub_agents(&ctx.repo_root);
-    let active_claims = node_active_claims(&repo_state, &node);
-    let available_slots = sub_agents.saturating_sub(active_claims);
     if matches!(args.count, Some(0)) {
         return Err(eyre!("batch-claim count must be at least 1"));
     }
-    let requested = args.count.unwrap_or(available_slots);
-    let claim_count = requested.min(available_slots);
 
-    if claim_count == 0 {
-        let output = BatchClaimOutput {
-            node: node.clone(),
-            sub_agents,
-            active_claims,
-            claimed_count: 0,
-            free_slots: 0,
-            claims: Vec::new(),
-        };
-        return print_value(ctx, &output, |value| {
-            format!(
-                "Node `{}` is already at capacity ({}/{} active claims). No new theses claimed.",
-                value.node, value.active_claims, value.sub_agents
-            )
-        });
-    }
+    let requested = args.count.unwrap_or(1);
+    let active_claims = node_active_claims(&repo_state, &node);
 
-    let theses = select_claimable_theses(&repo_state, &node, claim_count);
+    let theses = select_claimable_theses(&repo_state, &node, requested);
     if theses.is_empty() {
         let output = BatchClaimOutput {
             node: node.clone(),
-            sub_agents,
             active_claims,
             claimed_count: 0,
-            free_slots: available_slots,
+            requested_count: requested,
             claims: Vec::new(),
         };
         return print_value(ctx, &output, |value| {
             format!(
-                "No claimable theses available for node `{}`. Free slots remaining: {}.",
-                value.node, value.free_slots
+                "No claimable theses available for node `{}` (requested {}).",
+                value.node, value.requested_count
             )
         });
     }
@@ -105,23 +82,22 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
 
     let output = BatchClaimOutput {
         node: node.clone(),
-        sub_agents,
         active_claims,
         claimed_count: claims.len(),
-        free_slots: available_slots.saturating_sub(claims.len()),
+        requested_count: requested,
         claims,
     };
 
     print_value(ctx, &output, |value| {
         let header = if ctx.cli.dry_run {
             format!(
-                "Would claim {} thesis slots for node `{}` ({} active, {} free after).",
-                value.claimed_count, value.node, value.active_claims, value.free_slots
+                "Would claim {} of {} requested thesis slots for node `{}` ({} already active).",
+                value.claimed_count, value.requested_count, value.node, value.active_claims
             )
         } else {
             format!(
-                "Claimed {} thesis slots for node `{}` ({} active before, {} free after).",
-                value.claimed_count, value.node, value.active_claims, value.free_slots
+                "Claimed {} of {} requested thesis slots for node `{}` ({} already active before).",
+                value.claimed_count, value.requested_count, value.node, value.active_claims
             )
         };
         let lines = value

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -5,8 +5,7 @@ use crate::cli::IssueArgs;
 use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
 use crate::commands::{
-    AppContext, configured_sub_agents, create_thesis_worktree, node_active_claims, print_value,
-    read_node_id, slugify, thesis_worktree_path,
+    AppContext, create_thesis_worktree, print_value, read_node_id, slugify, thesis_worktree_path,
 };
 use crate::comments::ProtocolComment;
 use crate::state::{RepositoryState, ThesisState};
@@ -36,16 +35,6 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         ));
     }
     let thesis = require_claimable_thesis(&repo_state, args.issue)?;
-    let active_claims = node_active_claims(&repo_state, &node);
-    let sub_agents = configured_sub_agents(&ctx.repo_root);
-    if active_claims >= sub_agents {
-        return Err(eyre!(
-            "node `{}` is already at configured sub-agent capacity ({}/{} active claims)",
-            node,
-            active_claims,
-            sub_agents
-        ));
-    }
     if !thesis.active_claims.is_empty() {
         let nodes = thesis
             .active_claims

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -1,9 +1,7 @@
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
-use crate::commands::{
-    AppContext, configured_sub_agents, node_active_claims, print_value, read_node_id,
-};
+use crate::commands::{AppContext, print_value, read_node_id};
 use crate::comments::Observation;
 use crate::ledger::Ledger;
 use crate::state::{RepositoryState, ThesisPhase};
@@ -34,12 +32,6 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
 
     let mut blocking = Vec::new();
     let mut advisory = Vec::new();
-    let sub_agents = configured_sub_agents(&ctx.repo_root);
-    let active_claims = if node_id.is_empty() {
-        0
-    } else {
-        node_active_claims(repo_state, &node_id)
-    };
 
     for thesis in &repo_state.theses {
         if thesis.issue.state != "OPEN" {
@@ -98,13 +90,6 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyRepor
 
     let has_review_work = check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
     if !is_lead {
-        add_contributor_capacity_advisory(
-            repo_state,
-            &node_id,
-            sub_agents,
-            active_claims,
-            &mut advisory,
-        );
         check_contributor_idle_state(ctx, repo_state, &node_id, has_review_work, &mut advisory)?;
     }
 
@@ -372,48 +357,6 @@ fn check_contributor_idle_state(
     }
 
     Ok(())
-}
-
-fn add_contributor_capacity_advisory(
-    repo_state: &RepositoryState,
-    node_id: &str,
-    sub_agents: usize,
-    active_claims: usize,
-    advisory: &mut Vec<DutyItem>,
-) {
-    if node_id.is_empty() || sub_agents <= 1 {
-        return;
-    }
-
-    let free_slots = sub_agents.saturating_sub(active_claims);
-    if free_slots == 0 {
-        return;
-    }
-
-    let claimable_for_me = repo_state
-        .theses
-        .iter()
-        .filter(|thesis| thesis.issue.state == "OPEN")
-        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
-        .filter(|thesis| {
-            !thesis
-                .releases
-                .iter()
-                .any(|release| release.node == node_id)
-        })
-        .count();
-    if claimable_for_me == 0 {
-        return;
-    }
-
-    advisory.push(DutyItem {
-        category: "capacity".to_string(),
-        message: format!(
-            "Free parallel slots: {} ({} active claims, sub_agents = {}).",
-            free_slots, active_claims, sub_agents
-        ),
-        command: format!("polyresearch batch-claim --count {}", free_slots),
-    });
 }
 
 fn metric_floor_info(ctx: &AppContext, repo_state: &RepositoryState) -> Option<(f64, f64)> {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -7,42 +7,28 @@ use serde::Serialize;
 
 use crate::cli::InitArgs;
 use crate::commands::{AppContext, print_value, read_node_config, write_node_config};
-use crate::config::{DEFAULT_RESOURCE_POLICY, DEFAULT_SUB_AGENTS};
+use crate::config::DEFAULT_CAPACITY;
 
 #[derive(Debug, Serialize)]
 struct InitOutput {
     repo: String,
     node: String,
     github_login: String,
-    resource_policy: Option<String>,
-    effective_resource_policy: String,
-    is_default_policy: bool,
-    sub_agents: usize,
+    capacity: u8,
 }
 
 pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
-    let requested_resource_policy = args
-        .resource_policy
-        .as_ref()
-        .map(|value| value.trim())
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
     let login = ctx.github.current_login()?;
     let _ = ctx.github.auth_status()?;
     let _ = ctx.github.auth_token()?;
     let machine_id = args.node.clone().unwrap_or_else(default_machine_id);
     let node = format!("{login}/{machine_id}");
     let existing_config = read_node_config(&ctx.repo_root).ok();
-    let resource_policy = requested_resource_policy.or_else(|| {
-        existing_config
-            .as_ref()
-            .and_then(|config| config.resource_policy.clone())
-    });
-    let existing_sub_agents = existing_config
+    let existing_capacity = existing_config
         .as_ref()
-        .map(|config| config.sub_agents)
-        .unwrap_or(DEFAULT_SUB_AGENTS);
-    let sub_agents = args.sub_agents.unwrap_or(existing_sub_agents).max(1);
+        .map(|config| config.capacity)
+        .unwrap_or(DEFAULT_CAPACITY);
+    let capacity = args.capacity.unwrap_or(existing_capacity);
 
     if let Ok(false) = ctx.github.repo_has_issues() {
         eprintln!("Warning: Issues are disabled on this repository (common for forks).");
@@ -53,41 +39,21 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     }
 
     if !ctx.cli.dry_run {
-        write_node_config(
-            &ctx.repo_root,
-            &node,
-            resource_policy.as_deref(),
-            Some(sub_agents),
-        )?;
+        write_node_config(&ctx.repo_root, &node, Some(capacity))?;
     }
-
-    let (effective_resource_policy, is_default_policy) = match &resource_policy {
-        Some(policy) => (policy.clone(), false),
-        None => (DEFAULT_RESOURCE_POLICY.to_string(), true),
-    };
 
     let output = InitOutput {
         repo: ctx.repo.slug(),
         node,
         github_login: login,
-        resource_policy,
-        effective_resource_policy,
-        is_default_policy,
-        sub_agents,
+        capacity,
     };
 
     print_value(ctx, &output, |value| {
-        let mut text = format!(
-            "Initialized polyresearch for {} as node `{}` (GitHub: {}).",
-            value.repo, value.node, value.github_login
-        );
-        if value.is_default_policy {
-            text.push_str(" Using the default resource policy.");
-        } else {
-            text.push_str(" Saved the custom resource policy.");
-        }
-        text.push_str(&format!(" Sub-agents: {}.", value.sub_agents));
-        text
+        format!(
+            "Initialized polyresearch for {} as node `{}` (GitHub: {}). Capacity: {}% of total machine.",
+            value.repo, value.node, value.github_login, value.capacity
+        )
     })
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -28,7 +28,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
-use crate::config::{DEFAULT_SUB_AGENTS, NodeConfig, ProgramSpec, ProtocolConfig};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, RepoRef};
 use crate::state::RepositoryState;
 
@@ -110,20 +110,15 @@ pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
 }
 
 pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
-    write_node_config(repo_root, node, None, None)
+    write_node_config(repo_root, node, None)
 }
 
 pub fn write_node_config(
     repo_root: &PathBuf,
     node: &str,
-    resource_policy: Option<&str>,
-    sub_agents: Option<usize>,
+    capacity: Option<u8>,
 ) -> Result<()> {
     let existing = NodeConfig::load(repo_root).ok();
-    let existing_resource_policy = existing
-        .as_ref()
-        .and_then(|config| config.resource_policy.as_deref())
-        .map(ToString::to_string);
     let existing_budget = existing
         .as_ref()
         .map(|config| config.api_budget)
@@ -132,26 +127,23 @@ pub fn write_node_config(
         .as_ref()
         .map(|config| config.request_delay_ms)
         .unwrap_or_else(|| NodeConfig::load_request_delay_ms(repo_root));
-    let existing_sub_agents = existing
+    let existing_capacity = existing
         .as_ref()
-        .map(|config| config.sub_agents)
-        .unwrap_or(DEFAULT_SUB_AGENTS);
+        .map(|config| config.capacity)
+        .unwrap_or(crate::config::DEFAULT_CAPACITY);
     NodeConfig::new(
         node.to_string(),
-        resource_policy
-            .map(ToString::to_string)
-            .or(existing_resource_policy),
+        capacity.unwrap_or(existing_capacity),
         existing_budget,
         existing_request_delay_ms,
-        sub_agents.unwrap_or(existing_sub_agents),
     )
     .save(repo_root)
 }
 
-pub fn configured_sub_agents(repo_root: &PathBuf) -> usize {
+pub fn configured_capacity(repo_root: &PathBuf) -> u8 {
     read_node_config(repo_root)
-        .map(|config| config.sub_agents)
-        .unwrap_or(DEFAULT_SUB_AGENTS)
+        .map(|config| config.capacity)
+        .unwrap_or(crate::config::DEFAULT_CAPACITY)
 }
 
 pub fn node_active_claims(repo_state: &RepositoryState, node_id: &str) -> usize {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -140,12 +140,6 @@ pub fn write_node_config(
     .save(repo_root)
 }
 
-pub fn configured_capacity(repo_root: &PathBuf) -> u8 {
-    read_node_config(repo_root)
-        .map(|config| config.capacity)
-        .unwrap_or(crate::config::DEFAULT_CAPACITY)
-}
-
 pub fn node_active_claims(repo_state: &RepositoryState, node_id: &str) -> usize {
     repo_state
         .theses

--- a/cli/src/commands/pace.rs
+++ b/cli/src/commands/pace.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::commands::{AppContext, exit_with, node_active_claims, print_value, read_node_config};
 use crate::config::NodeConfig;
 use crate::github::RateLimitStatus;
+use crate::hardware::{self, HardwareBudget, HardwareSnapshot};
 use crate::state::{RepositoryState, ThesisPhase};
 
 const RATE_LIMIT_EXIT_CODE: i32 = 75;
@@ -13,9 +14,9 @@ const RATE_LIMIT_EXIT_CODE: i32 = 75;
 pub struct PaceOutput {
     pub repo: String,
     pub node_id: String,
-    pub resource_policy: String,
-    pub is_default_policy: bool,
-    pub sub_agents: usize,
+    pub capacity: u8,
+    pub hardware: HardwareSnapshot,
+    pub budget: HardwareBudget,
     pub api_budget: u64,
     pub rate_limit: PaceRateLimit,
     pub attempts_last_hour: usize,
@@ -23,7 +24,6 @@ pub struct PaceOutput {
     pub idle_minutes: Option<i64>,
     pub claimable_theses: usize,
     pub active_claims: usize,
-    pub free_slots: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -53,12 +53,6 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     );
 
     print_value(ctx, &output, |value| {
-        let resource_label = if value.is_default_policy {
-            "Resource policy (default)"
-        } else {
-            "Resource policy"
-        };
-        let mut rendered = format_wrapped_policy(resource_label, &value.resource_policy);
         let idle = value
             .idle_minutes
             .map(|minutes| minutes.to_string())
@@ -71,8 +65,11 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
                 format!("{} (in {minutes} min)", timestamp.to_rfc3339())
             })
             .unwrap_or_else(|| "unknown".to_string());
-        rendered.push_str(&format!(
-            "\n\nAPI budget:\n  Configured budget:           {}/hr\n  GitHub core limit:           {}/hr\n  Remaining quota:             {}\n  Used quota:                  {}\n  Resets at:                   {}\n  Cost per command:            {} calls ({} issues + {} PRs + 2 lists)\n  Commands left:               ~{}\n  Near limit:                  {}\n\nThroughput ({}):\n  Configured sub-agents:       {}\n  Active claims:               {}\n  Free slots:                  {}\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}",
+        format!(
+            "Hardware budget:\n  Machine:       {}\n  Your max:      {}\n  Live free:     {}\n  Multi-project: honor-system, not tracked. Sum project capacities yourself.\n\nAPI budget:\n  Configured budget:           {}/hr\n  GitHub core limit:           {}/hr\n  Remaining quota:             {}\n  Used quota:                  {}\n  Resets at:                   {}\n  Cost per command:            {} calls ({} issues + {} PRs + 2 lists)\n  Commands left:               ~{}\n  Near limit:                  {}\n\nThroughput ({}):\n  Active claims:               {}\n  Attempts last hour:          {}\n  Attempts last 4 hours:       {}\n  Minutes since last activity: {}\n  Claimable theses idle:       {}",
+            hardware::format_machine_line(&value.hardware),
+            hardware::format_share_line(&value.budget),
+            hardware::format_live_line(&value.hardware),
             value.rate_limit.configured_budget,
             value.rate_limit.limit,
             value.rate_limit.remaining,
@@ -84,15 +81,12 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             value.rate_limit.commands_left,
             if value.rate_limit.is_low { "yes" } else { "no" },
             value.node_id,
-            value.sub_agents,
             value.active_claims,
-            value.free_slots,
             value.attempts_last_hour,
             value.attempts_last_4_hours,
             idle,
-            value.claimable_theses
-        ));
-        rendered
+            value.claimable_theses,
+        )
     })?;
 
     if output.rate_limit.remaining < output.rate_limit.derive_cost {
@@ -127,7 +121,9 @@ pub fn build_output(
     let one_hour_ago = now - Duration::hours(1);
     let four_hours_ago = now - Duration::hours(4);
     let node_id = node_config.node_id.clone();
-    let (resource_policy, is_default_policy) = node_config.effective_resource_policy();
+    let capacity = node_config.effective_capacity();
+    let hardware_snapshot = hardware::probe();
+    let budget = hardware::budget(&hardware_snapshot, capacity);
 
     let attempts = repo_state
         .theses
@@ -151,7 +147,6 @@ pub fn build_output(
         })
         .count();
     let active_claims = node_active_claims(repo_state, &node_id);
-    let free_slots = node_config.sub_agents.saturating_sub(active_claims);
     let idle_minutes = last_activity(repo_state, &node_id)
         .map(|timestamp| now.signed_duration_since(timestamp).num_minutes().max(0));
     let issue_count = repo_state.theses.len();
@@ -161,9 +156,9 @@ pub fn build_output(
     PaceOutput {
         repo,
         node_id,
-        resource_policy: resource_policy.to_string(),
-        is_default_policy,
-        sub_agents: node_config.sub_agents,
+        capacity,
+        hardware: hardware_snapshot,
+        budget,
         api_budget,
         rate_limit: PaceRateLimit {
             configured_budget: api_budget,
@@ -182,7 +177,6 @@ pub fn build_output(
         idle_minutes,
         claimable_theses,
         active_claims,
-        free_slots,
     }
 }
 
@@ -229,44 +223,4 @@ fn last_activity(repo_state: &RepositoryState, node_id: &str) -> Option<DateTime
     }
 
     timestamps.into_iter().max()
-}
-
-fn format_wrapped_policy(label: &str, policy: &str) -> String {
-    let lines = wrap_text(policy, 72);
-    let mut rendered = String::new();
-    if let Some((first, rest)) = lines.split_first() {
-        rendered.push_str(&format!("{label}: {first}"));
-        for line in rest {
-            rendered.push_str(&format!("\n  {line}"));
-        }
-    } else {
-        rendered.push_str(&format!("{label}:"));
-    }
-    rendered
-}
-
-fn wrap_text(text: &str, width: usize) -> Vec<String> {
-    let mut lines = Vec::new();
-    let mut current = String::new();
-
-    for word in text.split_whitespace() {
-        if current.is_empty() {
-            current.push_str(word);
-            continue;
-        }
-
-        if current.len() + 1 + word.len() > width {
-            lines.push(current);
-            current = word.to_string();
-        } else {
-            current.push(' ');
-            current.push_str(word);
-        }
-    }
-
-    if !current.is_empty() {
-        lines.push(current);
-    }
-
-    lines
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -144,10 +144,6 @@ fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
 }
 
 fn warn_if_legacy_fields(contents: &str) {
-    static WARNED: OnceLock<()> = OnceLock::new();
-    if WARNED.set(()).is_err() {
-        return;
-    }
     let has_sub_agents = contents
         .lines()
         .any(|line| line.trim_start().starts_with("sub_agents"));
@@ -155,6 +151,13 @@ fn warn_if_legacy_fields(contents: &str) {
         .lines()
         .any(|line| line.trim_start().starts_with("resource_policy"));
     if !has_sub_agents && !has_resource_policy {
+        return;
+    }
+    // Only consume the OnceLock once we know we have something to warn about,
+    // otherwise the first legacy-free load would spend the lock and silence
+    // every subsequent legacy load in the same process.
+    static WARNED: OnceLock<()> = OnceLock::new();
+    if WARNED.set(()).is_err() {
         return;
     }
     eprintln!("warning: .polyresearch-node.toml contains legacy field(s):");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,16 +2,16 @@ use std::borrow::Cow;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result, eyre};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_RESOURCE_POLICY: &str = "Maximize throughput. Never leave claimable theses idle while experiments could be running. Run evaluations in parallel when the evaluator supports it. Interleave duties with long-running evaluations.";
 pub const DEFAULT_API_BUDGET: u64 = 5_000;
 pub const DEFAULT_REQUEST_DELAY_MS: u64 = 100;
-pub const DEFAULT_SUB_AGENTS: usize = 1;
+pub const DEFAULT_CAPACITY: u8 = 75;
 pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,30 +24,26 @@ pub enum MetricDirection {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeConfig {
     pub node_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resource_policy: Option<String>,
+    #[serde(default = "default_capacity")]
+    pub capacity: u8,
     #[serde(default = "default_api_budget")]
     pub api_budget: u64,
     #[serde(default = "default_request_delay_ms")]
     pub request_delay_ms: u64,
-    #[serde(default = "default_sub_agents")]
-    pub sub_agents: usize,
 }
 
 impl NodeConfig {
     pub fn new(
         node_id: impl Into<String>,
-        resource_policy: Option<String>,
+        capacity: u8,
         api_budget: u64,
         request_delay_ms: u64,
-        sub_agents: usize,
     ) -> Self {
         Self {
             node_id: node_id.into(),
-            resource_policy: normalize_resource_policy(resource_policy),
+            capacity: normalize_capacity(capacity),
             api_budget: normalize_api_budget(api_budget),
             request_delay_ms: normalize_request_delay_ms(request_delay_ms),
-            sub_agents: normalize_sub_agents(sub_agents),
         }
     }
 
@@ -78,9 +74,10 @@ impl NodeConfig {
             }
         };
 
-        let resource_policy = file_config
+        let capacity = file_config
             .as_ref()
-            .and_then(|config| config.resource_policy.clone());
+            .map(|config| config.capacity)
+            .unwrap_or(DEFAULT_CAPACITY);
         let api_budget = file_config
             .as_ref()
             .map(|config| config.api_budget)
@@ -89,18 +86,8 @@ impl NodeConfig {
             .as_ref()
             .map(|config| config.request_delay_ms)
             .unwrap_or(DEFAULT_REQUEST_DELAY_MS);
-        let sub_agents = file_config
-            .as_ref()
-            .map(|config| config.sub_agents)
-            .unwrap_or(DEFAULT_SUB_AGENTS);
 
-        Ok(Self::new(
-            node_id,
-            resource_policy,
-            api_budget,
-            request_delay_ms,
-            sub_agents,
-        ))
+        Ok(Self::new(node_id, capacity, api_budget, request_delay_ms))
     }
 
     pub fn load_api_budget(repo_root: &Path) -> u64 {
@@ -132,17 +119,8 @@ impl NodeConfig {
         Ok(())
     }
 
-    pub fn resource_policy(&self) -> Option<&str> {
-        self.resource_policy
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-    }
-
-    pub fn effective_resource_policy(&self) -> (&str, bool) {
-        match self.resource_policy() {
-            Some(policy) => (policy, false),
-            None => (DEFAULT_RESOURCE_POLICY, true),
-        }
+    pub fn effective_capacity(&self) -> u8 {
+        normalize_capacity(self.capacity)
     }
 
     pub fn effective_api_budget(&self) -> u64 {
@@ -161,7 +139,40 @@ pub fn node_config_path(repo_root: &Path) -> PathBuf {
 fn load_node_config_from_file(path: &Path) -> Result<NodeConfig> {
     let contents =
         fs::read_to_string(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    warn_if_legacy_fields(&contents);
     toml::from_str(&contents).wrap_err_with(|| format!("failed to parse {}", path.display()))
+}
+
+fn warn_if_legacy_fields(contents: &str) {
+    static WARNED: OnceLock<()> = OnceLock::new();
+    if WARNED.set(()).is_err() {
+        return;
+    }
+    let has_sub_agents = contents
+        .lines()
+        .any(|line| line.trim_start().starts_with("sub_agents"));
+    let has_resource_policy = contents
+        .lines()
+        .any(|line| line.trim_start().starts_with("resource_policy"));
+    if !has_sub_agents && !has_resource_policy {
+        return;
+    }
+    eprintln!("warning: .polyresearch-node.toml contains legacy field(s):");
+    if has_sub_agents {
+        eprintln!(
+            "  `sub_agents` is no longer read. Use `capacity` (integer 1..=100, percent of total machine; default 75)."
+        );
+    }
+    if has_resource_policy {
+        eprintln!(
+            "  `resource_policy` is no longer read. Per-run guidance belongs in PROGRAM.md / PREPARE.md or the agent launch prompt."
+        );
+    }
+    eprintln!("  Running `polyresearch init` will drop these fields on the next save.");
+}
+
+fn default_capacity() -> u8 {
+    DEFAULT_CAPACITY
 }
 
 fn default_api_budget() -> u64 {
@@ -170,10 +181,6 @@ fn default_api_budget() -> u64 {
 
 fn default_request_delay_ms() -> u64 {
     DEFAULT_REQUEST_DELAY_MS
-}
-
-fn default_sub_agents() -> usize {
-    DEFAULT_SUB_AGENTS
 }
 
 fn node_id_override() -> Option<String> {
@@ -458,6 +465,28 @@ fn parse_bool(value: &str) -> Result<bool> {
     }
 }
 
+fn normalize_capacity(capacity: u8) -> u8 {
+    match capacity {
+        0 => DEFAULT_CAPACITY,
+        value if value > 100 => 100,
+        value => value,
+    }
+}
+
+fn normalize_request_delay_ms(request_delay_ms: u64) -> u64 {
+    match request_delay_ms {
+        0 => DEFAULT_REQUEST_DELAY_MS,
+        value => value,
+    }
+}
+
+fn normalize_api_budget(api_budget: u64) -> u64 {
+    match api_budget {
+        0 => DEFAULT_API_BUDGET,
+        value => value,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -600,23 +629,42 @@ mod tests {
         fs::write(
             &path,
             r#"node_id = "node-7f83"
-resource_policy = "Run 4 evals in parallel."
+capacity = 50
 api_budget = 15000
 request_delay_ms = 250
-sub_agents = 6
 "#,
         )
         .unwrap();
 
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "node-7f83");
-        assert_eq!(
-            config.resource_policy.as_deref(),
-            Some("Run 4 evals in parallel.")
-        );
+        assert_eq!(config.capacity, 50);
         assert_eq!(config.api_budget, 15_000);
         assert_eq!(config.request_delay_ms, 250);
-        assert_eq!(config.sub_agents, 6);
+
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn loads_legacy_toml_with_sub_agents_and_resource_policy() {
+        let _guard = NodeIdEnvGuard::lock_clean();
+        let repo_root = unique_temp_dir("node-config-legacy");
+        let path = node_config_path(&repo_root);
+        fs::write(
+            &path,
+            r#"node_id = "node-legacy"
+sub_agents = 4
+resource_policy = "Keep CPUs busy."
+api_budget = 5000
+"#,
+        )
+        .unwrap();
+
+        let config = NodeConfig::load(&repo_root).unwrap();
+        assert_eq!(config.node_id, "node-legacy");
+        // Legacy fields silently ignored; capacity takes its default.
+        assert_eq!(config.capacity, DEFAULT_CAPACITY);
+        assert_eq!(config.api_budget, 5_000);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -629,7 +677,7 @@ sub_agents = 6
         fs::write(
             &path,
             r#"node_id = "file-node"
-resource_policy = "Run 4 evals in parallel."
+capacity = 50
 "#,
         )
         .unwrap();
@@ -637,12 +685,8 @@ resource_policy = "Run 4 evals in parallel."
 
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
-        assert_eq!(
-            config.resource_policy.as_deref(),
-            Some("Run 4 evals in parallel.")
-        );
+        assert_eq!(config.capacity, 50);
         assert_eq!(config.request_delay_ms, DEFAULT_REQUEST_DELAY_MS);
-        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -655,9 +699,8 @@ resource_policy = "Run 4 evals in parallel."
 
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
-        assert_eq!(config.resource_policy, None);
+        assert_eq!(config.capacity, DEFAULT_CAPACITY);
         assert_eq!(config.request_delay_ms, DEFAULT_REQUEST_DELAY_MS);
-        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
@@ -672,58 +715,69 @@ resource_policy = "Run 4 evals in parallel."
 
         let config = NodeConfig::load(&repo_root).unwrap();
         assert_eq!(config.node_id, "env-node");
-        assert_eq!(config.resource_policy, None);
+        assert_eq!(config.capacity, DEFAULT_CAPACITY);
         assert_eq!(config.request_delay_ms, DEFAULT_REQUEST_DELAY_MS);
-        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
 
         fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
-    fn defaults_resource_policy_when_missing() {
+    fn defaults_capacity_when_zero() {
+        let config = NodeConfig::new("node-7f83", 0, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS);
+        assert_eq!(config.capacity, DEFAULT_CAPACITY);
+    }
+
+    #[test]
+    fn clamps_capacity_above_one_hundred() {
         let config = NodeConfig::new(
             "node-7f83",
-            None,
+            200,
             DEFAULT_API_BUDGET,
             DEFAULT_REQUEST_DELAY_MS,
-            DEFAULT_SUB_AGENTS,
         );
-        let (policy, is_default) = config.effective_resource_policy();
-        assert!(is_default);
-        assert_eq!(policy, DEFAULT_RESOURCE_POLICY);
+        assert_eq!(config.capacity, 100);
     }
 
     #[test]
     fn defaults_api_budget_when_missing() {
-        let config = NodeConfig::new(
-            "node-7f83",
-            None,
-            0,
-            DEFAULT_REQUEST_DELAY_MS,
-            DEFAULT_SUB_AGENTS,
-        );
+        let config = NodeConfig::new("node-7f83", DEFAULT_CAPACITY, 0, DEFAULT_REQUEST_DELAY_MS);
         assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
     }
 
     #[test]
-    fn defaults_sub_agents_when_zero() {
-        let config = NodeConfig::new(
-            "node-7f83",
-            None,
-            DEFAULT_API_BUDGET,
-            DEFAULT_REQUEST_DELAY_MS,
-            0,
-        );
-        assert_eq!(config.sub_agents, DEFAULT_SUB_AGENTS);
-    }
-
-    #[test]
     fn defaults_request_delay_when_zero() {
-        let config = NodeConfig::new("node-7f83", None, DEFAULT_API_BUDGET, 0, DEFAULT_SUB_AGENTS);
+        let config = NodeConfig::new("node-7f83", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, 0);
         assert_eq!(
             config.effective_request_delay_ms(),
             DEFAULT_REQUEST_DELAY_MS
         );
+    }
+
+    #[test]
+    fn round_trip_drops_legacy_fields_on_save() {
+        let _guard = NodeIdEnvGuard::lock_clean();
+        let repo_root = unique_temp_dir("node-config-round-trip");
+        let path = node_config_path(&repo_root);
+        fs::write(
+            &path,
+            r#"node_id = "node-legacy"
+sub_agents = 4
+resource_policy = "Keep CPUs busy."
+capacity = 50
+"#,
+        )
+        .unwrap();
+
+        let loaded = NodeConfig::load(&repo_root).unwrap();
+        loaded.save(&repo_root).unwrap();
+
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(!saved.contains("sub_agents"));
+        assert!(!saved.contains("resource_policy"));
+        assert!(saved.contains("capacity"));
+        assert!(saved.contains("50"));
+
+        fs::remove_dir_all(repo_root).unwrap();
     }
 
     #[test]
@@ -928,33 +982,5 @@ Do something.
         let path = std::env::temp_dir().join(format!("polyresearch-{name}-{unique}"));
         fs::create_dir_all(&path).unwrap();
         path
-    }
-}
-
-fn normalize_resource_policy(resource_policy: Option<String>) -> Option<String> {
-    resource_policy.and_then(|value| {
-        let trimmed = value.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_string())
-    })
-}
-
-fn normalize_sub_agents(sub_agents: usize) -> usize {
-    match sub_agents {
-        0 => DEFAULT_SUB_AGENTS,
-        value => value,
-    }
-}
-
-fn normalize_request_delay_ms(request_delay_ms: u64) -> u64 {
-    match request_delay_ms {
-        0 => DEFAULT_REQUEST_DELAY_MS,
-        value => value,
-    }
-}
-
-fn normalize_api_budget(api_budget: u64) -> u64 {
-    match api_budget {
-        0 => DEFAULT_API_BUDGET,
-        value => value,
     }
 }

--- a/cli/src/hardware.rs
+++ b/cli/src/hardware.rs
@@ -1,0 +1,387 @@
+//! Best-effort hardware probe used by `polyresearch pace` to tell the agent its
+//! effective working budget.
+//!
+//! The probe reports two layers:
+//!
+//! - Static machine spec: physical cores, total memory, GPUs. These come from
+//!   `sysinfo` (cross-platform) and best-effort shell-outs for GPU enumeration
+//!   (`nvidia-smi` on Linux, `system_profiler` on macOS).
+//! - Live state: 1-minute load average and currently-available memory, so the
+//!   agent can detect when another process is eating the machine and back off.
+//!
+//! GPU live utilization is intentionally not probed — the per-pace shell-out
+//! latency would outweigh the signal value, and GPU busy state changes faster
+//! than the pace loop cadence anyway.
+
+use std::process::Command;
+use std::thread;
+
+use serde::Serialize;
+use sysinfo::System;
+
+const BYTES_PER_GB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Platform {
+    MacOS,
+    Linux,
+    Other,
+}
+
+impl Platform {
+    fn current() -> Self {
+        if cfg!(target_os = "macos") {
+            Platform::MacOS
+        } else if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else {
+            Platform::Other
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Platform::MacOS => "macos",
+            Platform::Linux => "linux",
+            Platform::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuVendor {
+    Nvidia,
+    AppleSilicon,
+    Amd,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuInfo {
+    pub vendor: GpuVendor,
+    pub name: String,
+    pub memory_gb: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HardwareSnapshot {
+    pub logical_cores: usize,
+    pub physical_cores: usize,
+    pub total_memory_gb: f64,
+    pub gpus: Vec<GpuInfo>,
+    pub platform: Platform,
+    pub load_avg_1m: f64,
+    pub available_memory_gb: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HardwareBudget {
+    pub cores: usize,
+    pub memory_gb: f64,
+    pub gpus: usize,
+    pub capacity_pct: u8,
+}
+
+pub fn probe() -> HardwareSnapshot {
+    let mut system = System::new();
+    system.refresh_memory();
+    system.refresh_cpu_all();
+    let total_memory_gb = system.total_memory() as f64 / BYTES_PER_GB;
+    let available_memory_gb = system.available_memory() as f64 / BYTES_PER_GB;
+    let logical_cores = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let physical_cores = system.physical_core_count().unwrap_or(logical_cores);
+    let load = System::load_average();
+    let platform = Platform::current();
+    let gpus = detect_gpus(platform);
+
+    HardwareSnapshot {
+        logical_cores,
+        physical_cores,
+        total_memory_gb,
+        gpus,
+        platform,
+        load_avg_1m: load.one,
+        available_memory_gb,
+    }
+}
+
+pub fn budget(snapshot: &HardwareSnapshot, capacity_pct: u8) -> HardwareBudget {
+    let pct = capacity_pct.clamp(1, 100);
+    let pct_usize = pct as usize;
+    HardwareBudget {
+        cores: (snapshot.physical_cores * pct_usize / 100).max(1),
+        memory_gb: snapshot.total_memory_gb * pct as f64 / 100.0,
+        gpus: snapshot.gpus.len() * pct_usize / 100,
+        capacity_pct: pct,
+    }
+}
+
+fn detect_gpus(platform: Platform) -> Vec<GpuInfo> {
+    match platform {
+        Platform::Linux => detect_nvidia_smi(),
+        Platform::MacOS => detect_macos_gpus(),
+        Platform::Other => Vec::new(),
+    }
+}
+
+fn detect_nvidia_smi() -> Vec<GpuInfo> {
+    let Ok(output) = Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=name,memory.total",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let Ok(text) = String::from_utf8(output.stdout) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter_map(|line| {
+            let (name, memory) = line.split_once(',')?;
+            let name = name.trim().to_string();
+            if name.is_empty() {
+                return None;
+            }
+            let memory_mb: f64 = memory.trim().parse().ok()?;
+            Some(GpuInfo {
+                vendor: GpuVendor::Nvidia,
+                name,
+                memory_gb: Some(memory_mb / 1024.0),
+            })
+        })
+        .collect()
+}
+
+fn detect_macos_gpus() -> Vec<GpuInfo> {
+    let Ok(output) = Command::new("system_profiler")
+        .args(["SPDisplaysDataType", "-json"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let Ok(text) = String::from_utf8(output.stdout) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    let Some(displays) = value.get("SPDisplaysDataType").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    displays
+        .iter()
+        .map(|display| {
+            let name = display
+                .get("sppci_model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown GPU")
+                .to_string();
+            let vendor_raw = display
+                .get("sppci_vendor")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let vendor = if vendor_raw.contains("Apple") || name.contains("Apple") {
+                GpuVendor::AppleSilicon
+            } else if vendor_raw.contains("NVIDIA") {
+                GpuVendor::Nvidia
+            } else if vendor_raw.contains("AMD") || vendor_raw.contains("ATI") {
+                GpuVendor::Amd
+            } else {
+                GpuVendor::Unknown
+            };
+            GpuInfo {
+                vendor,
+                name,
+                memory_gb: None,
+            }
+        })
+        .collect()
+}
+
+/// Format a snapshot for the `pace` "Machine" line.
+pub fn format_machine_line(snapshot: &HardwareSnapshot) -> String {
+    let gpu_summary = if snapshot.gpus.is_empty() {
+        "0 GPUs".to_string()
+    } else {
+        let counts = group_gpus(&snapshot.gpus);
+        counts.join(", ")
+    };
+    format!(
+        "{} physical cores ({} logical), {:.1} GB RAM, {} ({})",
+        snapshot.physical_cores,
+        snapshot.logical_cores,
+        snapshot.total_memory_gb,
+        gpu_summary,
+        snapshot.platform.as_str(),
+    )
+}
+
+/// Format the "Your max" share for pace output.
+pub fn format_share_line(budget: &HardwareBudget) -> String {
+    let gpu_part = if budget.gpus == 0 {
+        "0 GPUs".to_string()
+    } else if budget.gpus == 1 {
+        "1 GPU".to_string()
+    } else {
+        format!("{} GPUs", budget.gpus)
+    };
+    format!(
+        "{}% -> {} cores, {:.1} GB, {}",
+        budget.capacity_pct, budget.cores, budget.memory_gb, gpu_part,
+    )
+}
+
+/// Format the live-free line for pace output.
+pub fn format_live_line(snapshot: &HardwareSnapshot) -> String {
+    format!(
+        "load avg {:.1}/{}, {:.1} GB available",
+        snapshot.load_avg_1m, snapshot.logical_cores, snapshot.available_memory_gb,
+    )
+}
+
+fn group_gpus(gpus: &[GpuInfo]) -> Vec<String> {
+    let mut groups: Vec<(String, usize, Option<f64>)> = Vec::new();
+    for gpu in gpus {
+        if let Some(entry) = groups.iter_mut().find(|entry| entry.0 == gpu.name) {
+            entry.1 += 1;
+        } else {
+            groups.push((gpu.name.clone(), 1, gpu.memory_gb));
+        }
+    }
+    groups
+        .into_iter()
+        .map(|(name, count, memory)| match (count, memory) {
+            (1, Some(memory_gb)) => format!("1 x {name} ({memory_gb:.0} GB)"),
+            (1, None) => format!("1 x {name}"),
+            (n, Some(memory_gb)) => format!("{n} x {name} ({memory_gb:.0} GB each)"),
+            (n, None) => format!("{n} x {name}"),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_for(cores: usize, mem_gb: f64, gpus: usize) -> HardwareSnapshot {
+        HardwareSnapshot {
+            logical_cores: cores * 2,
+            physical_cores: cores,
+            total_memory_gb: mem_gb,
+            gpus: (0..gpus)
+                .map(|_| GpuInfo {
+                    vendor: GpuVendor::Nvidia,
+                    name: "Test GPU".to_string(),
+                    memory_gb: Some(48.0),
+                })
+                .collect(),
+            platform: Platform::Linux,
+            load_avg_1m: 1.0,
+            available_memory_gb: mem_gb * 0.5,
+        }
+    }
+
+    #[test]
+    fn budget_scales_by_capacity_percent() {
+        let snapshot = snapshot_for(18, 128.0, 2);
+        let b = budget(&snapshot, 50);
+        assert_eq!(b.cores, 9);
+        assert!((b.memory_gb - 64.0).abs() < 0.01);
+        assert_eq!(b.gpus, 1);
+        assert_eq!(b.capacity_pct, 50);
+    }
+
+    #[test]
+    fn budget_clamps_capacity_to_valid_range() {
+        let snapshot = snapshot_for(4, 16.0, 0);
+        assert_eq!(budget(&snapshot, 0).capacity_pct, 1);
+        assert_eq!(budget(&snapshot, 200).capacity_pct, 100);
+    }
+
+    #[test]
+    fn budget_never_returns_zero_cores() {
+        let snapshot = snapshot_for(2, 8.0, 0);
+        let b = budget(&snapshot, 1);
+        assert_eq!(b.cores, 1);
+    }
+
+    #[test]
+    fn budget_rounds_gpus_down() {
+        let snapshot = snapshot_for(8, 64.0, 3);
+        let b = budget(&snapshot, 50);
+        assert_eq!(b.gpus, 1);
+    }
+
+    #[test]
+    fn budget_covers_full_machine_at_100() {
+        let snapshot = snapshot_for(8, 64.0, 2);
+        let b = budget(&snapshot, 100);
+        assert_eq!(b.cores, 8);
+        assert!((b.memory_gb - 64.0).abs() < 0.01);
+        assert_eq!(b.gpus, 2);
+    }
+
+    #[test]
+    fn probe_reports_plausible_machine() {
+        // Runs against whatever CI/host we're on. Must return non-zero cores
+        // and non-zero memory, and a recognized platform.
+        let snapshot = probe();
+        assert!(snapshot.logical_cores >= 1);
+        assert!(snapshot.physical_cores >= 1);
+        assert!(snapshot.total_memory_gb > 0.0);
+        assert!(snapshot.available_memory_gb >= 0.0);
+        assert!(
+            matches!(
+                snapshot.platform,
+                Platform::MacOS | Platform::Linux | Platform::Other
+            )
+        );
+    }
+
+    #[test]
+    fn format_machine_line_includes_gpu_summary() {
+        let snapshot = snapshot_for(18, 128.0, 2);
+        let line = format_machine_line(&snapshot);
+        assert!(line.contains("18 physical cores"));
+        assert!(line.contains("128.0 GB RAM"));
+        assert!(line.contains("Test GPU"));
+    }
+
+    #[test]
+    fn format_machine_line_handles_no_gpus() {
+        let snapshot = snapshot_for(4, 8.0, 0);
+        let line = format_machine_line(&snapshot);
+        assert!(line.contains("0 GPUs"));
+    }
+
+    #[test]
+    fn format_share_line_renders_budget() {
+        let snapshot = snapshot_for(18, 128.0, 2);
+        let b = budget(&snapshot, 50);
+        let line = format_share_line(&b);
+        assert!(line.contains("50%"));
+        assert!(line.contains("9 cores"));
+        assert!(line.contains("64.0 GB"));
+        assert!(line.contains("1 GPU"));
+    }
+
+    #[test]
+    fn format_live_line_reports_load_and_memory() {
+        let snapshot = snapshot_for(18, 128.0, 0);
+        let line = format_live_line(&snapshot);
+        assert!(line.contains("load avg"));
+        assert!(line.contains("GB available"));
+    }
+}

--- a/cli/src/hardware.rs
+++ b/cli/src/hardware.rs
@@ -112,10 +112,19 @@ pub fn probe() -> HardwareSnapshot {
 pub fn budget(snapshot: &HardwareSnapshot, capacity_pct: u8) -> HardwareBudget {
     let pct = capacity_pct.clamp(1, 100);
     let pct_usize = pct as usize;
+    let gpu_count = snapshot.gpus.len();
     HardwareBudget {
         cores: (snapshot.physical_cores * pct_usize / 100).max(1),
         memory_gb: snapshot.total_memory_gb * pct as f64 / 100.0,
-        gpus: snapshot.gpus.len() * pct_usize / 100,
+        // GPUs are integers, not divisible. Floor-rounding hides single-GPU
+        // boxes from the agent (1 * 75 / 100 = 0), so when at least one GPU
+        // exists, give the project at least one. Multi-project oversubscription
+        // is the user's honor-system responsibility.
+        gpus: if gpu_count == 0 {
+            0
+        } else {
+            (gpu_count * pct_usize / 100).max(1)
+        },
         capacity_pct: pct,
     }
 }
@@ -318,10 +327,28 @@ mod tests {
     }
 
     #[test]
-    fn budget_rounds_gpus_down() {
+    fn budget_rounds_gpus_down_when_quotient_is_at_least_one() {
         let snapshot = snapshot_for(8, 64.0, 3);
         let b = budget(&snapshot, 50);
         assert_eq!(b.gpus, 1);
+    }
+
+    #[test]
+    fn budget_floors_gpus_at_one_when_machine_has_a_gpu() {
+        // Default 75% capacity on a 1-GPU box must surface that GPU to the
+        // agent, otherwise GPU evals never run on single-GPU machines.
+        let snapshot = snapshot_for(8, 64.0, 1);
+        let b = budget(&snapshot, 75);
+        assert_eq!(b.gpus, 1);
+        let b = budget(&snapshot, 1);
+        assert_eq!(b.gpus, 1);
+    }
+
+    #[test]
+    fn budget_reports_zero_gpus_when_machine_has_none() {
+        let snapshot = snapshot_for(8, 64.0, 0);
+        let b = budget(&snapshot, 100);
+        assert_eq!(b.gpus, 0);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod comments;
 pub mod config;
 pub mod github;
 pub mod github_debug;
+pub mod hardware;
 pub mod ledger;
 pub mod state;
 pub mod throttle;

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -310,8 +310,7 @@ async fn init_writes_node_identity() {
         false,
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
-            resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
-            sub_agents: Some(4),
+            capacity: Some(50),
         }),
     );
 
@@ -319,8 +318,7 @@ async fn init_writes_node_identity() {
         &ctx,
         &InitArgs {
             node: Some("test-node".to_string()),
-            resource_policy: Some("Use 2 GPUs and keep them busy.".to_string()),
-            sub_agents: Some(4),
+            capacity: Some(50),
         },
     )
     .await
@@ -329,12 +327,8 @@ async fn init_writes_node_identity() {
     let node_file = repo.path.join(".polyresearch-node.toml");
     let config: NodeConfig = toml::from_str(&fs::read_to_string(node_file).unwrap()).unwrap();
     assert_eq!(config.node_id, "lead/test-node");
-    assert_eq!(
-        config.resource_policy.as_deref(),
-        Some("Use 2 GPUs and keep them busy.")
-    );
     assert_eq!(config.api_budget, DEFAULT_API_BUDGET);
-    assert_eq!(config.sub_agents, 4);
+    assert_eq!(config.capacity, 50);
 }
 
 #[tokio::test]
@@ -349,13 +343,7 @@ async fn env_override_uses_session_node_id() {
         HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
-    commands::write_node_config(
-        &repo.path,
-        "lead/file-node",
-        Some("Keep CPUs saturated."),
-        Some(6),
-    )
-    .unwrap();
+    commands::write_node_config(&repo.path, "lead/file-node", Some(60)).unwrap();
     set_node_id_env("lead/env-node");
 
     let node_config = NodeConfig::load(&repo.path).unwrap();
@@ -371,10 +359,8 @@ async fn env_override_uses_session_node_id() {
     );
 
     assert_eq!(output.node_id, "lead/env-node");
-    assert_eq!(output.resource_policy, "Keep CPUs saturated.");
-    assert!(!output.is_default_policy);
-    assert_eq!(output.sub_agents, 6);
-    assert_eq!(output.free_slots, 6);
+    assert_eq!(output.capacity, 60);
+    assert_eq!(output.budget.capacity_pct, 60);
     assert_eq!(output.rate_limit.configured_budget, DEFAULT_API_BUDGET);
 }
 
@@ -431,13 +417,11 @@ async fn pace_reports_default_policy_and_node_metrics() {
     );
 
     assert_eq!(output.node_id, "test-node");
-    assert!(output.is_default_policy);
+    assert_eq!(output.capacity, polyresearch::config::DEFAULT_CAPACITY);
     assert_eq!(output.attempts_last_hour, 1);
     assert_eq!(output.attempts_last_4_hours, 1);
     assert_eq!(output.claimable_theses, 1);
     assert_eq!(output.active_claims, 2);
-    assert_eq!(output.sub_agents, 1);
-    assert_eq!(output.free_slots, 0);
     assert_eq!(output.idle_minutes, Some(0));
     assert_eq!(output.rate_limit.derive_cost, 5);
     assert_eq!(output.rate_limit.commands_left, 769);
@@ -528,8 +512,7 @@ async fn init_preserves_custom_api_budget() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: None,
+            capacity: None,
         }),
     );
 
@@ -537,8 +520,7 @@ async fn init_preserves_custom_api_budget() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: None,
+            capacity: None,
         },
     )
     .await
@@ -547,7 +529,7 @@ async fn init_preserves_custom_api_budget() {
     let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
     assert_eq!(config.node_id, "lead/new-node");
     assert_eq!(config.api_budget, 1_000);
-    assert_eq!(config.sub_agents, 1);
+    assert_eq!(config.capacity, polyresearch::config::DEFAULT_CAPACITY);
 }
 
 #[tokio::test]
@@ -575,8 +557,7 @@ async fn init_preserves_custom_request_delay() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: None,
+            capacity: None,
         }),
     );
 
@@ -584,8 +565,7 @@ async fn init_preserves_custom_request_delay() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: None,
+            capacity: None,
         },
     )
     .await
@@ -594,13 +574,13 @@ async fn init_preserves_custom_request_delay() {
     let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
     assert_eq!(config.node_id, "lead/new-node");
     assert_eq!(config.request_delay_ms, 250);
-    assert_eq!(config.sub_agents, 1);
+    assert_eq!(config.capacity, polyresearch::config::DEFAULT_CAPACITY);
 }
 
 #[tokio::test]
-async fn init_preserves_existing_resource_policy_and_updates_sub_agents() {
+async fn init_drops_legacy_fields_and_writes_capacity() {
     let _guard = NodeIdEnvGuard::lock_clean();
-    let repo = TestRepo::new("init-resource-policy");
+    let repo = TestRepo::new("init-legacy-drop");
     let toml_path = repo.path.join(".polyresearch-node.toml");
     fs::write(
         &toml_path,
@@ -622,8 +602,7 @@ async fn init_preserves_existing_resource_policy_and_updates_sub_agents() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: Some(8),
+            capacity: Some(40),
         }),
     );
 
@@ -631,20 +610,24 @@ async fn init_preserves_existing_resource_policy_and_updates_sub_agents() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            resource_policy: None,
-            sub_agents: Some(8),
+            capacity: Some(40),
         },
     )
     .await
     .unwrap();
 
-    let config: NodeConfig = toml::from_str(&fs::read_to_string(&toml_path).unwrap()).unwrap();
-    assert_eq!(config.node_id, "lead/new-node");
-    assert_eq!(
-        config.resource_policy.as_deref(),
-        Some("Keep CPUs saturated.")
+    let raw = fs::read_to_string(&toml_path).unwrap();
+    assert!(
+        !raw.contains("sub_agents"),
+        "legacy `sub_agents` should be dropped on save"
     );
-    assert_eq!(config.sub_agents, 8);
+    assert!(
+        !raw.contains("resource_policy"),
+        "legacy `resource_policy` should be dropped on save"
+    );
+    let config: NodeConfig = toml::from_str(&raw).unwrap();
+    assert_eq!(config.node_id, "lead/new-node");
+    assert_eq!(config.capacity, 40);
 }
 
 #[tokio::test]
@@ -950,11 +933,10 @@ async fn claim_creates_worktree_by_default() {
 }
 
 #[tokio::test]
-async fn batch_claim_fills_remaining_capacity_only() {
+async fn batch_claim_claims_requested_count() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("batch-claim");
     init_git_repo(&repo.path);
-    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
     let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
     let mut fixture_two = load_issue_fixture("acknowledged_invalid_issue.json");
     fixture_two.issue.number = fixture_one.issue.number + 1;
@@ -969,16 +951,8 @@ async fn batch_claim_fills_remaining_capacity_only() {
     }
     let mock = Arc::new(MockGitHubClient::new(
         "alice",
-        vec![
-            fixture_claimed.issue.clone(),
-            fixture_one.issue.clone(),
-            fixture_two.issue.clone(),
-        ],
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
         HashMap::from([
-            (
-                fixture_claimed.issue.number,
-                fixture_claimed.comments.clone(),
-            ),
             (fixture_one.issue.number, fixture_one.comments.clone()),
             (fixture_two.issue.number, fixture_two.comments.clone()),
         ]),
@@ -990,11 +964,11 @@ async fn batch_claim_fills_remaining_capacity_only() {
         mock.clone(),
         &fixture_one.lead_github_login,
         false,
-        Commands::BatchClaim(BatchClaimArgs { count: None }),
+        Commands::BatchClaim(BatchClaimArgs { count: Some(1) }),
     );
-    commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
+    commands::write_node_id(&repo.path, "test-node").unwrap();
 
-    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: None })
+    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(1) })
         .await
         .unwrap();
 
@@ -1007,7 +981,7 @@ async fn batch_claim_fills_remaining_capacity_only() {
     assert_eq!(
         mock.posted_issue_comments.lock().unwrap().len(),
         1,
-        "should only claim one additional thesis because one slot was already occupied"
+        "should claim exactly the requested count"
     );
 }
 
@@ -1051,7 +1025,7 @@ async fn batch_claim_reports_partial_success_when_later_claim_fails() {
         false,
         Commands::BatchClaim(BatchClaimArgs { count: Some(2) }),
     );
-    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+    commands::write_node_id(&repo.path, "node-a").unwrap();
 
     let error = commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(2) })
         .await
@@ -1095,47 +1069,12 @@ async fn batch_claim_rejects_zero_count() {
         true,
         Commands::BatchClaim(BatchClaimArgs { count: Some(0) }),
     );
-    commands::write_node_config(&repo.path, "node-a", None, Some(2)).unwrap();
+    commands::write_node_id(&repo.path, "node-a").unwrap();
 
     let error = commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(0) })
         .await
         .unwrap_err();
     assert!(error.to_string().contains("count must be at least 1"));
-}
-
-#[tokio::test]
-async fn batch_claim_noops_when_already_at_capacity() {
-    let _guard = NodeIdEnvGuard::lock_clean();
-    let repo = TestRepo::new("batch-claim-capacity");
-    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
-    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
-    let mock = Arc::new(MockGitHubClient::new(
-        "alice",
-        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
-        HashMap::from([
-            (
-                fixture_claimed.issue.number,
-                fixture_claimed.comments.clone(),
-            ),
-            (fixture_open.issue.number, fixture_open.comments.clone()),
-        ]),
-        vec![],
-        HashMap::new(),
-    ));
-    let ctx = make_ctx(
-        repo.path.clone(),
-        mock.clone(),
-        &fixture_open.lead_github_login,
-        false,
-        Commands::BatchClaim(BatchClaimArgs { count: None }),
-    );
-    commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
-
-    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: None })
-        .await
-        .unwrap();
-
-    assert!(mock.posted_issue_comments.lock().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -1357,50 +1296,6 @@ async fn duties_clean_on_no_claims() {
 }
 
 #[tokio::test]
-async fn duties_reports_free_slots_when_under_capacity() {
-    let _guard = NodeIdEnvGuard::lock_clean();
-    let repo = TestRepo::new("duties-capacity");
-    let approved_fixture = load_issue_fixture("acknowledged_invalid_issue.json");
-    let claimed_fixture = load_issue_fixture("claimed_no_attempts_issue.json");
-    let mock = Arc::new(MockGitHubClient::new(
-        "alice",
-        vec![
-            approved_fixture.issue.clone(),
-            claimed_fixture.issue.clone(),
-        ],
-        HashMap::from([
-            (
-                approved_fixture.issue.number,
-                approved_fixture.comments.clone(),
-            ),
-            (
-                claimed_fixture.issue.number,
-                claimed_fixture.comments.clone(),
-            ),
-        ]),
-        vec![],
-        HashMap::new(),
-    ));
-    let ctx = make_ctx(
-        repo.path.clone(),
-        mock,
-        &approved_fixture.lead_github_login,
-        false,
-        Commands::Duties,
-    );
-    commands::write_node_config(&repo.path, "test-node", None, Some(3)).unwrap();
-
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
-        .await
-        .unwrap();
-    let report = commands::duties::check(&ctx, &repo_state).unwrap();
-    assert!(
-        report.advisory.iter().any(|d| d.category == "capacity"),
-        "should report free slots under configured sub-agent capacity"
-    );
-}
-
-#[tokio::test]
 async fn duties_reports_metric_floor_and_stale_queue_for_lead() {
     let repo = TestRepo::new("duties-metric-floor-lead");
     let mock = Arc::new(MockGitHubClient::new(
@@ -1577,7 +1472,7 @@ async fn claim_allows_additional_claims_under_sub_agent_capacity() {
             issue: fixture_open.issue.number,
         }),
     );
-    commands::write_node_config(&repo.path, "test-node", None, Some(2)).unwrap();
+    commands::write_node_id(&repo.path, "test-node").unwrap();
 
     commands::claim::run(
         &ctx,
@@ -1587,50 +1482,6 @@ async fn claim_allows_additional_claims_under_sub_agent_capacity() {
     )
     .await
     .unwrap();
-}
-
-#[tokio::test]
-async fn claim_blocks_when_already_at_sub_agent_capacity() {
-    let _guard = NodeIdEnvGuard::lock_clean();
-    let repo = TestRepo::new("claim-capacity");
-    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
-    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
-    let mock = Arc::new(MockGitHubClient::new(
-        "alice",
-        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
-        HashMap::from([
-            (
-                fixture_claimed.issue.number,
-                fixture_claimed.comments.clone(),
-            ),
-            (fixture_open.issue.number, fixture_open.comments.clone()),
-        ]),
-        vec![],
-        HashMap::new(),
-    ));
-    let ctx = make_ctx(
-        repo.path.clone(),
-        mock,
-        &fixture_claimed.lead_github_login,
-        true,
-        Commands::Claim(IssueArgs {
-            issue: fixture_open.issue.number,
-        }),
-    );
-    commands::write_node_config(&repo.path, "test-node", None, Some(1)).unwrap();
-
-    let error = commands::claim::run(
-        &ctx,
-        &IssueArgs {
-            issue: fixture_open.issue.number,
-        },
-    )
-    .await
-    .unwrap_err();
-    assert!(
-        error.to_string().contains("configured sub-agent capacity"),
-        "claim should be blocked by capacity, got: {error}"
-    );
 }
 
 fn make_ctx(

--- a/skills/polyresearch/SKILL.md
+++ b/skills/polyresearch/SKILL.md
@@ -29,9 +29,7 @@ description: >-
    - Otherwise, follow the contributor loop.
    - Matching `lead_github_login` does NOT make you the lead. An empty
      queue does NOT make you the lead.
-8. Read `sub_agents` from `.polyresearch-node.toml` if it exists:
-   - If absent or `1`, follow the contributor loop exactly as written.
-   - If greater than `1`, use the "Contributor loop with sub-agents" section below.
+8. Read `capacity` from `.polyresearch-node.toml` if it exists (default `75` if absent, meaning "75% of total machine"). Run `polyresearch pace` to see the probed hardware budget and decide how many theses to run in parallel based on each eval's footprint in PREPARE.md. If only one eval fits, work one thesis at a time; if several fit, use `polyresearch batch-claim --count N` and one sub-agent per worktree (see "Running multiple sub-agents" below).
 9. If the repo is a fork and issues are disabled:
    `gh api repos/{owner}/{name} --method PATCH -f has_issues=true`
 10. For any CLI command details: `polyresearch <command> --help`
@@ -71,15 +69,19 @@ LOOP FOREVER:
      If BLOCKING items exist, resolve each one before continuing.
 
   1. polyresearch pace
-     Compare your effective resource policy against recent node throughput.
-     If the policy says to push harder, increase parallelism or claim rate.
-     If the policy says to stay under a hardware or API ceiling, back off.
+     Look at the Hardware budget block (machine, your max share, live free,
+     multi-project note). Effective working budget = min(your max, live free).
+     Divide by each eval's footprint (cores, RAM, GPU from PREPARE.md) to
+     decide how many theses you can run in parallel this iteration.
+     Also watch the API budget block: back off if near the GitHub quota.
 
   2. polyresearch status
      Look for approved, unclaimed theses.
 
   3. If a claimable thesis exists:
-     a. polyresearch claim <issue>
+     a. For one thesis: polyresearch claim <issue>
+        For several at once: polyresearch batch-claim --count N
+        (see "Running multiple sub-agents" below)
      b. cd into the worktree path printed by claim.
      c. Read PROGRAM.md for direction and constraints.
      d. For each experiment:
@@ -120,38 +122,31 @@ LOOP FOREVER:
   5. Repeat from step 0.
 ```
 
-## Contributor loop with sub-agents
+## Running multiple sub-agents
 
-Use this variant when `.polyresearch-node.toml` sets `sub_agents` greater than 1.
+When `polyresearch pace` shows your effective budget fits more than one
+evaluation at a time, run several theses in parallel. This is a variant of
+step 3 in the contributor loop above, not a separate loop.
 
 ```
-LOOP FOREVER:
+  3a. polyresearch batch-claim --count N
+      Claims N approved theses and creates one worktree per thesis.
+      Pick N from your effective budget / per-eval footprint.
 
-  0. polyresearch duties
-     Resolve BLOCKING items before continuing.
+  3b. For each claimed thesis, dispatch one sub-agent:
+      - Give it the issue number and worktree path.
+      - Tell it to read PROGRAM.md and PREPARE.md.
+      - Tell it to work only in its assigned worktree.
+      - Tell it to return every completed attempt with metric, baseline,
+        observation, and summary.
+      - Tell it NOT to run polyresearch CLI commands.
+      - Tell it NOT to talk to GitHub.
 
-  1. polyresearch pace
-     Read the current `sub_agents` setting, active claims, and free slots.
-
-  2. polyresearch batch-claim
-     Claims up to the node's free thesis slots. Creates one worktree per thesis.
-
-  3. For each claimed thesis, dispatch one sub-agent:
-     - Give it the issue number and worktree path.
-     - Tell it to read PROGRAM.md and PREPARE.md.
-     - Tell it to work only in its assigned worktree.
-     - Tell it to return every completed attempt with metric, baseline,
-       observation, and summary.
-     - Tell it NOT to run polyresearch CLI commands.
-     - Tell it NOT to talk to GitHub.
-
-  4. As each sub-agent finishes its thesis:
-     - post every returned attempt with `polyresearch attempt`
-     - if any attempt improved, `polyresearch submit <issue>`
-     - otherwise, `polyresearch release <issue> --reason no_improvement`
-     - remove the finished thesis worktree
-
-  5. Repeat from step 0.
+  3c. As each sub-agent finishes its thesis:
+      - post every returned attempt with `polyresearch attempt`
+      - if any attempt improved, `polyresearch submit <issue>`
+      - otherwise, `polyresearch release <issue> --reason no_improvement`
+      - `git worktree remove` the finished thesis worktree
 ```
 
 ## The lead loop
@@ -169,7 +164,7 @@ LOOP FOREVER:
      - Open PRs without policy-check
      - Stale results.tsv
 
-  1. polyresearch pace          # compare actual throughput vs effective policy
+  1. polyresearch pace          # inspect the hardware budget and throughput
   2. polyresearch sync          # on main branch, always first
   3. polyresearch audit         # check for inconsistencies
      A dirty audit blocks `policy-check`, `decide`, and `generate`.
@@ -201,12 +196,20 @@ LOOP FOREVER:
 
 ## Resource pacing
 
-Run `polyresearch pace` regularly. It prints your effective resource policy
-and recent throughput. It also prints the configured `sub_agents`, current
-active claims, and free slots. Treat `sub_agents` as the number of theses the
-contributor may work on in parallel. If `.polyresearch-node.toml` sets a
-`resource_policy`, treat it as an additional constraint. See `POLYRESEARCH.md`
-"Node configuration" for details.
+Run `polyresearch pace` regularly. It prints:
+
+- **Hardware budget**: the detected machine (cores, memory, GPUs), your project's
+  max share at the configured `capacity %`, and a live-free snapshot (load
+  average, available memory) that reflects all processes on the host. Effective
+  working budget is `min(Your max, Live free)` divided by each evaluation's
+  footprint. Other polyresearch projects on the same host are on the
+  honor-system: their `capacity` values are not tracked by the CLI, so confirm
+  the sum across projects is safe yourself.
+- **API budget**: GitHub core quota, commands left, near-limit flag.
+- **Throughput**: active claims for this node, attempts in the last hour and
+  four hours, claimable theses idle.
+
+See `POLYRESEARCH.md` "Node configuration" for full field semantics.
 
 ## Critical rules
 


### PR DESCRIPTION
## Summary

- Replaces `sub_agents` and `resource_policy` in `.polyresearch-node.toml` with a single `capacity: u8` (1..=100, default 75) representing this project's share of the total machine. Default matches Kubernetes/GKE allocatable conventions: leaves ~25% for OS, monitoring, SSH, and the agent process.
- New `cli/src/hardware.rs` probes the machine via `sysinfo` (cross-platform on macOS + Linux) for cores, memory, GPUs (`nvidia-smi` / `system_profiler` shell-outs), plus live load average and available memory. `polyresearch pace` now prints a 4-line `Hardware budget` block (Machine / Your max / Live free / Multi-project) so the agent can compute its effective working budget as `min(your max, live free)` and back off automatically when external processes are eating the box.
- Drops the static sub-agent ceiling everywhere (`claim`, `batch-claim`, `duties` capacity advisory) — the agent decides parallelism per loop iteration from `pace`. `batch-claim --count N` is the new API. Single contributor loop in POLYRESEARCH.md replaces the previous "with sub-agents" variant.
- Bumps CLI to **0.4.1** (`Cargo.toml`, `Cargo.lock`, `PROGRAM.md` `cli_version` gate). Tag `v0.4.1` should be cut from `main` after merge to trigger the existing release workflow.
- Migration is automatic: legacy `sub_agents` / `resource_policy` keys in existing `.polyresearch-node.toml` files are silently ignored on load (with a one-time stderr warning) and dropped on the next `polyresearch init`.

`NodeConfig` shrinks from 5 tunable fields to 3. Net change: 18 files, +813 / −628 LoC.

## Test plan

- [x] `cargo test --lib` (77 lib tests pass, including new `hardware::*` tests for budget math, capacity clamping, GPU rounding, and a probe sanity test)
- [x] `cargo test --test e2e` (40 e2e tests pass; updated `init`/`pace`/`batch-claim` tests, removed obsolete ceiling-based tests, added `init_drops_legacy_fields_and_writes_capacity` and `loads_legacy_toml_with_sub_agents_and_resource_policy` round-trip tests)
- [x] `cargo build` and `cargo clippy --all-targets` clean (no new warnings introduced; pre-existing collapsible-if in `init::resolve_hostname` carried forward unchanged)
- [x] `./target/debug/polyresearch init --capacity 0` correctly rejected by clap (`0 is not in 1..=100`)
- [x] `./target/debug/polyresearch init --help` shows `--capacity`, no `--sub-agents` / `--resource-policy`
- [ ] Post-merge: tag `v0.4.1` on `main`, push to trigger release workflow (`git tag -a v0.4.1 -m "polyresearch v0.4.1: capacity-based node config" && git push origin v0.4.1`)
- [ ] User-level skill at `~/.claude/skills/polyresearch/SKILL.md` updated to match the repo copy at `skills/polyresearch/SKILL.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI workflow for claiming/pacing and introduces best-effort hardware probing with external command execution (`nvidia-smi`, `system_profiler`), which could affect behavior across platforms and user configs.
> 
> **Overview**
> Switches node configuration from `sub_agents`/`resource_policy` to a single `capacity` percentage (1–100, default 75) in `.polyresearch-node.toml`, updating `polyresearch init` and docs accordingly and emitting a one-time warning when legacy keys are present (dropped on next save).
> 
> Reworks contributor pacing: `polyresearch pace` now probes machine hardware/load (new `hardware` module using `sysinfo` plus GPU shell-outs) and prints a hardware budget (Machine / Your max / Live free) so agents choose parallelism dynamically. Removes the hard sub-agent ceiling from `claim`, simplifies `batch-claim` to `--count N` requested claims, and drops related capacity advisories/tests.
> 
> Bumps CLI to `0.4.1` and updates lockfile, tests, and protocol/skill docs to reflect capacity-based parallelism and the new `pace` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52913977b7cddc584d158fddce299f891922d77a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->