### PR TITLE
Bump cli_version in PROGRAM.md to 0.5.0

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.4.1
+cli_version: 0.5.0
 
 ## Goal
 


### PR DESCRIPTION
## Summary
- PROGRAM.md still pinned `cli_version: 0.4.1` after the v0.5.0 Cargo.toml bump in PR #60, causing the release smoke test to fail on all three targets ([run 24671631033](https://github.com/superagent-ai/polyresearch/actions/runs/24671631033)).
- Updates `cli_version` to `0.5.0` so the version check passes.

## Test plan
- After merge: delete and recreate the `v0.5.0` tag on the new HEAD of main, push tag to re-trigger the release workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config update that only changes the declared CLI version in `PROGRAM.md`. Risk is limited to potential mismatches if other tooling expects a different version.
> 
> **Overview**
> Updates `PROGRAM.md` to bump `cli_version` from `0.4.1` to `0.5.0`, aligning the program config with the current CLI release and unblocking version checks in release workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4963412b15b600acf0ea291aa59cb0c42327c610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->