### PR TITLE
Update READMEs for v0.5.0 bootstrap/lead/contribute workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,7 @@ Polyresearch keeps the same loop and adds three things:
 2. **Complete experiment history.** Every attempt gets a row in `results.tsv` and stays as an unmerged branch: accepted, discarded, and crashed. No `git reset`, no lost code. The full history feeds thesis generation and prevents repeating dead ends.
 3. **Independent verification.** Reviewers rerun the evaluation on the candidate *and* on the baseline, measuring both numbers themselves. The evaluation code lives outside the editable surface, so agents cannot grade their own homework.
 
-## How it works
-
-A polyresearch project is any GitHub repo with a few coordination files:
-
-- **`PROGRAM.md`** — the research playbook. Same concept as autoresearch's [program.md](https://github.com/karpathy/autoresearch/blob/master/program.md). Describes the research goal, which files agents can edit, strategy, and constraints.
-- **`PREPARE.md`** — the evaluation setup. What commands to run, how to parse the metric, what the ground truth is. The evaluation code is outside the editable surface, so agents cannot change how they are judged.
-- **`POLYRESEARCH.md`** — the coordination protocol. Same for every project, like a LICENSE file. Not modified.
-- **`.polyresearch/`** — the reproducible environment. Setup scripts, evaluators, frozen dependencies. Optional.
-
-Contributors pick up theses from the GitHub Issues queue, run experiments, and submit results. Other contributors independently verify results. The lead manages the queue and merges accepted work. Everything is coordinated through structured comments on GitHub -- no external services, no database. Requires `git` and `gh`.
-
 ## Install
-
-Two steps:
-
-1. **Install the CLI.**
 
 ```bash
 cargo install polyresearch
@@ -33,78 +18,91 @@ cargo install polyresearch
 
 Don't have Rust? See [other install options](cli/README.md#other-install-options).
 
-2. **Install the agent skill.** Copy `skills/polyresearch/SKILL.md` from this repo into your agent's skill directory (e.g. `~/.claude/skills/polyresearch/`, or equivalent for your agent). The skill teaches agents the full protocol -- bootstrapping, the lead loop, the contributor loop, and all CLI usage.
-
 ## Usage
 
-Polyresearch has two agent roles: a **lead** and one or more **contributors**. The **maintainer** is the human who writes the research playbook and optionally reviews work.
+Polyresearch has two roles: a **lead** and one or more **contributors**. The human who owns the repo is the **maintainer** -- they review the research playbook and optionally approve work.
 
-### Start a new project
+### 1. Bootstrap a project
 
-Tell your lead agent to bootstrap polyresearch on any GitHub repo. The skill fetches the protocol templates, drafts `PROGRAM.md` and `PREPARE.md` by exploring the repo, and hands them to you for review.
+Point it at any GitHub repo with a codebase and a metric you want to improve:
 
-```
-Bootstrap polyresearch on https://github.com/owner/repo.
-You are the lead for this project.
-```
-
-After you review the drafts, the lead enters its loop: sync results, process PRs, generate new theses when the queue runs low.
-
-### Run a contributor
-
-Point your agent at any repo that has been bootstrapped with polyresearch:
-
-```
-Do polyresearch on https://github.com/owner/repo.
+```bash
+polyresearch bootstrap https://github.com/owner/repo
+polyresearch bootstrap https://github.com/owner/repo --fork myorg
 ```
 
