### PR TITLE
Fix bootstrap and contribute to clone into repo-named subdirectory

### DIFF
--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -46,7 +46,8 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
 }
 
 pub(crate) fn repo_name_from_url(url: &str) -> String {
-    url.rsplit('/')
+    url.trim_end_matches('/')
+        .rsplit('/')
         .next()
         .unwrap_or("repo")
         .trim_end_matches(".git")

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -11,31 +11,46 @@ use crate::config::NodeConfig;
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     eprintln!("Bootstrapping polyresearch project from {}", args.url);
 
+    let repo_root = if ctx.repo_root.join(".git").exists() {
+        ctx.repo_root.clone()
+    } else {
+        let name = repo_name_from_url(&args.url);
+        ctx.repo_root.join(name)
+    };
+
     // Step 1: Clone or reuse
     if let Some(fork_owner) = &args.fork {
-        fork_and_clone(&args.url, fork_owner, &ctx.repo_root)?;
+        fork_and_clone(&args.url, fork_owner, &repo_root)?;
     } else {
-        clone_if_needed(&args.url, &ctx.repo_root)?;
+        clone_if_needed(&args.url, &repo_root)?;
     }
 
     // Step 2: Write templates
-    write_templates(&ctx.repo_root, args.goal.as_deref())?;
+    write_templates(&repo_root, args.goal.as_deref())?;
 
     // Step 3: Initialize node config
-    initialize_node(&ctx.repo_root)?;
+    initialize_node(&repo_root)?;
 
     // Step 4: Spawn agent for project-specific setup
     if !args.pause_after_bootstrap {
-        spawn_setup_agent(&ctx.repo_root)?;
+        spawn_setup_agent(&repo_root)?;
     } else {
         eprintln!("Pausing after bootstrap. Edit PROGRAM.md and PREPARE.md manually.");
     }
 
     // Step 5: Normalize PROGRAM.md
-    normalize_program_md(&ctx.repo_root)?;
+    normalize_program_md(&repo_root)?;
 
     eprintln!("Bootstrap complete.");
     Ok(())
+}
+
+pub(crate) fn repo_name_from_url(url: &str) -> String {
+    url.rsplit('/')
+        .next()
+        .unwrap_or("repo")
+        .trim_end_matches(".git")
+        .to_string()
 }
 
 fn fork_and_clone(url: &str, fork_owner: &str, repo_root: &Path) -> Result<()> {
@@ -72,8 +87,8 @@ fn fork_and_clone(url: &str, fork_owner: &str, repo_root: &Path) -> Result<()> {
         }
     }
 
-    let repo_name = url.rsplit('/').next().unwrap_or("repo").trim_end_matches(".git");
-    let fork_url = format!("https://github.com/{fork_owner}/{repo_name}.git");
+    let name = repo_name_from_url(url);
+    let fork_url = format!("https://github.com/{fork_owner}/{name}.git");
     clone_if_needed(&fork_url, repo_root)?;
 
     commands::run_git(

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -14,9 +14,22 @@ use crate::state::{RepositoryState, ThesisPhase, ThesisState};
 use crate::worker::{self, ThesisWorker, WorkerContext, WorkerOutcome};
 
 pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
-    if let Some(url) = &args.url {
-        clone_repo(url, &ctx.repo_root)?;
-    }
+    let ctx = if let Some(url) = &args.url {
+        let repo_root = if ctx.repo_root.join(".git").exists() {
+            ctx.repo_root.clone()
+        } else {
+            let name = super::bootstrap::repo_name_from_url(url);
+            ctx.repo_root.join(name)
+        };
+        clone_repo(url, &repo_root)?;
+        std::borrow::Cow::Owned(AppContext {
+            repo_root,
+            ..ctx.clone()
+        })
+    } else {
+        std::borrow::Cow::Borrowed(ctx)
+    };
+    let ctx = ctx.as_ref();
 
     let config = ProtocolConfig::load(&ctx.repo_root)?;
     config.check_cli_version(env!("CARGO_PKG_VERSION"))?;


### PR DESCRIPTION
## Summary

- `polyresearch bootstrap <url>` and `polyresearch contribute --url <url>` were cloning directly into `cwd` when run outside a git repo, causing `fatal: destination path already exists and is not an empty directory`
- Now both commands derive the repo name from the URL (e.g. `dotenv` from `https://github.com/motdotla/dotenv`) and clone into `cwd/<repo_name>`, matching the standard `git clone` behavior
- Extracted `repo_name_from_url` as a shared `pub(crate)` helper to avoid duplication

## Test plan

- [ ] Run `polyresearch bootstrap <url>` from a non-empty directory and verify it creates a subdirectory named after the repo
- [ ] Run `polyresearch bootstrap <url> --fork <owner>` and verify the same
- [ ] Run from inside an already-cloned repo and verify the existing `.git` check still skips cloning
- [ ] Run `polyresearch contribute --url <url>` from a non-empty directory and verify it clones into a subdirectory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI path-selection change that affects where repos are cloned and where files are written, with minimal impact beyond filesystem layout.
> 
> **Overview**
> Fixes `bootstrap` and `contribute --url` to **clone into a repo-named subdirectory** when run outside an existing git checkout, avoiding `git clone` failures in non-empty directories.
> 
> Adds shared helper `repo_name_from_url` and reworks `bootstrap` (including fork flow) and `contribute` to compute an effective `repo_root` (either the current repo if `.git` exists, or `cwd/<repo>`), ensuring subsequent template/config/setup steps target the correct path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e505879b91e2d0c31cfe66c122b85be9c9ffdfbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->