### PR TITLE
Use --dangerously-skip-permissions and derive cli_version from Cargo.toml

### DIFF
--- a/cli/prompts/template-program.md
+++ b/cli/prompts/template-program.md
@@ -1,6 +1,6 @@
 # Research Program
 
-cli_version: 0.5.1
+cli_version: {{VERSION}}
 lead_github_login: replace-me
 maintainer_github_login: replace-me
 metric_tolerance: 0.01

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -409,8 +409,8 @@ mod tests {
     #[test]
     fn shell_words_splits_simple_command() {
         assert_eq!(
-            shell_words("claude -p --permission-mode bypassPermissions"),
-            vec!["claude", "-p", "--permission-mode", "bypassPermissions"]
+            shell_words("claude -p --dangerously-skip-permissions"),
+            vec!["claude", "-p", "--dangerously-skip-permissions"]
         );
     }
 

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -187,10 +187,11 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
     let program_path = repo_root.join("PROGRAM.md");
     if !program_path.exists() {
         let base = include_str!("../../prompts/template-program.md");
+        let versioned = base.replace("{{VERSION}}", env!("CARGO_PKG_VERSION"));
         let template = if let Some(goal) = goal {
-            replace_goal_section(base, goal)
+            replace_goal_section(&versioned, goal)
         } else {
-            base.to_string()
+            versioned
         };
         fs::write(&program_path, template)
             .wrap_err_with(|| format!("failed to write {}", program_path.display()))?;
@@ -258,7 +259,7 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides) ->
             overrides
                 .agent_command
                 .clone()
-                .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string())
+                .unwrap_or_else(|| "claude -p --dangerously-skip-permissions".to_string())
         });
 
     let prompt = include_str!("../../prompts/bootstrap-setup.md");

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -27,7 +27,7 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
             args.overrides
                 .agent_command
                 .clone()
-                .unwrap_or_else(|| "claude -p --permission-mode bypassPermissions".to_string())
+                .unwrap_or_else(|| "claude -p --dangerously-skip-permissions".to_string())
         });
 
     eprintln!("Running lead loop as `{login}`");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -29,7 +29,7 @@ pub struct AgentConfig {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            command: "claude -p --permission-mode bypassPermissions".to_string(),
+            command: "claude -p --dangerously-skip-permissions".to_string(),
         }
     }
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1825,9 +1825,10 @@ async fn policy_check_rejects_stale_ledger() {
 fn write_program_md(path: &PathBuf) {
     fs::write(
         path.join("PROGRAM.md"),
-        r#"# Research Program
+        format!(
+            r#"# Research Program
 
-cli_version: 0.5.0
+cli_version: {}
 lead_github_login: lead
 maintainer_github_login: maintainer
 metric_tolerance: 0.01
@@ -1846,6 +1847,8 @@ Test goal.
 
 - `PREPARE.md`
 "#,
+            env!("CARGO_PKG_VERSION")
+        ),
     )
     .unwrap();
 }
@@ -1880,7 +1883,7 @@ async fn bootstrap_writes_templates_when_missing() {
     assert!(results_path.exists());
 
     let program = fs::read_to_string(&program_path).unwrap();
-    assert!(program.contains("cli_version: 0.5.0"));
+    assert!(program.contains(&format!("cli_version: {}", env!("CARGO_PKG_VERSION"))));
     assert!(program.contains("Optimize latency"));
     assert!(program.contains("## Goal"));
     assert!(program.contains("## What you CAN modify"));
@@ -2355,9 +2358,10 @@ async fn contribute_uses_real_config_not_default() {
 
     fs::write(
         repo.path.join("PROGRAM.md"),
-        r#"# Research Program
+        format!(
+            r#"# Research Program
 
-cli_version: 0.5.0
+cli_version: {}
 lead_github_login: actual-lead
 maintainer_github_login: actual-maintainer
 metric_tolerance: 0.01
@@ -2376,6 +2380,8 @@ Test.
 
 - `PREPARE.md`
 "#,
+            env!("CARGO_PKG_VERSION")
+        ),
     )
     .unwrap();
 

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -56,7 +56,7 @@ impl ScenarioRepo {
             format!(
                 r#"# Research Program
 
-cli_version: 0.5.0
+cli_version: {version}
 lead_github_login: {lead}
 maintainer_github_login: {lead}
 metric_tolerance: 0.01
@@ -78,7 +78,8 @@ Test scenario goal.
 
 - `PREPARE.md`
 - `docs/`
-"#
+"#,
+                version = env!("CARGO_PKG_VERSION")
             ),
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- Replace `--permission-mode bypassPermissions` with the equivalent `--dangerously-skip-permissions` flag in all default agent command strings (config.rs, bootstrap.rs, lead.rs, agent.rs test).
- Replace hardcoded `cli_version` strings in the PROGRAM.md template and all test fixtures with `env!("CARGO_PKG_VERSION")` so that `Cargo.toml` is the single source of truth for the version. No test or template edits needed on version bumps.

## Test plan

- [x] `cargo test` -- all 198 tests pass (122 unit + 65 e2e + 11 scenarios)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to default command strings and template/test version stamping; the main potential issue is if downstream environments rely on the old agent flag name.
> 
> **Overview**
> Updates the default agent launch command across the CLI to use `claude -p --dangerously-skip-permissions` instead of the deprecated `--permission-mode bypassPermissions` (including related parsing tests).
> 
> Makes `PROGRAM.md` generation and test fixtures derive `cli_version` from `env!("CARGO_PKG_VERSION")` by templating `cli/prompts/template-program.md` with `{{VERSION}}` and replacing it at bootstrap time, eliminating hardcoded version bumps in templates/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e99eadfd688651f203901c9030c9cc4ac5d1fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->