-The agent clones the repo, claims work from the issue queue, runs experiments, and submits results in a loop until you stop it. Launch as many contributor agents as you have machines.
+This clones the repo (or forks it first with `--fork`), writes template files, initializes your machine as a node, and spawns an agent to fill in project-specific details. When it finishes you'll have:
+
+- **`PROGRAM.md`** -- the research playbook. Describes the goal, which files agents can edit, strategy hints. This is the only file agents read.
+- **`PREPARE.md`** -- the evaluation setup. Benchmark command, metric parsing, ground truth. Lives outside the editable surface so agents can't change how they're judged.
+- **`results.tsv`** -- the experiment ledger. Every attempt ever recorded.
+- **`.polyresearch-node.toml`** -- your machine's identity and capacity setting. Gitignored.
+
+Review `PROGRAM.md` and `PREPARE.md`, tweak them for your project, commit, and push.
+
+### 2. Run the lead
+
+```bash
+polyresearch lead
+```
+
+The lead syncs the results ledger, policy-checks open PRs, decides candidates (merge or reject), and generates new theses when the queue runs low. It runs in a loop until you stop it. Use `--once` for a single iteration.
+
+### 3. Run contributors
+
+On any machine (yours, a teammate's, a rented GPU box):
+
+```bash
+polyresearch contribute https://github.com/owner/repo
+```
+
+The contributor clones the repo, claims theses from the issue queue, spawns an agent for each one, records results, and submits PRs. Launch as many contributor machines as you want -- they all pull from the same queue.
 
 ### Hardware utilization
 
-A single contributor agent working on one thesis at a time only runs one evaluation at a time. On a multi-core server or multi-GPU machine, most of the hardware sits idle.
+A single evaluation often doesn't saturate a machine. The `contribute` command handles this automatically: it reads `capacity` from your node config and `eval_cores`/`eval_memory_gb` from `PREPARE.md`, probes the hardware, and claims multiple theses in parallel when resources allow.
 
-Polyresearch can use sub-agents to keep that hardware busy. Set `capacity` in `.polyresearch-node.toml` to the percent of the total machine this project may use (default 75). `polyresearch pace` probes the machine and prints your share (cores, memory, GPUs) alongside a live-free load snapshot; the contributor divides that by each eval's resource footprint from PREPARE.md, claims that many theses via `polyresearch batch-claim --count N`, dispatches one sub-agent per worktree, and posts results as each thesis finishes. This improves hardware utilization while keeping GitHub API usage low because there is still only one visible contributor session and one GitHub token in use.
+`polyresearch pace` shows the reasoning -- your hardware budget, live free resources, and GitHub API quota -- so you can see exactly what the contributor will do.
 
 ### Run on a remote machine
 
 #### Pattern A: Remote evaluation over SSH
 
-The contributor runs on your local machine. The experiments run on a remote server. Set up the repo, CLI, and `gh` auth on the remote, then tell your agent:
+The contributor runs on your local machine. The experiments run on a remote server. Set up the repo, CLI, and `gh` auth on the remote, then:
 
-```
-Do polyresearch on https://github.com/owner/repo.
-Run all evaluations and experiments over SSH on user@remote-host.
+```bash
+polyresearch contribute https://github.com/owner/repo
+# evaluations are dispatched to the remote via the agent's SSH access
 ```
 
 Your local machine only needs the agent; the remote server does the compute.
 
 #### Pattern B: Run the contributor on the server
 
-This is the recommended pattern for sub-agents. The contributor and its sub-agents all run directly on the server, so file access, git operations, and evaluations are local. There is no SSH relay in the middle.
+The recommended pattern. The contributor runs directly on the server, so file access, git operations, and evaluations are all local.
 
 Use `tmux` so the session survives disconnects:
 
 ```bash
 ssh user@remote-host
 tmux new-session -s polyresearch
-claude -p "Do polyresearch on https://github.com/owner/repo."
+polyresearch contribute https://github.com/owner/repo
 # Detach with Ctrl-B D. Reconnect with: tmux attach -t polyresearch
 ```
 
-Detaching means the process keeps running after your SSH session closes. `tmux` creates a persistent terminal session on the server. If your laptop sleeps or your network drops, the contributor keeps working. Later you reconnect with `tmux attach -t polyresearch` and resume the same terminal.
+If your laptop sleeps or your network drops, the contributor keeps working. Reconnect later with `tmux attach -t polyresearch`.
 
 ## CLI
 
-The `polyresearch` CLI handles all protocol state transitions: claiming theses, posting attempts, submitting candidates, syncing results, and more. Agents use it -- not humans. The skill teaches agents every command, so you don't need to learn them yourself.
+The `polyresearch` CLI handles all coordination: claiming theses, recording attempts, submitting candidates, syncing results, deciding PRs. Agents don't need to understand the protocol. The CLI runs the protocol; agents run experiments.
 
 Full command reference in [cli/README.md](cli/README.md).
 
 ## Design
 
-**Protocol, not a platform.** Three markdown files and an optional environment directory dropped into any repo. No opinions on agent, model, sandbox, or language.
+**Protocol, not a platform.** Two markdown files (`PROGRAM.md` and `PREPARE.md`) and an optional environment directory dropped into any repo. No opinions on agent, model, sandbox, or language.
 
-**Structured comments as state.** Agents coordinate through structured HTML comments on GitHub Issues and PRs. State is derived from the comment trail, not from labels or a database. Every transition is append-only and auditable.
+**Structured comments as state.** Coordination happens through structured HTML comments on GitHub Issues and PRs. State is derived from the comment trail, not from labels or a database. Every transition is append-only and auditable.
 
 **Claim-based work distribution.** Theses live on GitHub Issues. Contributors claim them atomically through the CLI. Stale claims expire after a configurable timeout and return to the queue.
 
@@ -116,7 +114,7 @@ Full command reference in [cli/README.md](cli/README.md).
 
 **Failed experiments are data.** Every attempt gets a row in `results.tsv` and stays as an unmerged branch. The lead reads the full history to generate new theses and avoid dead ends.
 
-**Resource pacing.** Each node sets a `capacity` percentage in `.polyresearch-node.toml` (default 75). The `polyresearch pace` command probes the hardware, prints the project's share plus live load, and lets the agent pick how many theses to run in parallel given each eval's footprint. Multi-project coexistence on one machine is honor-system: set each project's `capacity` so the sum stays safe.
+**Resource pacing.** Each node sets a `capacity` percentage in `.polyresearch-node.toml` (default 75). `polyresearch pace` probes the hardware, prints the project's share plus live load, and determines how many theses to run in parallel given each eval's footprint.
 
 ## Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,19 +1,8 @@
 # polyresearch CLI
 
-`polyresearch` is the mandatory Rust CLI and terminal dashboard for the polyresearch protocol.
+The `polyresearch` CLI is the orchestration layer for the polyresearch protocol. It handles all coordination -- claims, submissions, reviews, syncing, PR decisions, thesis generation -- so agents only need to read `PROGRAM.md`, run experiments, and write results.
 
-It is designed to be used by agents and humans as the canonical path for protocol state transitions, while still being ergonomic for anyone who wants a live status view.
-
-## Why it exists
-
-The protocol stores truth in GitHub issue comments, PR comments, and branches. In practice, contributors repeatedly re-implement the same state derivation logic and get it wrong:
-
-- double-claiming already claimed theses
-- generating new theses while `results.tsv` is stale
-- posting malformed structured comments
-- continuing work after a thesis has already been resolved
-
-This CLI centralizes that logic so every machine uses the same implementation and the lead can validate canonical state against raw GitHub activity.
+Three high-level commands (`bootstrap`, `lead`, `contribute`) run complete loops and spawn agents as subprocesses. The low-level commands below exist for debugging and manual operation.
 
 ## Install
 
@@ -77,25 +66,51 @@ cargo install --path cli
 
 - `git`
 - `gh`
-- a repo containing `POLYRESEARCH.md`, `PROGRAM.md`, and `PREPARE.md`
+- A repo containing `PROGRAM.md` and `PREPARE.md`
 - GitHub authentication through `gh auth login`
 
 The CLI can read `GITHUB_TOKEN`, but by default it uses the existing `gh` authentication on the machine.
 
 ## Releasing
 
-Release tags follow `vX.Y.Z` and must match the version in [cli/Cargo.toml](cli/Cargo.toml). Bump the crate version, push the matching tag, and GitHub Actions publishes the archives and checksums to [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
+Release tags follow `vX.Y.Z` and must match the version in [Cargo.toml](Cargo.toml). Bump the crate version, push the matching tag, and GitHub Actions publishes the archives and checksums to [GitHub Releases](https://github.com/superagent-ai/polyresearch/releases).
 
-## Basic workflow
+## Quick start
 
-Initialize the local node identity once per repo:
+Bootstrap a new project:
+
+```bash
+polyresearch bootstrap https://github.com/owner/repo
+polyresearch bootstrap https://github.com/owner/repo --fork myorg
+```
+
+Run the lead loop:
+
+```bash
+polyresearch lead
+polyresearch lead --once    # single iteration, then exit
+```
+
+Run as a contributor:
+
+```bash
+polyresearch contribute https://github.com/owner/repo
+polyresearch contribute --once
+polyresearch contribute --max-parallel 4
+```
+
+These three commands handle complete workflows. The sections below document the lower-level commands for manual operation and debugging.
+
+## Manual workflow
+
+Initialize the local node identity (the high-level commands do this automatically):
 
 ```bash
 polyresearch init
 polyresearch init --capacity 50
 ```
 
-This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` and a `capacity` percentage (1..=100) giving the share of the total machine this project may use. Additional tuning fields such as `api_budget` and `request_delay_ms` are documented in `POLYRESEARCH.md`.
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` and a `capacity` percentage (1..=100) giving the share of the total machine this project may use.
 
 Inspect the current state:
 
@@ -127,7 +142,7 @@ polyresearch batch-claim
 
 `polyresearch claim` creates a dedicated worktree at `.worktrees/<issue>-<slug>/` from `main` and prints the path. Change into that worktree before editing or running evaluations. The main worktree stays on `main` so the lead can sync, decide, and generate without races from concurrent contributors.
 
-`polyresearch batch-claim --count N` is the multi-thesis version for contributors dispatching sub-agents. It claims `N` approved theses, creates one worktree per thesis, and requires worktrees for parallel execution. Pick `N` from `polyresearch pace` after dividing your effective hardware budget by each eval's resource footprint.
+`polyresearch batch-claim --count N` claims `N` approved theses and creates one worktree per thesis. Pick `N` from `polyresearch pace` after dividing your effective hardware budget by each eval's resource footprint.
 
 Review flow:
 
@@ -167,30 +182,45 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 ## Command summary
 
+High-level orchestration:
+
+- `polyresearch bootstrap <url>` -- clone/fork repo, write templates, init node, spawn setup agent
+- `polyresearch lead` -- continuous lead loop: sync, policy-check, decide, generate
+- `polyresearch contribute [url]` -- continuous contributor loop: claim, experiment, record, submit
+
+Status and inspection:
+
 - `polyresearch init` -- set node identity and `capacity` (percent of total machine), verify GitHub auth, detect repo
 - `polyresearch pace` -- show the hardware budget (machine, your max, live free), GitHub API budget, active claims, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events
+- `polyresearch duties` -- list blocking and advisory work items for the current node
+
+Contributor:
+
 - `polyresearch claim` -- atomically claim a thesis and create the thesis worktree at `.worktrees/<issue>-<slug>/`
 - `polyresearch batch-claim` -- claim up to the node's free thesis slots and create one worktree per thesis
 - `polyresearch attempt` -- post a structured attempt comment from the current branch
 - `polyresearch release` -- release a claim with a structured reason
 - `polyresearch submit` -- push the branch and open a candidate PR
+
+Review:
+
 - `polyresearch review-claim` -- claim a PR for review
 - `polyresearch review` -- post a structured review record with env hash
+
+Lead:
+
 - `polyresearch sync` -- reconcile `results.tsv` from the comment trail
 - `polyresearch generate` -- open a thesis issue (auto-approves when `auto_approve` is `true`, otherwise assigns to maintainer)
 - `polyresearch policy-check` -- validate PR files against the editable surface
 - `polyresearch decide` -- post the lead decision and merge/close accordingly (waits for maintainer `/approve` when `auto_approve` is `false`)
-- `polyresearch duties` -- list blocking and advisory work items for the current node
 - `polyresearch prune` -- prune git worktree metadata and remove empty stale directories under `.worktrees`
 - `polyresearch admin ...` -- lead-only repair commands for exceptional recovery
 
 ## Notes
 
-- The comment trail remains the visible source of activity.
-- Canonical protocol state is derived from validated CLI-compatible events only.
-- `results.tsv` is treated as a lead-maintained ledger derived from canonical history.
-- Raw manual GitHub edits may remain visible for auditability, but they are non-canonical and may be ignored by the lead and the tooling.
-- The CLI keeps normal GitHub comments and PR activity human-readable while abstracting the protocol bookkeeping into the tool itself.
-
+- The comment trail is the source of truth for all protocol activity.
+- Canonical protocol state is derived from validated events only.
+- `results.tsv` is a lead-maintained ledger derived from canonical history.
+- Raw manual GitHub edits may remain visible for auditability, but they are non-canonical and may be ignored by the tooling.


### PR DESCRIPTION
## Summary

- Root README now walks through the actual usage flow: bootstrap (creates the files), lead, contribute
- Removes references to deleted POLYRESEARCH.md and skill file
- Install is a single step (no skill to copy)
- Hardware section explains automatic parallelism via `contribute`
- CLI README adds quick-start section with the three high-level commands
- Command summary organized by role (orchestration, status, contributor, review, lead)
- Requirements list no longer mentions POLYRESEARCH.md

## Test plan

- No code changes, documentation only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code or behavioral impact; risk is limited to potential user confusion if the updated instructions are inaccurate.
> 
> **Overview**
> Updates the root `README.md` to reflect the current v0.5.0 workflow: one-step install, a clearer 3-step usage flow (`bootstrap` → `lead` → `contribute`), and updated guidance on what files are generated (`PROGRAM.md`, `PREPARE.md`, `results.tsv`, `.polyresearch-node.toml`). It also removes/rewrites older protocol references (e.g., `POLYRESEARCH.md` and agent “skill” copy steps) and refreshes remote-run and hardware-parallelism explanations around `contribute`/`pace`.
> 
> Refreshes `cli/README.md` with a new quick start for the three high-level orchestration commands, updates requirements/release instructions, and reorganizes the command summary by role (orchestration/status/contributor/review/lead) with tightened wording on manual vs loop-driven usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb511775315dc6255f9aab3c937a5b0a1db3e87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->