### PR TITLE
Codebase health cleanup: dead code, deduplication, stale docs, visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Default is Claude Code headless. Change it to any agent that accepts a prompt an
 
 ```toml
 [agent]
-command = "codex --prompt"
-command = "cursor --bg --prompt"
+# command = "codex --prompt"
+# command = "cursor --bg --prompt"
 command = "python3 ~/my-agent.py --prompt"
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -118,8 +118,8 @@ Default is Claude Code headless. You can replace it with any compatible agent:
 
 ```toml
 [agent]
-command = "codex --prompt"
-command = "cursor --bg --prompt"
+# command = "codex --prompt"
+# command = "cursor --bg --prompt"
 command = "python3 ~/my-agent.py --prompt"
 ```
 
@@ -156,6 +156,7 @@ Initialize the local node identity once per repo:
 
 ```bash
 polyresearch init
+polyresearch init --node my-node-id
 polyresearch init --capacity 50
 ```
 
@@ -191,6 +192,7 @@ These are the building blocks used internally by `lead` and `contribute`. They r
 - `polyresearch claim`
 - `polyresearch batch-claim`
 - `polyresearch attempt`
+- `polyresearch annotate`
 - `polyresearch release`
 - `polyresearch submit`
 - `polyresearch review-claim`
@@ -201,7 +203,10 @@ These are the building blocks used internally by `lead` and `contribute`. They r
 - `polyresearch decide`
 - `polyresearch duties`
 - `polyresearch prune`
-- `polyresearch admin ...`
+- `polyresearch admin release-claim`
+- `polyresearch admin acknowledge-invalid`
+- `polyresearch admin reopen-thesis`
+- `polyresearch admin reconcile-ledger`
 
 ## Notes
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -49,7 +49,7 @@ pub enum Commands {
     Prune,
 }
 
-#[derive(Debug, Args, Clone)]
+#[derive(Debug, Args, Clone, Default)]
 pub struct InitArgs {
     #[arg(long)]
     pub node: Option<String>,

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -5,7 +5,7 @@ use crate::cli::BatchClaimArgs;
 use crate::commands::claim::{ClaimOutput, claim_selected_thesis};
 use crate::commands::duties;
 use crate::commands::{AppContext, node_active_claims, print_value, read_node_id};
-use crate::state::{RepositoryState, ThesisPhase, ThesisState};
+use crate::state::{RepositoryState, ThesisState};
 
 #[derive(Debug, Serialize)]
 struct BatchClaimOutput {
@@ -21,17 +21,7 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
-    if !duty_report.blocking.is_empty() {
-        let items: Vec<String> = duty_report
-            .blocking
-            .iter()
-            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
-            .collect();
-        return Err(eyre!(
-            "cannot batch-claim while blocking duties exist:\n{}",
-            items.join("\n")
-        ));
-    }
+    duties::require_no_blocking(&duty_report, "batch-claim")?;
 
     if matches!(args.count, Some(0)) {
         return Err(eyre!("batch-claim count must be at least 1"));
@@ -124,16 +114,5 @@ fn select_claimable_theses<'a>(
     node: &str,
     count: usize,
 ) -> Vec<&'a ThesisState> {
-    let mut theses = repo_state
-        .theses
-        .iter()
-        .filter(|thesis| thesis.issue.state == "OPEN")
-        .filter(|thesis| thesis.approved)
-        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
-        .filter(|thesis| thesis.active_claims.is_empty())
-        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
-        .collect::<Vec<_>>();
-    theses.sort_by_key(|thesis| thesis.issue.number);
-    theses.truncate(count);
-    theses
+    crate::commands::select_claimable_theses(repo_state, node, count)
 }

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -35,16 +35,11 @@ pub fn prepare_checkout(start: &Path, args: &BootstrapArgs) -> Result<PathBuf> {
     let target_dir = start.join(&upstream.name);
 
     if target_dir.exists() {
-        if !target_dir.join(".git").exists() {
-            return Err(eyre!(
-                "target directory `{}` already exists and is not a git repository",
-                target_dir.display()
-            ));
-        }
+        crate::commands::ensure_git_repo_or_clone(&target_dir, &clone_source)?;
         eprintln!("→ Reusing existing checkout at {}", target_dir.display());
     } else {
         eprintln!("→ Cloning {} into {}", clone_source.slug(), target_dir.display());
-        clone_repo(&clone_source, &target_dir)?;
+        crate::commands::clone_github_repo(&clone_source, &target_dir)?;
     }
 
     if clone_source.slug() != upstream.slug() {
@@ -83,14 +78,7 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         .wrap_err_with(|| format!("failed to create {}", ctx.repo_root.join(".polyresearch").display()))?;
 
     print_progress(ctx, "Initializing node configuration...");
-    init::run(
-        ctx,
-        &InitArgs {
-            node: None,
-            capacity: None,
-        },
-    )
-    .await?;
+    init::run(ctx, &InitArgs::default()).await?;
 
     let node_config = read_node_config(&ctx.repo_root)?;
     let runner = ShellAgentRunner::from_node_config(&node_config)?;
@@ -169,22 +157,6 @@ fn create_fork(upstream: &RepoRef) -> Result<()> {
         return Err(eyre!(
             "failed to create fork for {}: {}",
             upstream.slug(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    Ok(())
-}
-
-fn clone_repo(repo: &RepoRef, target_dir: &Path) -> Result<()> {
-    let url = format!("https://github.com/{}.git", repo.slug());
-    let output = Command::new("git")
-        .args(["clone", &url, &target_dir.to_string_lossy()])
-        .output()
-        .wrap_err("failed to run `git clone`")?;
-    if !output.status.success() {
-        return Err(eyre!(
-            "failed to clone {}: {}",
-            repo.slug(),
             String::from_utf8_lossy(&output.stderr).trim()
         ));
     }

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -23,17 +23,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
-    if !duty_report.blocking.is_empty() {
-        let items: Vec<String> = duty_report
-            .blocking
-            .iter()
-            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
-            .collect();
-        return Err(eyre!(
-            "cannot claim while blocking duties exist:\n{}",
-            items.join("\n")
-        ));
-    }
+    duties::require_no_blocking(&duty_report, "claim")?;
     let thesis = require_claimable_thesis(&repo_state, args.issue)?;
     if !thesis.active_claims.is_empty() {
         let nodes = thesis

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -18,6 +18,8 @@ use crate::github::RepoRef;
 use crate::hardware;
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
 
+const EXPERIMENT_PROMPT: &str = "Read PROGRAM.md, PREPARE.md, and .polyresearch/thesis.md, then work only the current thesis. Run one baseline plus at most 3 serious candidate attempts in this session. If you find a clear improvement earlier, stop early. When you are done, write .polyresearch/result.json exactly as PROGRAM.md specifies and exit immediately.";
+
 #[derive(Debug, Serialize)]
 struct ContributeOutput {
     repo: String,
@@ -36,28 +38,7 @@ struct WorkerResult {
 pub fn prepare_checkout(start: &Path, repo_url: &str) -> Result<PathBuf> {
     let repo = RepoRef::parse(repo_url)?;
     let target_dir = start.join(&repo.name);
-    if target_dir.exists() {
-        if !target_dir.join(".git").exists() {
-            return Err(eyre!(
-                "target directory `{}` already exists and is not a git repository",
-                target_dir.display()
-            ));
-        }
-        return Ok(target_dir);
-    }
-
-    let url = format!("https://github.com/{}.git", repo.slug());
-    let output = Command::new("git")
-        .args(["clone", &url, &target_dir.to_string_lossy()])
-        .output()
-        .wrap_err("failed to run `git clone`")?;
-    if !output.status.success() {
-        return Err(eyre!(
-            "failed to clone {}: {}",
-            repo.slug(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
+    crate::commands::ensure_git_repo_or_clone(&target_dir, &repo)?;
     Ok(target_dir)
 }
 
@@ -155,7 +136,6 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
             sync_node_config_to_worktree(&ctx.repo_root, &worktree_path)?;
             write_thesis_context(&worktree_path, thesis)?;
 
-            let prompt = "Read PROGRAM.md, PREPARE.md, and .polyresearch/thesis.md, then work only the current thesis. Run one baseline plus at most 3 serious candidate attempts in this session. If you find a clear improvement earlier, stop early. When you are done, write .polyresearch/result.json exactly as PROGRAM.md specifies and exit immediately.".to_string();
             let issue = thesis.issue.number;
             let runner = runner.clone();
             let default_branch = default_branch.clone();
@@ -163,7 +143,7 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
 
             tasks.spawn_blocking(move || {
                 let result = runner
-                    .run_experiment(&prompt, &worktree_path)
+                    .run_experiment(EXPERIMENT_PROMPT, &worktree_path)
                     .or_else(|error| {
                         recover_experiment_result(&worktree_path, direction, tolerance).or_else(
                             |_| {
@@ -220,7 +200,6 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
                 continue;
             }
 
-            let prompt = "Read PROGRAM.md, PREPARE.md, and .polyresearch/thesis.md, then work only the current thesis. Run one baseline plus at most 3 serious candidate attempts in this session. If you find a clear improvement earlier, stop early. When you are done, write .polyresearch/result.json exactly as PROGRAM.md specifies and exit immediately.".to_string();
             let issue = claim.issue;
             let runner = runner.clone();
             let default_branch = default_branch.clone();
@@ -228,7 +207,7 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
 
             tasks.spawn_blocking(move || {
                 let result = runner
-                    .run_experiment(&prompt, &worktree_path)
+                    .run_experiment(EXPERIMENT_PROMPT, &worktree_path)
                     .or_else(|error| {
                         recover_experiment_result(&worktree_path, direction, tolerance).or_else(
                             |_| {
@@ -294,14 +273,7 @@ async fn ensure_initialized(ctx: &AppContext) -> Result<()> {
         return Ok(());
     }
 
-    init::run(
-        ctx,
-        &InitArgs {
-            node: None,
-            capacity: None,
-        },
-    )
-    .await
+    init::run(ctx, &InitArgs::default()).await
 }
 
 async fn auto_submit_blocking(ctx: &AppContext, repo_state: &RepositoryState) -> Result<usize> {
@@ -384,18 +356,7 @@ fn select_claimable_theses<'a>(
     node: &str,
     count: usize,
 ) -> Vec<&'a ThesisState> {
-    let mut theses = repo_state
-        .theses
-        .iter()
-        .filter(|thesis| thesis.issue.state == "OPEN")
-        .filter(|thesis| thesis.approved)
-        .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
-        .filter(|thesis| thesis.active_claims.is_empty())
-        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
-        .collect::<Vec<_>>();
-    theses.sort_by_key(|thesis| thesis.issue.number);
-    theses.truncate(count);
-    theses
+    crate::commands::select_claimable_theses(repo_state, node, count)
 }
 
 fn select_resumable_theses<'a>(

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::commands::{AppContext, print_value, read_node_id};
@@ -18,6 +18,21 @@ pub struct DutyReport {
     pub blocking: Vec<DutyItem>,
     pub advisory: Vec<DutyItem>,
     pub clean: bool,
+}
+
+pub fn require_no_blocking(report: &DutyReport, action: &str) -> Result<()> {
+    if report.blocking.is_empty() {
+        return Ok(());
+    }
+    let items: Vec<String> = report
+        .blocking
+        .iter()
+        .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
+        .collect();
+    Err(eyre!(
+        "cannot {action} while blocking duties exist:\n{}",
+        items.join("\n")
+    ))
 }
 
 pub fn check(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyReport> {

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -32,7 +32,7 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         advisory: Vec::new(),
         clean: true,
     };
-    duties::require_no_blocking(&lead_report, "generate theses while PRs need processing")?;
+    duties::require_no_blocking(&lead_report, "generate")?;
 
     if let Some(max_queue_depth) = ctx.config.max_queue_depth {
         if repo_state.queue_depth >= max_queue_depth {

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -23,21 +23,16 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     let _ = ensure_current_ledger(ctx, &repo_state)?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
-    let lead_blocking: Vec<_> = duty_report
-        .blocking
-        .iter()
-        .filter(|d| d.category == "decide" || d.category == "policy-check")
-        .collect();
-    if !lead_blocking.is_empty() {
-        let items: Vec<String> = lead_blocking
-            .iter()
-            .map(|d| format!("  [{}] {} Run: {}", d.category, d.message, d.command))
-            .collect();
-        return Err(eyre!(
-            "cannot generate theses while PRs need processing:\n{}",
-            items.join("\n")
-        ));
-    }
+    let lead_report = duties::DutyReport {
+        blocking: duty_report
+            .blocking
+            .into_iter()
+            .filter(|d| d.category == "decide" || d.category == "policy-check")
+            .collect(),
+        advisory: Vec::new(),
+        clean: true,
+    };
+    duties::require_no_blocking(&lead_report, "generate theses while PRs need processing")?;
 
     if let Some(max_queue_depth) = ctx.config.max_queue_depth {
         if repo_state.queue_depth >= max_queue_depth {

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -23,14 +23,15 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
     let _ = ensure_current_ledger(ctx, &repo_state)?;
 
     let duty_report = duties::check(ctx, &repo_state)?;
+    let lead_blocking: Vec<_> = duty_report
+        .blocking
+        .into_iter()
+        .filter(|d| d.category == "decide" || d.category == "policy-check")
+        .collect();
     let lead_report = duties::DutyReport {
-        blocking: duty_report
-            .blocking
-            .into_iter()
-            .filter(|d| d.category == "decide" || d.category == "policy-check")
-            .collect(),
+        clean: lead_blocking.is_empty(),
+        blocking: lead_blocking,
         advisory: Vec::new(),
-        clean: true,
     };
     duties::require_no_blocking(&lead_report, "generate")?;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub mod submit;
 pub mod sync;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
@@ -155,6 +155,25 @@ pub fn write_node_config(
         existing_agent,
     )
     .save(repo_root)
+}
+
+pub fn select_claimable_theses<'a>(
+    repo_state: &'a RepositoryState,
+    node: &str,
+    count: usize,
+) -> Vec<&'a crate::state::ThesisState> {
+    let mut theses = repo_state
+        .theses
+        .iter()
+        .filter(|thesis| thesis.issue.state == "OPEN")
+        .filter(|thesis| thesis.approved)
+        .filter(|thesis| matches!(thesis.phase, crate::state::ThesisPhase::Approved))
+        .filter(|thesis| thesis.active_claims.is_empty())
+        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
+        .collect::<Vec<_>>();
+    theses.sort_by_key(|thesis| thesis.issue.number);
+    theses.truncate(count);
+    theses
 }
 
 pub fn node_active_claims(repo_state: &RepositoryState, node_id: &str) -> usize {
@@ -300,6 +319,35 @@ pub fn resume_thesis_worktree(
         branch,
         worktree_path,
     })
+}
+
+pub fn ensure_git_repo_or_clone(target_dir: &Path, repo: &RepoRef) -> Result<()> {
+    if target_dir.exists() {
+        if !target_dir.join(".git").exists() {
+            return Err(eyre!(
+                "target directory `{}` already exists and is not a git repository",
+                target_dir.display()
+            ));
+        }
+        return Ok(());
+    }
+    clone_github_repo(repo, target_dir)
+}
+
+pub fn clone_github_repo(repo: &RepoRef, target_dir: &Path) -> Result<()> {
+    let url = format!("https://github.com/{}.git", repo.slug());
+    let output = std::process::Command::new("git")
+        .args(["clone", &url, &target_dir.to_string_lossy()])
+        .output()
+        .wrap_err("failed to run `git clone`")?;
+    if !output.status.success() {
+        return Err(eyre!(
+            "failed to clone {}: {}",
+            repo.slug(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
 }
 
 pub fn push_current_branch(repo_root: &PathBuf) -> Result<String> {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -226,7 +226,6 @@ pub struct ProtocolConfig {
     pub default_branch: Option<String>,
     pub auto_approve: bool,
     pub assignment_timeout: Duration,
-    pub review_timeout: Duration,
     pub min_queue_depth: usize,
     pub max_queue_depth: Option<usize>,
     pub cli_version: Option<String>,
@@ -243,7 +242,6 @@ impl Default for ProtocolConfig {
             default_branch: None,
             auto_approve: true,
             assignment_timeout: Duration::from_secs(24 * 60 * 60),
-            review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: None,
             cli_version: None,
@@ -317,7 +315,6 @@ impl ProtocolConfig {
                 }
                 "auto_approve" => config.auto_approve = parse_bool(value)?,
                 "assignment_timeout" => config.assignment_timeout = parse_duration(value)?,
-                "review_timeout" => config.review_timeout = parse_duration(value)?,
                 "min_queue_depth" => {
                     config.min_queue_depth = value
                         .parse()
@@ -396,7 +393,7 @@ pub struct ProgramSpec {
 }
 
 impl ProgramSpec {
-    pub fn load(repo_root: &Path, _config: &ProtocolConfig) -> Result<Self> {
+    pub fn load(repo_root: &Path) -> Result<Self> {
         let path = repo_root.join("PROGRAM.md");
         let contents = fs::read_to_string(&path)
             .wrap_err_with(|| format!("failed to read {}", path.display()))?;

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -664,8 +664,6 @@ pub struct IssueComment {
     pub body: String,
     pub user: CommentUser,
     pub created_at: DateTime<Utc>,
-    #[serde(default)]
-    pub updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cli/src/hardware.rs
+++ b/cli/src/hardware.rs
@@ -40,7 +40,7 @@ impl Platform {
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             Platform::MacOS => "macos",
             Platform::Linux => "linux",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     if !is_bootstrap {
         config.check_cli_version(env!("CARGO_PKG_VERSION"))?;
     }
-    let program = load_program_spec(&repo_root, &config, &cli.command)?;
+    let program = load_program_spec(&repo_root, &cli.command)?;
     let default_branch = if is_bootstrap {
         config
             .default_branch
@@ -75,11 +75,7 @@ fn prepare_repo_root(start: &PathBuf, command: &Commands) -> Result<PathBuf> {
     }
 }
 
-fn load_program_spec(
-    repo_root: &PathBuf,
-    config: &ProtocolConfig,
-    command: &Commands,
-) -> Result<ProgramSpec> {
+fn load_program_spec(repo_root: &PathBuf, command: &Commands) -> Result<ProgramSpec> {
     if matches!(command, Commands::Bootstrap(_)) && !repo_root.join("PROGRAM.md").exists() {
         return Ok(ProgramSpec {
             can_modify: Vec::new(),
@@ -87,7 +83,7 @@ fn load_program_spec(
         });
     }
 
-    ProgramSpec::load(repo_root, config)
+    ProgramSpec::load(repo_root)
 }
 
 fn discover_repo_root(start: &PathBuf) -> Result<PathBuf> {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -703,7 +703,6 @@ mod tests {
             default_branch: Some("main".to_string()),
             auto_approve: true,
             assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
-            review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
             cli_version: None,

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -133,7 +133,7 @@ impl RepositoryState {
         Self::derive_from_fetched(issues, prs, &mut issue_comments, &mut pr_comments, config)
     }
 
-    pub fn derive_from_fetched(
+    fn derive_from_fetched(
         issues: Vec<Issue>,
         prs: Vec<PullRequest>,
         issue_comments: &mut std::collections::HashMap<u64, Vec<IssueComment>>,
@@ -491,7 +491,7 @@ pub fn parse_thesis_number_from_branch(branch: &str) -> Option<u64> {
     number.parse::<u64>().ok()
 }
 
-pub fn select_metric(current: Option<f64>, candidate: f64, direction: MetricDirection) -> f64 {
+fn select_metric(current: Option<f64>, candidate: f64, direction: MetricDirection) -> f64 {
     match current {
         None => candidate,
         Some(existing) => match direction {

--- a/cli/src/throttle.rs
+++ b/cli/src/throttle.rs
@@ -16,13 +16,13 @@ const THROTTLE_FILE_NAME: &str = ".polyresearch-throttle";
 static REQUEST_THROTTLE: OnceLock<RequestThrottle> = OnceLock::new();
 
 #[derive(Debug, Clone)]
-pub struct RequestThrottle {
+struct RequestThrottle {
     request_delay: Duration,
     state_path: PathBuf,
 }
 
 impl RequestThrottle {
-    pub fn new(request_delay_ms: u64) -> Self {
+    fn new(request_delay_ms: u64) -> Self {
         Self::with_path(request_delay_ms, default_state_path())
     }
 

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -98,27 +98,12 @@ pub struct ValidDecisionRecord {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MaintainerVerdict {
-    Approve,
-    Reject,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct MaintainerFeedback {
-    pub verdict: MaintainerVerdict,
-    pub reason: Option<String>,
-    pub created_at: DateTime<Utc>,
-}
-
 #[derive(Debug, Clone)]
 pub struct PullRequestValidation {
     pub thesis_number: Option<u64>,
     pub policy_pass: bool,
     pub maintainer_approved: bool,
     pub maintainer_rejected: bool,
-    pub maintainer_feedback: Vec<MaintainerFeedback>,
     pub review_claims: Vec<ValidReviewClaimRecord>,
     pub reviews: Vec<ValidReviewRecord>,
     pub decision: Option<ValidDecisionRecord>,
@@ -130,7 +115,6 @@ pub struct IssueValidation {
     pub approved: bool,
     pub maintainer_approved: bool,
     pub maintainer_rejected: bool,
-    pub maintainer_feedback: Vec<MaintainerFeedback>,
     pub active_claims: Vec<ValidClaimRecord>,
     pub releases: Vec<ValidReleaseRecord>,
     pub attempts: Vec<ValidAttemptRecord>,
@@ -160,7 +144,6 @@ pub fn validate_pull_request(
     let mut policy_pass = false;
     let mut maintainer_approved = false;
     let mut maintainer_rejected = false;
-    let mut maintainer_feedback = Vec::new();
     let mut review_claims = Vec::new();
     let mut claimed_nodes = BTreeSet::new();
     let mut reviews = Vec::new();
@@ -173,7 +156,7 @@ pub fn validate_pull_request(
 
     for comment in sorted_comments {
         match &comment.protocol {
-            Some(ProtocolComment::SlashApprove { reason }) => {
+            Some(ProtocolComment::SlashApprove { .. }) => {
                 if !is_maintainer_actor(&comment.author, config) {
                     if config.auto_approve {
                         continue;
@@ -186,14 +169,9 @@ pub fn validate_pull_request(
                 } else {
                     maintainer_approved = true;
                     maintainer_rejected = false;
-                    maintainer_feedback.push(MaintainerFeedback {
-                        verdict: MaintainerVerdict::Approve,
-                        reason: reason.clone(),
-                        created_at: comment.created_at,
-                    });
                 }
             }
-            Some(ProtocolComment::SlashReject { reason }) => {
+            Some(ProtocolComment::SlashReject { .. }) => {
                 if !is_maintainer_actor(&comment.author, config) {
                     findings.push(invalid_issue_like(
                         AuditScope::PullRequest { number: pr.number },
@@ -203,11 +181,6 @@ pub fn validate_pull_request(
                 } else {
                     maintainer_approved = false;
                     maintainer_rejected = true;
-                    maintainer_feedback.push(MaintainerFeedback {
-                        verdict: MaintainerVerdict::Reject,
-                        reason: reason.clone(),
-                        created_at: comment.created_at,
-                    });
                 }
             }
             Some(ProtocolComment::AdminNote {
@@ -393,7 +366,6 @@ pub fn validate_pull_request(
         policy_pass,
         maintainer_approved,
         maintainer_rejected,
-        maintainer_feedback,
         review_claims,
         reviews,
         decision,
@@ -413,7 +385,6 @@ pub fn validate_issue(
     let mut approved = false;
     let mut maintainer_approved = false;
     let mut maintainer_rejected = false;
-    let mut maintainer_feedback = Vec::new();
     let mut findings = Vec::new();
     let mut acknowledged_comment_ids = BTreeSet::new();
     let mut active_claims = HashMap::<String, ValidClaimRecord>::new();
@@ -425,7 +396,7 @@ pub fn validate_issue(
 
     for comment in sorted_comments {
         match &comment.protocol {
-            Some(ProtocolComment::SlashApprove { reason }) => {
+            Some(ProtocolComment::SlashApprove { .. }) => {
                 if !is_maintainer_actor(&comment.author, config) {
                     if config.auto_approve {
                         continue;
@@ -441,14 +412,9 @@ pub fn validate_issue(
                     approved = true;
                     maintainer_approved = true;
                     maintainer_rejected = false;
-                    maintainer_feedback.push(MaintainerFeedback {
-                        verdict: MaintainerVerdict::Approve,
-                        reason: reason.clone(),
-                        created_at: comment.created_at,
-                    });
                 }
             }
-            Some(ProtocolComment::SlashReject { reason }) => {
+            Some(ProtocolComment::SlashReject { .. }) => {
                 if !is_maintainer_actor(&comment.author, config) {
                     findings.push(invalid_issue_like(
                         AuditScope::Issue {
@@ -461,11 +427,6 @@ pub fn validate_issue(
                     approved = false;
                     maintainer_approved = false;
                     maintainer_rejected = true;
-                    maintainer_feedback.push(MaintainerFeedback {
-                        verdict: MaintainerVerdict::Reject,
-                        reason: reason.clone(),
-                        created_at: comment.created_at,
-                    });
                 }
             }
             Some(ProtocolComment::AdminNote {
@@ -709,7 +670,6 @@ pub fn validate_issue(
         approved,
         maintainer_approved,
         maintainer_rejected,
-        maintainer_feedback,
         active_claims,
         releases,
         attempts,
@@ -901,7 +861,6 @@ mod tests {
         assert!(validation.approved);
         assert!(validation.maintainer_approved);
         assert!(!validation.maintainer_rejected);
-        assert_eq!(validation.maintainer_feedback.len(), 1);
         assert!(validation.findings.is_empty());
     }
 
@@ -921,7 +880,6 @@ mod tests {
         assert!(!validation.approved);
         assert!(!validation.maintainer_approved);
         assert!(validation.maintainer_rejected);
-        assert_eq!(validation.maintainer_feedback.len(), 1);
         assert!(validation.findings.is_empty());
     }
 
@@ -981,7 +939,6 @@ mod tests {
             default_branch: Some("main".to_string()),
             auto_approve: true,
             assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
-            review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
             cli_version: None,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1829,7 +1829,7 @@ async fn duties_reports_waiting_for_approval_when_queue_has_only_submitted_these
 // --- B6: Duty gate on claim ---
 
 #[tokio::test]
-async fn claim_allows_additional_claims_under_sub_agent_capacity() {
+async fn claim_allows_additional_claims_on_different_thesis() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-gate");
     init_git_repo(&repo.path);

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1900,7 +1900,6 @@ fn make_ctx(
             default_branch: Some("main".to_string()),
             auto_approve: true,
             assignment_timeout: Duration::from_secs(24 * 60 * 60),
-            review_timeout: Duration::from_secs(12 * 60 * 60),
             min_queue_depth: 5,
             max_queue_depth: Some(10),
             cli_version: None,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -138,7 +138,6 @@ impl GitHubApi for MockGitHubClient {
                         login: self.current_login.clone(),
                     },
                     created_at: latest + chrono::Duration::seconds(1 + idx as i64),
-                    updated_at: None,
                 });
             }
         }
@@ -182,7 +181,6 @@ impl GitHubApi for MockGitHubClient {
                 login: self.current_login.clone(),
             },
             created_at: chrono::Utc::now(),
-            updated_at: None,
         })
     }
 

--- a/examples/corewar/PROGRAM.md
+++ b/examples/corewar/PROGRAM.md
@@ -40,7 +40,6 @@ replication logic, imp launchers, decoys, process management.
 - `.polyresearch/` - the trusted environment: setup, evaluator, LLM helper,
 prompts, simulator, gauntlet, vendored source notes, and dependencies
 - `PREPARE.md` - the trust boundary
-- `POLYRESEARCH.md` - the coordination protocol
 - `results.tsv` - maintained by the lead on `main`
 
 ## Constraints

--- a/examples/corewar/README.md
+++ b/examples/corewar/README.md
@@ -55,9 +55,7 @@ The final warrior is an 8-instruction paper replicator scoring 0.785, with perfe
 grep "^battle_score:" run.log     # parse the metric
 ```
 
