### PR TITLE
Support owner/repo shorthand in bootstrap and contribute

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -203,6 +203,7 @@ pub struct AdminReopenThesisArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct BootstrapArgs {
+    #[arg(help = "GitHub repo (owner/repo or full URL)")]
     pub url: String,
 
     #[arg(long)]
@@ -235,6 +236,7 @@ pub struct LeadArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct ContributeArgs {
+    #[arg(help = "GitHub repo (owner/repo or full URL)")]
     pub url: Option<String>,
 
     #[arg(long)]

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -10,22 +10,23 @@ use crate::config::NodeConfig;
 use crate::github::RepoRef;
 
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
-    eprintln!("Bootstrapping polyresearch project from {}", args.url);
+    let upstream = RepoRef::from_user_input(&args.url)?;
+    let clone_url = upstream.clone_url();
+    eprintln!("Bootstrapping polyresearch project from {}", upstream.slug());
 
     let repo_root = if ctx.repo_root.join(".git").exists() {
         ctx.repo_root.clone()
     } else {
-        let name = repo_name_from_url(&args.url);
-        ctx.repo_root.join(name)
+        ctx.repo_root.join(&upstream.name)
     };
 
     // Step 1: Clone or fork-then-clone
     if args.no_fork {
-        clone_if_needed(&args.url, &repo_root)?;
+        clone_if_needed(&clone_url, &repo_root)?;
     } else if let Some(fork_owner) = &args.fork {
-        fork_and_clone(&args.url, fork_owner, &repo_root)?;
+        fork_and_clone(&upstream, fork_owner, &repo_root)?;
     } else {
-        auto_clone_or_fork(&args.url, &repo_root)?;
+        auto_clone_or_fork(&upstream, &repo_root)?;
     }
 
     // Step 2: Write templates
@@ -48,35 +49,23 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn repo_name_from_url(url: &str) -> String {
-    url.trim_end_matches('/')
-        .rsplit('/')
-        .next()
-        .unwrap_or("repo")
-        .trim_end_matches(".git")
-        .to_string()
-}
-
-fn auto_clone_or_fork(url: &str, repo_root: &Path) -> Result<()> {
+fn auto_clone_or_fork(upstream: &RepoRef, repo_root: &Path) -> Result<()> {
     if repo_root.join(".git").exists() {
         eprintln!("Repository already exists at {}", repo_root.display());
         let _ = commands::run_git(&repo_root.to_path_buf(), &["fetch", "origin"]);
         return Ok(());
     }
 
-    let upstream = RepoRef::parse_url(url)
-        .ok_or_else(|| eyre!("could not parse GitHub owner/repo from URL: {url}"))?;
-
     if has_push_access(&upstream.owner, &upstream.name) {
         eprintln!("Push access confirmed, cloning directly.");
-        clone_if_needed(url, repo_root)
+        clone_if_needed(&upstream.clone_url(), repo_root)
     } else {
         let login = get_current_login()?;
         eprintln!(
             "No push access to {}/{}, forking to {login}...",
             upstream.owner, upstream.name
         );
-        fork_and_clone(url, &login, repo_root)
+        fork_and_clone(upstream, &login, repo_root)
     }
 }
 
@@ -113,14 +102,15 @@ fn get_current_login() -> Result<String> {
     Ok(login)
 }
 
-fn fork_and_clone(url: &str, fork_owner: &str, repo_root: &Path) -> Result<()> {
+fn fork_and_clone(upstream: &RepoRef, fork_owner: &str, repo_root: &Path) -> Result<()> {
     if repo_root.join(".git").exists() {
         eprintln!("Repository already exists, skipping clone.");
         return Ok(());
     }
 
-    eprintln!("Forking {url} to {fork_owner}...");
-    let mut args = vec!["repo", "fork", url, "--clone=false"];
+    let slug = upstream.slug();
+    eprintln!("Forking {slug} to {fork_owner}...");
+    let mut args = vec!["repo", "fork", slug.as_str(), "--clone=false"];
 
     let current_user = Command::new("gh")
         .args(["api", "user", "--jq", ".login"])
@@ -147,13 +137,13 @@ fn fork_and_clone(url: &str, fork_owner: &str, repo_root: &Path) -> Result<()> {
         }
     }
 
-    let name = repo_name_from_url(url);
-    let fork_url = format!("https://github.com/{fork_owner}/{name}.git");
+    let fork_url = format!("https://github.com/{fork_owner}/{}.git", upstream.name);
     clone_if_needed(&fork_url, repo_root)?;
 
+    let upstream_url = upstream.clone_url();
     commands::run_git(
         &repo_root.to_path_buf(),
-        &["remote", "add", "upstream", url],
+        &["remote", "add", "upstream", &upstream_url],
     )
     .ok();
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -15,13 +15,13 @@ use crate::worker::{self, ThesisWorker, WorkerContext, WorkerOutcome};
 
 pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
     let ctx = if let Some(url) = &args.url {
+        let upstream = RepoRef::from_user_input(url)?;
         let repo_root = if ctx.repo_root.join(".git").exists() {
             ctx.repo_root.clone()
         } else {
-            let name = super::bootstrap::repo_name_from_url(url);
-            ctx.repo_root.join(name)
+            ctx.repo_root.join(&upstream.name)
         };
-        clone_repo(url, &repo_root)?;
+        clone_repo(&upstream.clone_url(), &repo_root)?;
         std::borrow::Cow::Owned(AppContext {
             repo_root,
             ..ctx.clone()

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -81,12 +81,30 @@ impl RepoRef {
     pub fn slug(&self) -> String {
         format!("{}/{}", self.owner, self.name)
     }
+
+    /// Accepts either a full GitHub URL or bare `owner/repo` shorthand.
+    pub fn from_user_input(input: &str) -> Result<Self> {
+        if let Some(repo) = Self::parse_url(input) {
+            return Ok(repo);
+        }
+        let trimmed = input.trim();
+        if trimmed.contains("://") || trimmed.starts_with("git@") {
+            return Err(eyre!("not a recognized GitHub URL: {input}"));
+        }
+        Self::parse(trimmed)
+    }
+
+    pub fn clone_url(&self) -> String {
+        format!("https://github.com/{}/{}.git", self.owner, self.name)
+    }
 }
 
 fn strip_github_prefix(url: &str) -> Option<&str> {
     let trimmed = url.trim().trim_end_matches(".git");
     const PREFIXES: &[&str] = &[
+        "https://www.github.com/",
         "https://github.com/",
+        "http://www.github.com/",
         "http://github.com/",
         "git@github.com:",
     ];
@@ -1087,5 +1105,67 @@ mod tests {
     fn parse_url_rejects_owner_only() {
         assert!(RepoRef::parse_url("https://github.com/owner").is_none());
         assert!(RepoRef::parse_url("https://github.com/owner/").is_none());
+    }
+
+    #[test]
+    fn parse_url_handles_www_github() {
+        let r = RepoRef::parse_url("https://www.github.com/owner/repo").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn parse_url_handles_http_www_github() {
+        let r = RepoRef::parse_url("http://www.github.com/owner/repo.git").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn from_user_input_accepts_shorthand() {
+        let r = RepoRef::from_user_input("alanzabihi/dotenv").unwrap();
+        assert_eq!(r.owner, "alanzabihi");
+        assert_eq!(r.name, "dotenv");
+    }
+
+    #[test]
+    fn from_user_input_accepts_https_url() {
+        let r = RepoRef::from_user_input("https://github.com/owner/repo").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn from_user_input_accepts_www_url() {
+        let r = RepoRef::from_user_input("https://www.github.com/owner/repo").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn from_user_input_accepts_ssh_url() {
+        let r = RepoRef::from_user_input("git@github.com:owner/repo.git").unwrap();
+        assert_eq!(r.owner, "owner");
+        assert_eq!(r.name, "repo");
+    }
+
+    #[test]
+    fn from_user_input_rejects_bare_owner() {
+        assert!(RepoRef::from_user_input("owner").is_err());
+    }
+
+    #[test]
+    fn from_user_input_rejects_non_github_urls() {
+        assert!(RepoRef::from_user_input("https://gitlab.com/owner/repo").is_err());
+        assert!(RepoRef::from_user_input("https://bitbucket.org/owner/repo").is_err());
+    }
+
+    #[test]
+    fn clone_url_produces_https() {
+        let r = RepoRef {
+            owner: "alanzabihi".to_string(),
+            name: "dotenv".to_string(),
+        };
+        assert_eq!(r.clone_url(), "https://github.com/alanzabihi/dotenv.git");
     }
 }

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -53,6 +53,9 @@ impl RepoRef {
         let (owner, name) = value
             .split_once('/')
             .ok_or_else(|| eyre!("expected repo in `owner/name` format"))?;
+        if owner.is_empty() || name.is_empty() || name.contains('/') {
+            return Err(eyre!("expected repo in `owner/name` format, got `{value}`"));
+        }
         Ok(Self {
             owner: owner.to_string(),
             name: name.to_string(),
@@ -1152,6 +1155,24 @@ mod tests {
     #[test]
     fn from_user_input_rejects_bare_owner() {
         assert!(RepoRef::from_user_input("owner").is_err());
+    }
+
+    #[test]
+    fn from_user_input_rejects_extra_path_segments() {
+        assert!(RepoRef::from_user_input("owner/repo/tree/main").is_err());
+        assert!(RepoRef::from_user_input("owner/repo/pulls").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_extra_path_segments() {
+        assert!(RepoRef::parse("owner/repo/extra").is_err());
+        assert!(RepoRef::parse("owner/repo/tree/main").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_empty_parts() {
+        assert!(RepoRef::parse("/name").is_err());
+        assert!(RepoRef::parse("owner/").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `RepoRef::from_user_input()` accepting both `owner/repo` shorthand and full GitHub URLs (including `www.github.com`)
- Adds `RepoRef::clone_url()` to derive HTTPS clone URLs from a parsed repo reference
- Refactors `bootstrap` and `contribute` to parse input early into a `RepoRef`, removing the raw URL string threading and the now-dead `repo_name_from_url` helper
- Non-GitHub URLs (gitlab, bitbucket, etc.) are rejected with a clear error message

## Test plan

- [x] All 8 new unit tests pass (`from_user_input` variants, `clone_url`, `www.github.com`)
- [x] All 11 existing `parse_url` tests still pass (no regressions)
- [x] Clean build with zero warnings
- [ ] Manual: `polyresearch contribute alanzabihi/dotenv` clones and runs
- [ ] Manual: `polyresearch bootstrap owner/repo` works the same as the full URL form

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the clone/fork path in `bootstrap`/`contribute` and changes repo parsing/normalization, which could break existing edge-case inputs despite added tests.
> 
> **Overview**
> Adds support for specifying repositories as `owner/repo` shorthand (in addition to full GitHub URLs) for `bootstrap` and `contribute`, and updates CLI help text accordingly.
> 
> Refactors these commands to parse input once into a `RepoRef`, consistently derive HTTPS clone URLs via new `RepoRef::clone_url()`, and removes the URL-derived repo-name helper; parsing is tightened to reject malformed shorthand/non-GitHub URLs while accepting `www.github.com` variants, with expanded unit test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae70d16e2f0f1ec2af6c51791029db0591025e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->