### PR TITLE
Extract prompts from inline Rust strings into cli/prompts/

### DIFF
--- a/cli/prompts/bootstrap-setup.md
+++ b/cli/prompts/bootstrap-setup.md
@@ -1,0 +1,7 @@
+Read the repository to understand its source layout, test suite, and build system. Then read PROGRAM.md and PREPARE.md and fill in the project-specific details.
+
+In PROGRAM.md: set lead_github_login and maintainer_github_login. Update the CAN/CANNOT modify globs to match reality — the editable surface should be the source code, the protected surface should include the evaluation and configuration. Write a concrete, measurable goal (not generic placeholder text).
+
+In PREPARE.md: write a real benchmark command that produces a parseable METRIC=<number> line. Fill in the setup steps so a fresh machine can reproduce the evaluation.
+
+Do NOT create or modify any source code files.

--- a/cli/prompts/experiment.md
+++ b/cli/prompts/experiment.md
@@ -1,0 +1,7 @@
+Read PROGRAM.md for constraints and strategy. Read PREPARE.md for evaluation setup. Read .polyresearch/thesis.md for the thesis and prior attempt history — understand what has already been tried so you do not repeat it.
+
+Implement the thesis idea. Favor changes that simplify the code. A small improvement that adds ugly complexity is not worth keeping.
+
+Run the evaluation as defined in PREPARE.md. If the run crashes, use judgment: fix trivial bugs (typos, missing imports) and re-run. If the idea is fundamentally broken, skip it.
+
+Write your result to .polyresearch/result.json with fields: metric (f64), baseline (f64), observation (improved|no_improvement|crashed|infra_failure), summary (string).

--- a/cli/prompts/template-prepare.md
+++ b/cli/prompts/template-prepare.md
@@ -1,0 +1,31 @@
+# Evaluation Setup
+
+This file is outside the editable surface. It defines how results are judged. Agents cannot modify the evaluator or the scoring logic — the evaluation is the trust boundary.
+
+Consider defining more than one evaluation criterion. Optimizing for a single number makes it easy to overfit and silently break other things. A secondary metric or sanity check helps keep the process honest.
+
+eval_cores: 1
+eval_memory_gb: 1.0
+
+## Setup
+
+Install dependencies and prepare the evaluation environment.
+
+## Run command
+
+```bash
+# Replace with actual benchmark command
+echo "METRIC=0.0"
+```
+
+## Output format
+
+The benchmark must print `METRIC=<number>` to stdout.
+
+## Metric parsing
+
+The CLI looks for `METRIC=<number>` or `ops_per_sec=<number>` in the output.
+
+## Ground truth
+
+Describe what the baseline metric represents and how it was measured.

--- a/cli/prompts/template-program.md
+++ b/cli/prompts/template-program.md
@@ -1,0 +1,44 @@
+# Research Program
+
+cli_version: 0.5.0
+lead_github_login: replace-me
+maintainer_github_login: replace-me
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+required_confirmations: 0
+auto_approve: true
+min_queue_depth: 5
+assignment_timeout: 24h
+
+## Goal
+
+Improve the target metric through systematic experimentation.
+
+## What you CAN modify
+
+- `src/` — source code
+
+## What you CANNOT modify
+
+- `PROGRAM.md` — research program specification
+- `PREPARE.md` — evaluation setup and trust boundary
+- `.polyresearch/` — runtime directory
+- Any file that defines the evaluation harness or scoring logic
+
+## Constraints
+
+- All changes must pass the evaluation harness defined in PREPARE.md.
+- Each experiment should be atomic and independently verifiable.
+- All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth keeping. Removing code and getting equal or better results is a great outcome.
+- If a run crashes, use judgment: fix trivial bugs (typos, missing imports) and re-run. If the idea is fundamentally broken, skip it and move on.
+- Document what you tried and what you observed in the attempt summary.
+
+## Strategy hints
+
+- Read the full codebase before your first experiment. Understand what you are working with.
+- Start with the lowest-hanging fruit.
+- Measure before and after every change.
+- Read results.tsv to learn from history. Do not repeat approaches that already failed.
+- If an approach does not show improvement after reasonable effort, release and move on.
+- Try combining ideas from previous near-misses.
+- If you are stuck, try something more radical. Re-read the source for new angles.