-The canonical protocol file for this repo is [POLYRESEARCH.md](POLYRESEARCH.md).
-
-See [PREPARE.md](PREPARE.md) for full evaluation details and [PROGRAM.md](PROGRAM.md) for the research playbook.
+See [PREPARE.md](PREPARE.md) for full evaluation details, [PROGRAM.md](PROGRAM.md) for the research playbook, and [cli/README.md](../../cli/README.md) for the CLI command reference.
 
 ## Why this is a good polyresearch example
 

--- a/examples/eslint/PROGRAM.md
+++ b/examples/eslint/PROGRAM.md
@@ -35,7 +35,6 @@ Secondary constraint: correctness. Workload A must produce 63 messages with fing
 ## What you CANNOT modify
 
 - `.polyresearch/` - the reproducible environment
-- `POLYRESEARCH.md` - the coordination protocol
 - `PROGRAM.md` - the research playbook
 - `PREPARE.md` - the evaluation setup
 - `results.tsv` - maintained by the lead on `main`

--- a/examples/eslint/README.md
+++ b/examples/eslint/README.md
@@ -70,9 +70,7 @@ node .polyresearch/bench.js
 
 You should see output with `METRIC_A`, `METRIC_B`, and `METRIC` lines. The composite `METRIC` should be approximately 350 on modern hardware.
 
