### PR TITLE
Add CLI flags for node config overrides and auto-fork in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ Point it at any GitHub repo with a codebase and a metric you want to improve:
 ```bash
 polyresearch bootstrap https://github.com/owner/repo
 polyresearch bootstrap https://github.com/owner/repo --fork myorg
+polyresearch bootstrap https://github.com/owner/repo --no-fork
 ```
 
-This clones the repo (or forks it first with `--fork`), writes template files, initializes your machine as a node, and spawns an agent to fill in project-specific details. When it finishes you'll have:
+Bootstrap checks whether you have push access to the target repo. If not, it forks to your GitHub account automatically (or to a specific org with `--fork`). Use `--no-fork` to skip the check and clone directly.
+
+This writes template files, initializes your machine as a node, and spawns an agent to fill in project-specific details. When it finishes you'll have:
 
 - **`PROGRAM.md`** -- the research playbook. Describes the goal, which files agents can edit, strategy hints. This is the only file agents read.
 - **`PREPARE.md`** -- the evaluation setup. Benchmark command, metric parsing, ground truth. Lives outside the editable surface so agents can't change how they're judged.
@@ -46,9 +49,10 @@ From the root of your project (where you ran `bootstrap`):
 
 ```bash
 polyresearch lead
+polyresearch lead --agent-command "codex --full-auto"
 ```
 
-The lead syncs the results ledger, policy-checks open PRs, decides candidates (merge or reject), and generates new theses when the queue runs low. It runs in a loop until you stop it. Use `--once` for a single iteration.
+The lead syncs the results ledger, policy-checks open PRs, decides candidates (merge or reject), and generates new theses when the queue runs low. It runs in a loop until you stop it. Use `--once` for a single iteration. Node config settings (`--capacity`, `--api-budget`, `--request-delay`, `--agent-command`) can be overridden at runtime without editing `.polyresearch-node.toml`.
 
 ### 3. Run contributors
 
@@ -56,9 +60,10 @@ On any machine (yours, a teammate's, a rented GPU box):
 
 ```bash
 polyresearch contribute https://github.com/owner/repo
+polyresearch contribute --capacity 50 --agent-command "codex --full-auto"
 ```
 
-The contributor clones the repo, claims theses from the issue queue, spawns an agent for each one, records results, and submits PRs. Launch as many contributor machines as you want -- they all pull from the same queue.
+The contributor clones the repo, claims theses from the issue queue, spawns an agent for each one, records results, and submits PRs. Launch as many contributor machines as you want -- they all pull from the same queue. Node config settings (`--capacity`, `--api-budget`, `--request-delay`, `--agent-command`) can be overridden at runtime without editing `.polyresearch-node.toml`.
 
 ### Run on a remote machine
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -82,13 +82,17 @@ Bootstrap a new project:
 ```bash
 polyresearch bootstrap https://github.com/owner/repo
 polyresearch bootstrap https://github.com/owner/repo --fork myorg
+polyresearch bootstrap https://github.com/owner/repo --no-fork
 ```
+
+Bootstrap auto-forks when you lack push access to the target repo. Use `--fork <org>` to fork to a specific organization, or `--no-fork` to clone directly.
 
 Run the lead loop:
 
 ```bash
 polyresearch lead
 polyresearch lead --once    # single iteration, then exit
+polyresearch lead --agent-command "codex --full-auto"
 ```
 
 Run as a contributor:
@@ -97,7 +101,10 @@ Run as a contributor:
 polyresearch contribute https://github.com/owner/repo
 polyresearch contribute --once
 polyresearch contribute --max-parallel 4
+polyresearch contribute --capacity 50 --agent-command "codex --full-auto"
 ```
+
+All four node config settings can be overridden at runtime via `--capacity`, `--api-budget`, `--request-delay`, and `--agent-command`. These are pure runtime overrides and do not modify `.polyresearch-node.toml`.
 
 These three commands handle complete workflows. The sections below document the lower-level commands for manual operation and debugging.
 
@@ -114,9 +121,10 @@ Initialize the local node identity (the high-level commands do this automaticall
 ```bash
 polyresearch init
 polyresearch init --capacity 50
+polyresearch init --api-budget 10000 --request-delay 200 --agent-command "codex --full-auto"
 ```
 
-This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id` and a `capacity` percentage (1..=100) giving the share of the total machine this project may use.
+This writes `.polyresearch-node.toml` in the repo root. The file stores a stable `node_id`, a `capacity` percentage (1..=100) giving the share of the total machine this project may use, an `api_budget` for GitHub API rate pacing, a `request_delay_ms` between API calls, and an `[agent] command` for the experiment runner.
 
 Inspect the current state:
 
@@ -190,13 +198,13 @@ The maintainer comments `/approve` or `/reject` directly on thesis issues and ca
 
 High-level orchestration:
 
-- `polyresearch bootstrap <url>` -- clone/fork repo, write templates, init node, spawn setup agent
-- `polyresearch lead` -- continuous lead loop: sync, policy-check, decide, generate
-- `polyresearch contribute [url]` -- continuous contributor loop: claim, experiment, record, submit
+- `polyresearch bootstrap <url>` -- auto-fork (or `--fork <org>`, `--no-fork`), write templates, init node, spawn setup agent. Accepts `--capacity`, `--api-budget`, `--request-delay`, `--agent-command` to set initial node config values.
+- `polyresearch lead` -- continuous lead loop: sync, policy-check, decide, generate. Accepts `--capacity`, `--api-budget`, `--request-delay`, `--agent-command` as runtime overrides.
+- `polyresearch contribute [url]` -- continuous contributor loop: claim, experiment, record, submit. Accepts `--capacity`, `--api-budget`, `--request-delay`, `--agent-command` as runtime overrides.
 
 Status and inspection:
 
-- `polyresearch init` -- set node identity and `capacity` (percent of total machine), verify GitHub auth, detect repo
+- `polyresearch init` -- set node identity and config (`--capacity`, `--api-budget`, `--request-delay`, `--agent-command`), verify GitHub auth, detect repo
 - `polyresearch pace` -- show the hardware budget (machine, your max, live free), GitHub API budget, active claims, and recent node throughput
 - `polyresearch status` -- derive thesis state, queue depth, active nodes, current best metric
 - `polyresearch audit` -- validate raw GitHub activity and report invalid or suspicious protocol events

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -208,7 +208,7 @@ pub struct BootstrapArgs {
     #[arg(long)]
     pub fork: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, conflicts_with = "fork")]
     pub no_fork: bool,
 
     #[arg(long)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -49,13 +49,28 @@ pub enum Commands {
     Contribute(ContributeArgs),
 }
 
