### PR TITLE
Update READMEs for v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,7 @@ A single evaluation often doesn't saturate a machine. The `contribute` command h
 
 ### Run on a remote machine
 
-#### Pattern A: Remote evaluation over SSH
-
-The contributor runs on your local machine. The experiments run on a remote server. Set up the repo, CLI, and `gh` auth on the remote, then:
-
-```bash
-polyresearch contribute https://github.com/owner/repo
-# evaluations are dispatched to the remote via the agent's SSH access
-```
-
-Your local machine only needs the agent; the remote server does the compute.
-
-#### Pattern B: Run the contributor on the server
-
-The recommended pattern. The contributor runs directly on the server, so file access, git operations, and evaluations are all local.
-
-Use `tmux` so the session survives disconnects:
+Run the contributor directly on the server so file access, git operations, and evaluations are all local. Use `tmux` so the session survives disconnects:
 
 ```bash
 ssh user@remote-host


### PR DESCRIPTION
## Summary

- Root README restructured around the actual usage flow: bootstrap, lead, contribute
- Removes references to deleted POLYRESEARCH.md and skill file
- Install is a single step
- Hardware section explains automatic parallelism via `contribute`
- Removes fictional SSH relay pattern from remote machine section
- CLI README adds quick-start section with the three high-level commands
- Command summary organized by role
- Requirements no longer mention POLYRESEARCH.md

## Test plan

- Documentation only, no code changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes obsolete/incorrect instructions; no code paths or runtime behavior are affected.
> 
> **Overview**
> Updates `README.md` to **simplify the “Run on a remote machine” guidance** by removing the previously documented SSH relay pattern and consolidating the section into a single recommended workflow: run `polyresearch contribute` directly on the remote server (with `tmux`) so evals and git/file operations stay local.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94aed31013fbc54ea09c4c280bfe622d6f18d5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->