-The canonical protocol file for this repo is [POLYRESEARCH.md](../../POLYRESEARCH.md).
-
-See [PREPARE.md](PREPARE.md) for full evaluation details and [PROGRAM.md](PROGRAM.md) for the research playbook.
+See [PREPARE.md](PREPARE.md) for full evaluation details, [PROGRAM.md](PROGRAM.md) for the research playbook, and [cli/README.md](../../cli/README.md) for the CLI command reference.
 
 ## Why this is a good polyresearch example
 

--- a/examples/postcss/PROGRAM.md
+++ b/examples/postcss/PROGRAM.md
@@ -36,7 +36,6 @@ Secondary constraint: correctness. Workload A must produce fingerprint `4b81f7a5
 ## What you CANNOT modify
 
 - `.polyresearch/` — the reproducible environment (benchmark harness)
-- `POLYRESEARCH.md` — the coordination protocol
 - `PROGRAM.md` — the research playbook
 - `PREPARE.md` — the evaluation setup
 - `results.tsv` — maintained by the lead on `main`

--- a/examples/postcss/README.md
+++ b/examples/postcss/README.md
@@ -69,9 +69,7 @@ node .polyresearch/bench.js
 
 You should see output with `METRIC_A`, `METRIC_B`, and `METRIC` lines. The composite `METRIC` should be approximately 115 on modern server hardware.
 
-The canonical protocol file for this repo is [POLYRESEARCH.md](../../POLYRESEARCH.md).
-
-See [PREPARE.md](PREPARE.md) for full evaluation details and [PROGRAM.md](PROGRAM.md) for the research playbook.
+See [PREPARE.md](PREPARE.md) for full evaluation details, [PROGRAM.md](PROGRAM.md) for the research playbook, and [cli/README.md](../../cli/README.md) for the CLI command reference.
 
 ## Why this is a good polyresearch example
 


### PR DESCRIPTION
## Summary

Post-refactor cleanup of the CLI codebase after the move from protocol-spec-driven to CLI-first coordination. No behavioral changes.

- **Remove dead code**: `review_timeout` field (parsed but never read), unused `_config` parameter on `ProgramSpec::load`, `IssueComment.updated_at` (deserialized but never read), and `MaintainerFeedback` / `MaintainerVerdict` structs (written but never propagated to state or output).
- **Deduplicate shared logic**: metric extraction from logs (agent.rs vs contribute.rs), blocking duties error formatting (claim/batch_claim/generate), git clone + directory validation (bootstrap vs contribute), `select_claimable_theses` (contribute vs batch_claim had diverging predicates), experiment prompt string (verbatim duplicate), and default `InitArgs` construction.
- **Fix stale documentation**: remove broken `POLYRESEARCH.md` links from all three example projects, add missing `annotate` command and `admin` subcommands to CLI README, document `init --node` flag, fix invalid TOML in agent config examples.
- **Tighten visibility**: make `derive_from_fetched`, `select_metric`, `RequestThrottle`, and `Platform::as_str` private since they are only used within their own modules.
- **Rename misleading test**: `claim_allows_additional_claims_under_sub_agent_capacity` referenced the legacy `sub_agents` concept.

Depends on #58 (`cli-first-remediation-root`).

## Test plan

- [x] All 86 unit tests pass
- [x] All 47 e2e tests pass
- [x] `cargo check` compiles with zero warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactors and documentation updates with minimal functional change; main risk is subtle behavior drift from shared helper extraction (claim selection/clone checks) and reduced config surface.
> 
> **Overview**
> Streamlines the CLI after the CLI-first refactor by **removing unused/stale fields and dead types** (e.g., `ProtocolConfig.review_timeout`, `IssueComment.updated_at`, maintainer feedback structs) and tightening internal visibility on helpers that are no longer part of the public surface.
> 
> Deduplicates common coordination logic by centralizing **blocking-duty error formatting**, **claimable thesis selection**, **git checkout/clone validation**, and **default `init` argument construction**, plus minor prompt/log parsing reuse in the contributor flow. Documentation is updated to fix invalid TOML examples, document `init --node`, and refresh command references (including `annotate` and `admin` subcommands) while removing broken example links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81222a32012df68111e7fac3ba59b8e1729e137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->