+#[derive(Debug, Args, Clone, Default)]
+pub struct NodeOverrides {
+    #[arg(long, value_parser = clap::value_parser!(u8).range(1..=100))]
+    pub capacity: Option<u8>,
+
+    #[arg(long)]
+    pub api_budget: Option<u64>,
+
+    #[arg(long)]
+    pub request_delay: Option<u64>,
+
+    #[arg(long)]
+    pub agent_command: Option<String>,
+}
+
 #[derive(Debug, Args, Clone)]
 pub struct InitArgs {
     #[arg(long)]
     pub node: Option<String>,
 
-    #[arg(long, value_parser = clap::value_parser!(u8).range(1..=100))]
-    pub capacity: Option<u8>,
+    #[command(flatten)]
+    pub overrides: NodeOverrides,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -194,10 +209,16 @@ pub struct BootstrapArgs {
     pub fork: Option<String>,
 
     #[arg(long)]
+    pub no_fork: bool,
+
+    #[arg(long)]
     pub goal: Option<String>,
 
     #[arg(long)]
     pub pause_after_bootstrap: bool,
+
+    #[command(flatten)]
+    pub overrides: NodeOverrides,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -207,6 +228,9 @@ pub struct LeadArgs {
 
     #[arg(long, default_value = "60")]
     pub sleep_secs: u64,
+
+    #[command(flatten)]
+    pub overrides: NodeOverrides,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -221,4 +245,7 @@ pub struct ContributeArgs {
 
     #[arg(long, default_value = "60")]
     pub sleep_secs: u64,
+
+    #[command(flatten)]
+    pub overrides: NodeOverrides,
 }

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -7,6 +7,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use crate::cli::BootstrapArgs;
 use crate::commands::{self, AppContext};
 use crate::config::NodeConfig;
+use crate::github::RepoRef;
 
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     eprintln!("Bootstrapping polyresearch project from {}", args.url);
@@ -18,22 +19,24 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         ctx.repo_root.join(name)
     };
 
-    // Step 1: Clone or reuse
-    if let Some(fork_owner) = &args.fork {
+    // Step 1: Clone or fork-then-clone
+    if args.no_fork {
+        clone_if_needed(&args.url, &repo_root)?;
+    } else if let Some(fork_owner) = &args.fork {
         fork_and_clone(&args.url, fork_owner, &repo_root)?;
     } else {
-        clone_if_needed(&args.url, &repo_root)?;
+        auto_clone_or_fork(&args.url, &repo_root)?;
     }
 
     // Step 2: Write templates
     write_templates(&repo_root, args.goal.as_deref())?;
 
-    // Step 3: Initialize node config
-    initialize_node(&repo_root)?;
+    // Step 3: Initialize node config (with any CLI overrides)
+    initialize_node(&repo_root, &args.overrides)?;
 
     // Step 4: Spawn agent for project-specific setup
     if !args.pause_after_bootstrap {
-        spawn_setup_agent(&repo_root)?;
+        spawn_setup_agent(&repo_root, &args.overrides)?;
     } else {
         eprintln!("Pausing after bootstrap. Edit PROGRAM.md and PREPARE.md manually.");
     }
@@ -52,6 +55,62 @@ pub(crate) fn repo_name_from_url(url: &str) -> String {
         .unwrap_or("repo")
         .trim_end_matches(".git")
         .to_string()
+}
+
+fn auto_clone_or_fork(url: &str, repo_root: &Path) -> Result<()> {
+    if repo_root.join(".git").exists() {
+        eprintln!("Repository already exists at {}", repo_root.display());
+        let _ = commands::run_git(&repo_root.to_path_buf(), &["fetch", "origin"]);
+        return Ok(());
+    }
+
+    let upstream = RepoRef::parse_url(url)
+        .ok_or_else(|| eyre!("could not parse GitHub owner/repo from URL: {url}"))?;
+
+    if has_push_access(&upstream.owner, &upstream.name) {
+        eprintln!("Push access confirmed, cloning directly.");
+        clone_if_needed(url, repo_root)
+    } else {
+        let login = get_current_login()?;
+        eprintln!(
+            "No push access to {}/{}, forking to {login}...",
+            upstream.owner, upstream.name
+        );
+        fork_and_clone(url, &login, repo_root)
+    }
+}
+
+fn has_push_access(owner: &str, name: &str) -> bool {
+    Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{owner}/{name}"),
+            "--jq",
+            ".permissions.push",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim() == "true")
+        .unwrap_or(false)
+}
+
+fn get_current_login() -> Result<String> {
+    let output = Command::new("gh")
+        .args(["api", "user", "--jq", ".login"])
+        .output()
+        .wrap_err("failed to query current GitHub user")?;
+    if !output.status.success() {
+        return Err(eyre!(
+            "gh api user failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let login = String::from_utf8(output.stdout)?.trim().to_string();
+    if login.is_empty() {
+        return Err(eyre!("could not determine GitHub login; run `gh auth login` first"));
+    }
+    Ok(login)
 }
 
 fn fork_and_clone(url: &str, fork_owner: &str, repo_root: &Path) -> Result<()> {
@@ -223,16 +282,32 @@ Describe what the baseline metric represents and how it was measured.
     Ok(())
 }
 
-fn initialize_node(repo_root: &Path) -> Result<()> {
-    commands::ensure_node_config(repo_root)
+fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
+    commands::ensure_node_config(repo_root)?;
+    if overrides.capacity.is_some()
+        || overrides.api_budget.is_some()
+        || overrides.request_delay.is_some()
+        || overrides.agent_command.is_some()
+    {
+        let config = NodeConfig::load(repo_root)?;
+        config.with_overrides(overrides).save(repo_root)?;
+    }
+    Ok(())
 }
 
-fn spawn_setup_agent(repo_root: &Path) -> Result<()> {
-    let node_config = NodeConfig::load(&repo_root.to_path_buf()).ok();
+fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
+    let node_config = NodeConfig::load(&repo_root.to_path_buf())
+        .ok()
+        .map(|c| c.with_overrides(overrides));
     let agent_command = node_config
         .as_ref()
         .map(|c| c.agent.command.clone())
-        .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string());
+        .unwrap_or_else(|| {
+            overrides
+                .agent_command
+                .clone()
+                .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string())
+        });
 
     let prompt = "Read PROGRAM.md and PREPARE.md. Fill in the project-specific details: \
         set lead_github_login and maintainer_github_login to appropriate values, \

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -55,7 +55,7 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
     };
 
     ensure_node_config(&ctx.repo_root)?;
-    let node_config = NodeConfig::load(&ctx.repo_root)?;
+    let node_config = NodeConfig::load(&ctx.repo_root)?.with_overrides(&args.overrides);
     let node_id = node_config.node_id.clone();
     let agent_command = node_config.agent.command.clone();
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -28,7 +28,7 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
         .as_ref()
         .map(|config| config.capacity)
         .unwrap_or(DEFAULT_CAPACITY);
-    let capacity = args.capacity.unwrap_or(existing_capacity);
+    let capacity = args.overrides.capacity.unwrap_or(existing_capacity);
 
     if let Ok(false) = ctx.github.repo_has_issues() {
         eprintln!("Warning: Issues are disabled on this repository (common for forks).");
@@ -39,7 +39,7 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     }
 
     if !ctx.cli.dry_run {
-        write_node_config(&ctx.repo_root, &node, Some(capacity))?;
+        write_node_config(&ctx.repo_root, &node, &args.overrides)?;
     }
 
     let output = InitOutput {

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -17,11 +17,18 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
     config.check_cli_version(env!("CARGO_PKG_VERSION"))?;
     let program = ProgramSpec::load(&ctx.repo_root, &config)?;
     let default_branch = config.resolve_default_branch(&ctx.repo_root)?;
-    let node_config = NodeConfig::load(&ctx.repo_root).ok();
+    let node_config = NodeConfig::load(&ctx.repo_root)
+        .ok()
+        .map(|c| c.with_overrides(&args.overrides));
     let agent_command = node_config
         .as_ref()
         .map(|c| c.agent.command.clone())
-        .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string());
+        .unwrap_or_else(|| {
+            args.overrides
+                .agent_command
+                .clone()
+                .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string())
+        });
 
     eprintln!("Running lead loop as `{login}`");
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -116,13 +116,13 @@ pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
 }
 
 pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
-    write_node_config(repo_root, node, None)
+    write_node_config(repo_root, node, &crate::cli::NodeOverrides::default())
 }
 
 pub fn write_node_config(
     repo_root: &PathBuf,
     node: &str,
-    capacity: Option<u8>,
+    overrides: &crate::cli::NodeOverrides,
 ) -> Result<()> {
     let existing = NodeConfig::load(repo_root).ok();
     let existing_budget = existing
@@ -140,10 +140,16 @@ pub fn write_node_config(
     let existing_agent = existing.as_ref().map(|config| config.agent.clone());
     NodeConfig::new(
         node.to_string(),
-        capacity.unwrap_or(existing_capacity),
-        existing_budget,
-        existing_request_delay_ms,
-        existing_agent,
+        overrides.capacity.unwrap_or(existing_capacity),
+        overrides.api_budget.unwrap_or(existing_budget),
+        overrides.request_delay.unwrap_or(existing_request_delay_ms),
+        overrides
+            .agent_command
+            .as_ref()
+            .map(|cmd| crate::config::AgentConfig {
+                command: cmd.clone(),
+            })
+            .or(existing_agent),
     )
     .save(repo_root)
 }
@@ -168,7 +174,7 @@ pub fn ensure_node_config(repo_root: &Path) -> Result<()> {
             .collect()
     };
     let node_id = format!("{hostname}-{suffix}");
-    write_node_config(&repo_root.to_path_buf(), &node_id, None)?;
+    write_node_config(&repo_root.to_path_buf(), &node_id, &crate::cli::NodeOverrides::default())?;
     eprintln!("Initialized node as `{node_id}`");
     Ok(())
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -136,6 +136,24 @@ impl NodeConfig {
         Ok(())
     }
 
+    pub fn with_overrides(mut self, overrides: &crate::cli::NodeOverrides) -> Self {
+        if let Some(c) = overrides.capacity {
+            self.capacity = normalize_capacity(c);
+        }
+        if let Some(b) = overrides.api_budget {
+            self.api_budget = normalize_api_budget(b);
+        }
+        if let Some(d) = overrides.request_delay {
+            self.request_delay_ms = normalize_request_delay_ms(d);
+        }
+        if let Some(ref cmd) = overrides.agent_command {
+            self.agent = AgentConfig {
+                command: cmd.clone(),
+            };
+        }
+        self
+    }
+
     pub fn effective_capacity(&self) -> u8 {
         normalize_capacity(self.capacity)
     }
@@ -1015,6 +1033,90 @@ Do something.
     fn check_cli_version_skipped_when_unset() {
         let config = ProtocolConfig::default();
         assert!(config.check_cli_version("0.0.0").is_ok());
+    }
+
+    #[test]
+    fn with_overrides_applies_capacity() {
+        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            capacity: Some(42),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.capacity, 42);
+        assert_eq!(updated.api_budget, DEFAULT_API_BUDGET);
+        assert_eq!(updated.request_delay_ms, DEFAULT_REQUEST_DELAY_MS);
+        assert_eq!(updated.agent, AgentConfig::default());
+    }
+
+    #[test]
+    fn with_overrides_applies_api_budget() {
+        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            api_budget: Some(10_000),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.api_budget, 10_000);
+        assert_eq!(updated.capacity, DEFAULT_CAPACITY);
+    }
+
+    #[test]
+    fn with_overrides_applies_request_delay() {
+        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            request_delay: Some(500),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.request_delay_ms, 500);
+    }
+
+    #[test]
+    fn with_overrides_applies_agent_command() {
+        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            agent_command: Some("codex --full-auto".to_string()),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.agent.command, "codex --full-auto");
+    }
+
+    #[test]
+    fn with_overrides_applies_all_fields() {
+        let config = NodeConfig::new("n", 50, 3000, 200, None);
+        let overrides = crate::cli::NodeOverrides {
+            capacity: Some(80),
+            api_budget: Some(9000),
+            request_delay: Some(300),
+            agent_command: Some("my-agent run".to_string()),
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.capacity, 80);
+        assert_eq!(updated.api_budget, 9000);
+        assert_eq!(updated.request_delay_ms, 300);
+        assert_eq!(updated.agent.command, "my-agent run");
+        assert_eq!(updated.node_id, "n");
+    }
+
+    #[test]
+    fn with_overrides_empty_leaves_unchanged() {
+        let config = NodeConfig::new("n", 50, 3000, 200, Some(AgentConfig { command: "original".to_string() }));
+        let overrides = crate::cli::NodeOverrides::default();
+        let updated = config.clone().with_overrides(&overrides);
+        assert_eq!(updated, config);
+    }
+
+    #[test]
+    fn with_overrides_normalizes_zero_capacity() {
+        let config = NodeConfig::new("n", 50, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            capacity: Some(0),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.capacity, DEFAULT_CAPACITY);
     }
 
     fn unique_temp_dir(name: &str) -> PathBuf {

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -60,23 +60,11 @@ impl RepoRef {
     }
 
     fn parse_remote(remote: &str) -> Result<Self> {
-        let stripped = remote
-            .trim()
-            .trim_end_matches(".git")
-            .trim_start_matches("https://github.com/")
-            .trim_start_matches("http://github.com/")
-            .trim_start_matches("git@github.com:");
-
-        Self::parse(stripped)
+        Self::parse(strip_github_url(remote))
     }
 
     pub fn parse_url(url: &str) -> Option<Self> {
-        let stripped = url
-            .trim()
-            .trim_end_matches(".git")
-            .trim_start_matches("https://github.com/")
-            .trim_start_matches("http://github.com/")
-            .trim_start_matches("git@github.com:");
+        let stripped = strip_github_url(url);
         let (owner, name) = stripped.split_once('/')?;
         if owner.is_empty() || name.is_empty() {
             return None;
@@ -90,6 +78,14 @@ impl RepoRef {
     pub fn slug(&self) -> String {
         format!("{}/{}", self.owner, self.name)
     }
+}
+
+fn strip_github_url(url: &str) -> &str {
+    url.trim()
+        .trim_end_matches(".git")
+        .trim_start_matches("https://github.com/")
+        .trim_start_matches("http://github.com/")
+        .trim_start_matches("git@github.com:")
 }
 
 #[derive(Debug, Clone)]

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -70,6 +70,23 @@ impl RepoRef {
         Self::parse(stripped)
     }
 
+    pub fn parse_url(url: &str) -> Option<Self> {
+        let stripped = url
+            .trim()
+            .trim_end_matches(".git")
+            .trim_start_matches("https://github.com/")
+            .trim_start_matches("http://github.com/")
+            .trim_start_matches("git@github.com:");
+        let (owner, name) = stripped.split_once('/')?;
+        if owner.is_empty() || name.is_empty() {
+            return None;
+        }
+        Some(Self {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+
     pub fn slug(&self) -> String {
         format!("{}/{}", self.owner, self.name)
     }
@@ -1007,5 +1024,36 @@ mod tests {
     #[test]
     fn jittered_delay_noops_for_zero_base() {
         assert_eq!(jittered_delay(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_url_handles_https() {
+        let r = RepoRef::parse_url("https://github.com/owner/repo").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn parse_url_handles_https_with_git_suffix() {
+        let r = RepoRef::parse_url("https://github.com/owner/repo.git").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn parse_url_handles_ssh() {
+        let r = RepoRef::parse_url("git@github.com:owner/repo.git").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn parse_url_returns_none_for_garbage() {
+        assert!(RepoRef::parse_url("not-a-url").is_none());
+    }
+
+    #[test]
+    fn parse_url_returns_none_for_empty_parts() {
+        assert!(RepoRef::parse_url("https://github.com//").is_none());
     }
 }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -86,6 +86,7 @@ fn strip_github_url(url: &str) -> &str {
         .trim_start_matches("https://github.com/")
         .trim_start_matches("http://github.com/")
         .trim_start_matches("git@github.com:")
+        .trim_end_matches('/')
 }
 
 #[derive(Debug, Clone)]
@@ -1051,5 +1052,12 @@ mod tests {
     #[test]
     fn parse_url_returns_none_for_empty_parts() {
         assert!(RepoRef::parse_url("https://github.com//").is_none());
+    }
+
+    #[test]
+    fn parse_url_handles_trailing_slash() {
+        let r = RepoRef::parse_url("https://github.com/owner/repo/").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
     }
 }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -60,13 +60,16 @@ impl RepoRef {
     }
 
     fn parse_remote(remote: &str) -> Result<Self> {
-        Self::parse(strip_github_url(remote))
+        let stripped = strip_github_prefix(remote)
+            .unwrap_or_else(|| remote.trim().trim_end_matches(".git"));
+        Self::parse(stripped)
     }
 
     pub fn parse_url(url: &str) -> Option<Self> {
-        let stripped = strip_github_url(url);
-        let (owner, name) = stripped.split_once('/')?;
-        if owner.is_empty() || name.is_empty() {
+        let stripped = strip_github_prefix(url)?;
+        let (owner, rest) = stripped.split_once('/')?;
+        let name = rest.split('/').next().unwrap_or("");
+        if owner.is_empty() || name.is_empty() || name != rest {
             return None;
         }
         Some(Self {
@@ -80,13 +83,19 @@ impl RepoRef {
     }
 }
 
-fn strip_github_url(url: &str) -> &str {
-    url.trim()
-        .trim_end_matches(".git")
-        .trim_start_matches("https://github.com/")
-        .trim_start_matches("http://github.com/")
-        .trim_start_matches("git@github.com:")
-        .trim_end_matches('/')
+fn strip_github_prefix(url: &str) -> Option<&str> {
+    let trimmed = url.trim().trim_end_matches(".git");
+    const PREFIXES: &[&str] = &[
+        "https://github.com/",
+        "http://github.com/",
+        "git@github.com:",
+    ];
+    for prefix in PREFIXES {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return Some(rest.trim_end_matches('/'));
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone)]
@@ -1059,5 +1068,24 @@ mod tests {
         let r = RepoRef::parse_url("https://github.com/owner/repo/").unwrap();
         assert_eq!(r.owner, "owner");
         assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn parse_url_rejects_non_github_urls() {
+        assert!(RepoRef::parse_url("https://gitlab.com/owner/repo").is_none());
+        assert!(RepoRef::parse_url("https://bitbucket.org/owner/repo").is_none());
+        assert!(RepoRef::parse_url("https://example.com/owner/repo").is_none());
+    }
+
+    #[test]
+    fn parse_url_rejects_extra_path_segments() {
+        assert!(RepoRef::parse_url("https://github.com/owner/repo/tree/main").is_none());
+        assert!(RepoRef::parse_url("https://github.com/owner/repo/pulls").is_none());
+    }
+
+    #[test]
+    fn parse_url_rejects_owner_only() {
+        assert!(RepoRef::parse_url("https://github.com/owner").is_none());
+        assert!(RepoRef::parse_url("https://github.com/owner/").is_none());
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,9 +28,17 @@ async fn main() -> Result<()> {
 
     let cwd = env::current_dir().wrap_err("failed to determine current working directory")?;
 
+    let (api_budget_override, request_delay_override) = match &cli.command {
+        Commands::Contribute(args) => (args.overrides.api_budget, args.overrides.request_delay),
+        Commands::Lead(args) => (args.overrides.api_budget, args.overrides.request_delay),
+        _ => (None, None),
+    };
+
     if needs_deferred_setup {
         let repo_root = discover_repo_root(&cwd).unwrap_or(cwd);
-        throttle::init(NodeConfig::load_request_delay_ms(&repo_root));
+        let request_delay_ms = request_delay_override
+            .unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
+        throttle::init(request_delay_ms);
         let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)
             .ok()
             .unwrap_or_else(|| RepoRef {
@@ -38,7 +46,8 @@ async fn main() -> Result<()> {
                 name: String::new(),
             });
         let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-        let api_budget = NodeConfig::load_api_budget(&repo_root);
+        let api_budget = api_budget_override
+            .unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
         let config = ProtocolConfig::default();
         let program = ProgramSpec {
             can_modify: Vec::new(),
@@ -59,10 +68,13 @@ async fn main() -> Result<()> {
     }
 
     let repo_root = discover_repo_root(&cwd)?;
-    throttle::init(NodeConfig::load_request_delay_ms(&repo_root));
+    let request_delay_ms = request_delay_override
+        .unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
+    throttle::init(request_delay_ms);
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-    let api_budget = NodeConfig::load_api_budget(&repo_root);
+    let api_budget = api_budget_override
+        .unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
     let config = ProtocolConfig::load(&repo_root)?;
     config.check_cli_version(env!("CARGO_PKG_VERSION"))?;
     let program = ProgramSpec::load(&repo_root, &config)?;

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch::cli::{
-    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, PrArgs,
-    ReleaseArgs, StatusArgs,
+    AttemptArgs, BatchClaimArgs, Cli, Commands, GenerateArgs, InitArgs, IssueArgs, NodeOverrides,
+    PrArgs, ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
 use polyresearch::comments::{Observation, ReleaseReason};
@@ -315,7 +315,7 @@ async fn init_writes_node_identity() {
         false,
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
-            capacity: Some(50),
+            overrides: NodeOverrides { capacity: Some(50), ..Default::default() },
         }),
     );
 
@@ -323,7 +323,7 @@ async fn init_writes_node_identity() {
         &ctx,
         &InitArgs {
             node: Some("test-node".to_string()),
-            capacity: Some(50),
+            overrides: NodeOverrides { capacity: Some(50), ..Default::default() },
         },
     )
     .await
@@ -348,7 +348,7 @@ async fn env_override_uses_session_node_id() {
         HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
-    commands::write_node_config(&repo.path, "lead/file-node", Some(60)).unwrap();
+    commands::write_node_config(&repo.path, "lead/file-node", &NodeOverrides { capacity: Some(60), ..Default::default() }).unwrap();
     set_node_id_env("lead/env-node");
 
     let node_config = NodeConfig::load(&repo.path).unwrap();
@@ -517,7 +517,7 @@ async fn init_preserves_custom_api_budget() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            capacity: None,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -525,7 +525,7 @@ async fn init_preserves_custom_api_budget() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            capacity: None,
+            overrides: NodeOverrides::default(),
         },
     )
     .await
@@ -562,7 +562,7 @@ async fn init_preserves_custom_request_delay() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            capacity: None,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -570,7 +570,7 @@ async fn init_preserves_custom_request_delay() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            capacity: None,
+            overrides: NodeOverrides::default(),
         },
     )
     .await
@@ -607,7 +607,7 @@ async fn init_drops_legacy_fields_and_writes_capacity() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            capacity: Some(40),
+            overrides: NodeOverrides { capacity: Some(40), ..Default::default() },
         }),
     );
 
@@ -615,7 +615,7 @@ async fn init_drops_legacy_fields_and_writes_capacity() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            capacity: Some(40),
+            overrides: NodeOverrides { capacity: Some(40), ..Default::default() },
         },
     )
     .await
@@ -2044,6 +2044,7 @@ async fn contribute_blocks_on_non_submit_duties() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -2052,6 +2053,7 @@ async fn contribute_blocks_on_non_submit_duties() {
         once: true,
         max_parallel: Some(1),
         sleep_secs: 0,
+        overrides: NodeOverrides::default(),
     }).await;
 
     assert!(result.is_ok() || result.unwrap_err().to_string().contains("blocking"));
@@ -2401,6 +2403,7 @@ Test.
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -2420,6 +2423,7 @@ Test.
         once: true,
         max_parallel: Some(1),
         sleep_secs: 0,
+        overrides: NodeOverrides::default(),
     })
     .await;
 

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use polyresearch::cli::{
-    BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs,
+    BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides,
 };
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
@@ -260,8 +260,10 @@ async fn scenario_bootstrap_fresh() {
         Commands::Bootstrap(BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
+            no_fork: true,
             goal: Some("Optimize throughput".to_string()),
             pause_after_bootstrap: true,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -270,8 +272,10 @@ async fn scenario_bootstrap_fresh() {
         &BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
+            no_fork: true,
             goal: Some("Optimize throughput".to_string()),
             pause_after_bootstrap: true,
+            overrides: NodeOverrides::default(),
         },
     )
     .await
@@ -318,8 +322,10 @@ async fn scenario_bootstrap_idempotent() {
         Commands::Bootstrap(BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
+            no_fork: true,
             goal: None,
             pause_after_bootstrap: true,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -328,8 +334,10 @@ async fn scenario_bootstrap_idempotent() {
         &BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
+            no_fork: true,
             goal: None,
             pause_after_bootstrap: true,
+            overrides: NodeOverrides::default(),
         },
     )
     .await
@@ -383,6 +391,7 @@ async fn scenario_contribute_improved() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -393,6 +402,7 @@ async fn scenario_contribute_improved() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         },
     )
     .await;
@@ -429,6 +439,7 @@ async fn scenario_contribute_no_improvement() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -439,6 +450,7 @@ async fn scenario_contribute_no_improvement() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         },
     )
     .await;
@@ -475,6 +487,7 @@ async fn scenario_contribute_agent_failure() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -485,6 +498,7 @@ async fn scenario_contribute_agent_failure() {
             once: true,
             max_parallel: Some(1),
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         },
     )
     .await;
@@ -589,6 +603,7 @@ async fn scenario_lead_accept_pr() {
         Commands::Lead(LeadArgs {
             once: true,
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -597,6 +612,7 @@ async fn scenario_lead_accept_pr() {
         &LeadArgs {
             once: true,
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         },
     )
     .await;
@@ -708,6 +724,7 @@ async fn scenario_lead_reject_non_improvement() {
         Commands::Lead(LeadArgs {
             once: true,
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         }),
     );
 
@@ -716,6 +733,7 @@ async fn scenario_lead_reject_non_improvement() {
         &LeadArgs {
             once: true,
             sleep_secs: 0,
+            overrides: NodeOverrides::default(),
         },
     )
     .await;


### PR DESCRIPTION
## Summary

- Adds `--capacity`, `--api-budget`, `--request-delay`, and `--agent-command` flags to `contribute`, `lead`, `init`, and `bootstrap` via a shared `NodeOverrides` struct (clap flatten). For `contribute`/`lead` these are pure runtime overrides that do not write to `.polyresearch-node.toml`. For `init`/`bootstrap` they set initial values in the TOML file.
- Bootstrap now auto-forks when the user lacks push access to the target repo (checked via `gh api repos/{owner}/{name} --jq '.permissions.push'`). Adds `--no-fork` to bypass the check and clone directly. The existing `--fork <org>` flag is preserved for explicit org targeting.
- Adds `RepoRef::parse_url()` for URL-based owner/repo extraction used by the auto-fork logic.
- Updates both READMEs with new flag documentation.

Closes #65

## Test plan

- [x] All 194 existing tests pass (118 unit + 65 e2e + 11 scenario)
- [x] New unit tests for `NodeConfig::with_overrides()` (7 tests covering each field independently, all fields together, empty overrides, and normalization)
- [x] New unit tests for `RepoRef::parse_url()` (5 tests covering HTTPS, SSH, `.git` suffix, garbage input, empty parts)
- [x] Existing e2e and scenario tests updated for new struct fields
- [ ] Manual: `polyresearch contribute --capacity 50 --agent-command "echo test"` applies overrides at runtime
- [ ] Manual: `polyresearch bootstrap <url>` auto-forks when user lacks push access
- [ ] Manual: `polyresearch bootstrap <url> --no-fork` clones directly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument parsing and bootstrap clone/fork behavior, and can alter GitHub throttling at runtime; mistakes could break bootstrapping or cause unexpected API usage, but the surface area is limited and covered by tests.
> 
> **Overview**
> Adds a shared set of CLI flags (via `NodeOverrides`) to override node settings (`--capacity`, `--api-budget`, `--request-delay`, `--agent-command`) across `init`, `bootstrap`, `lead`, and `contribute`. `init`/`bootstrap` persist these values into `.polyresearch-node.toml`, while `lead`/`contribute` apply them at runtime (including request throttling and API budget) without modifying the file.
> 
> Updates `bootstrap` to **auto-fork** when the caller lacks push access to the upstream repo (via `gh api ... .permissions.push`), adds `--no-fork` to force a direct clone, and introduces `RepoRef::parse_url()` to reliably extract `owner/repo` from GitHub URLs. Docs and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491144e163e7f5f2e486bf73139c8cd3e8ab0ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->