--- a/cli/prompts/thesis-generation.md
+++ b/cli/prompts/thesis-generation.md
@@ -1,0 +1,7 @@
+Read PROGRAM.md to understand the goal and constraints. Study results.tsv to see what has been tried, what improved, and what failed.
+
+Generate thesis proposals as a JSON array of objects with "title" and "body" fields. Write the array to .polyresearch/thesis-proposals.json.
+
+Each thesis should be specific and actionable, not a vague direction. Do not propose ideas that echo approaches already marked as no_improvement or crashed — the full history exists to prevent repeating dead ends. Favor ideas that build on successful experiments or combine near-misses. Prefer ideas that simplify the code over ideas that add complexity.
+
+Explore different directions. If progress has stalled, propose something more radical.

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -203,21 +203,12 @@ pub fn write_thesis_context(
 }
 
 pub fn experiment_prompt() -> &'static str {
-    "Read PROGRAM.md for the experiment loop and constraints. \
-     Read PREPARE.md for evaluation setup. \
-     Read .polyresearch/thesis.md for the thesis context and prior attempt history. \
-     Run the experiment, then write your result to .polyresearch/result.json with fields: \
-     metric (f64), baseline (f64), observation (improved|no_improvement|crashed|infra_failure), \
-     summary (string)."
+    include_str!("../prompts/experiment.md")
 }
 
 pub fn thesis_generation_prompt(count: usize) -> String {
-    format!(
-        "Read PROGRAM.md and results.tsv to understand the current research state. \
-         Generate exactly {count} thesis proposals as a JSON array of objects with \
-         \"title\" and \"body\" fields. Write the array to .polyresearch/thesis-proposals.json. \
-         Each thesis should be specific, actionable, and explore a different direction."
-    )
+    let base = include_str!("../prompts/thesis-generation.md");
+    format!("{base}\n\nGenerate exactly {count} thesis proposals.")
 }
 
 struct HarnessSpec {

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -186,46 +186,15 @@ fn clone_if_needed(url: &str, repo_root: &Path) -> Result<()> {
 pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
     let program_path = repo_root.join("PROGRAM.md");
     if !program_path.exists() {
-        let goal_text = goal.unwrap_or("Improve the target metric through systematic experimentation.");
-        let template = format!(
-r#"# Research Program
-
-cli_version: 0.5.0
-lead_github_login: replace-me
-maintainer_github_login: replace-me
-metric_tolerance: 0.01
-metric_direction: higher_is_better
-required_confirmations: 0
-auto_approve: true
-min_queue_depth: 5
-assignment_timeout: 24h
-
-## Goal
-
-{goal_text}
-
-## What you CAN modify
-
-- `src/` — source code
-
-## What you CANNOT modify
-
-- `PROGRAM.md` — research program specification
-- `PREPARE.md` — evaluation setup
-- `.polyresearch/` — runtime directory
-
-## Constraints
-
-- All changes must pass the evaluation harness defined in PREPARE.md
-- Each experiment should be atomic and independently verifiable
-- Document your approach in the attempt summary
-
-## Strategy hints
-
-- Start with the lowest-hanging fruit
-- Measure before and after every change
-- If an approach doesn't show improvement after reasonable effort, release and move on
-"#);
+        let base = include_str!("../../prompts/template-program.md");
+        let template = if let Some(goal) = goal {
+            base.replace(
+                "Improve the target metric through systematic experimentation.",
+                goal,
+            )
+        } else {
+            base.to_string()
+        };
         fs::write(&program_path, template)
             .wrap_err_with(|| format!("failed to write {}", program_path.display()))?;
         eprintln!("Created {}", program_path.display());
@@ -233,34 +202,7 @@ assignment_timeout: 24h
 
     let prepare_path = repo_root.join("PREPARE.md");
     if !prepare_path.exists() {
-        let template = r#"# Evaluation Setup
-
-eval_cores: 1
-eval_memory_gb: 1.0
-
-## Setup
-
-Install dependencies and prepare the evaluation environment.
-
-## Run command
-
-```bash
-# Replace with actual benchmark command
-echo "METRIC=0.0"
-```
-
-## Output format
-
-The benchmark must print `METRIC=<number>` to stdout.
-
-## Metric parsing
-
-The CLI looks for `METRIC=<number>` or `ops_per_sec=<number>` in the output.
-
-## Ground truth
-
-Describe what the baseline metric represents and how it was measured.
-"#;
+        let template = include_str!("../../prompts/template-prepare.md");
         fs::write(&prepare_path, template)
             .wrap_err_with(|| format!("failed to write {}", prepare_path.display()))?;
         eprintln!("Created {}", prepare_path.display());
@@ -309,11 +251,7 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides) ->
                 .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string())
         });
 
-    let prompt = "Read PROGRAM.md and PREPARE.md. Fill in the project-specific details: \
-        set lead_github_login and maintainer_github_login to appropriate values, \
-        update the editable surface globs to match this project's source code layout, \
-        update PREPARE.md with the actual benchmark command and setup steps. \
-        Do NOT create or modify any source code files.";
+    let prompt = include_str!("../../prompts/bootstrap-setup.md");
 
     eprintln!("Spawning agent for initial setup...");
     let _ = crate::agent::spawn_experiment(&agent_command, repo_root, prompt);

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -188,10 +188,7 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
     if !program_path.exists() {
         let base = include_str!("../../prompts/template-program.md");
         let template = if let Some(goal) = goal {
-            base.replace(
-                "Improve the target metric through systematic experimentation.",
-                goal,
-            )
+            replace_goal_section(base, goal)
         } else {
             base.to_string()
         };
@@ -222,6 +219,19 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn replace_goal_section(template: &str, goal: &str) -> String {
+    const HEADER: &str = "## Goal\n";
+    let Some(start) = template.find(HEADER) else {
+        return template.to_string();
+    };
+    let body_start = start + HEADER.len();
+    let body_end = template[body_start..]
+        .find("\n## ")
+        .map(|i| body_start + i)
+        .unwrap_or(template.len());
+    format!("{}\n{}\n{}", &template[..body_start], goal, &template[body_end..])
 }
 
 fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {


### PR DESCRIPTION
## Summary

- Moves all hardcoded agent prompts and document templates out of inline Rust strings into separate `.md` files under `cli/prompts/`, embedded at compile time via `include_str!`. Prompts are now editable without touching Rust code.
- Enriches prompt content with quality principles from autoresearch: simplicity criterion, history awareness, trust boundary framing, crash judgment, multi-criteria evaluation guidance.
- Runtime values (thesis count, goal text) are appended programmatically so prompt files contain zero special syntax that users could accidentally break.

## Test plan

- [x] `cargo check` passes
- [x] All 198 tests pass (122 unit + 65 e2e + 11 scenario)
- [x] Function signatures unchanged — no call site modifications needed
- [x] Binary distribution unchanged — still a single compiled binary via `include_str!`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactors prompt/template text plumbing; behavior changes are limited to slightly different prompt content and template goal replacement logic.
> 
> **Overview**
> Moves bootstrap/program/prepare templates and agent prompts out of inline Rust strings into new `cli/prompts/*.md` files and embeds them via `include_str!`, centralizing prompt content and making it easier to update.
> 
> Updates `write_templates`, bootstrap setup spawning, and thesis/experiment prompt generation to use these embedded files; adds `replace_goal_section` to safely inject a CLI-provided goal into the `PROGRAM.md` template while keeping prompt files syntax-free.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aa2ccfb39179425a6f5608c60c2bce2dd7b4eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->