### PR TITLE
Add interactive confirmation gate to bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ polyresearch bootstrap https://github.com/owner/repo
 
 Use `--goal` to tell the agent what you're optimizing for -- it pre-fills the Goal section of `PROGRAM.md`. Bootstrap checks whether you have push access; if not, it forks to your GitHub account automatically. See the [full flag list](cli/README.md#command-summary) for `--fork`, `--no-fork`, and other options.
 
-This writes template files, initializes your machine as a node, and spawns an agent to fill in project-specific details. When it finishes you'll have:
+This writes template files, initializes your machine as a node, and pauses for you to review before spawning the bootstrap agent. When it finishes you'll have:
 
 - `**PROGRAM.md**` -- the research playbook. Describes the goal, which files agents can edit, strategy hints. This is the only file agents read.
 - `**PREPARE.md**` -- the evaluation setup. Benchmark command, metric parsing, ground truth. Lives outside the editable surface so agents can't change how they're judged.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -421,6 +421,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +690,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +859,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -2060,6 +2096,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "crossterm",
+ "dialoguer",
  "globset",
  "octocrab",
  "rand 0.10.1",
@@ -2661,6 +2698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +2923,19 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env"] }
 color-eyre = "0.6.5"
 crossterm = "0.29.0"
+dialoguer = "0.12.0"
 globset = "0.4.18"
 octocrab = "0.49.7"
 rand = "0.10.1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -83,9 +83,10 @@ Bootstrap a new project:
 polyresearch bootstrap https://github.com/owner/repo
 polyresearch bootstrap https://github.com/owner/repo --fork myorg
 polyresearch bootstrap https://github.com/owner/repo --no-fork
+polyresearch bootstrap https://github.com/owner/repo --yes   # skip confirmation, spawn agent immediately
 ```
 
-Bootstrap auto-forks when you lack push access to the target repo. Use `--fork <org>` to fork to a specific organization, or `--no-fork` to clone directly.
+Bootstrap auto-forks when you lack push access to the target repo. Use `--fork <org>` to fork to a specific organization, or `--no-fork` to clone directly. After writing templates and initializing the node, bootstrap pauses so you can review `PROGRAM.md`, `PREPARE.md`, and `.polyresearch-node.toml` before spawning the bootstrap agent. Pass `--yes` (`-y`) to skip the confirmation.
 
 Run the lead loop:
 
@@ -244,7 +245,7 @@ Several flags accept a fixed set of values.
 
 #### `bootstrap`
 
-Auto-fork, write templates, init node, and spawn the setup agent.
+Auto-fork, write templates, init node, confirm, then spawn the bootstrap agent.
 
 Usage: `polyresearch bootstrap <url> [flags]`
 
@@ -253,7 +254,7 @@ Usage: `polyresearch bootstrap <url> [flags]`
 | `--fork <org>` | string | — | Fork to a specific organization |
 | `--no-fork` | bool | `false` | Clone directly without forking (conflicts with `--fork`) |
 | `--goal <text>` | string | — | Initial research goal |
-| `--pause-after-bootstrap` | bool | `false` | Exit after setup instead of starting the loop |
+| `--yes`, `-y` | bool | `false` | Skip confirmation and spawn the bootstrap agent immediately |
 
 Also accepts [node overrides](#node-overrides).
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -220,8 +220,8 @@ pub struct BootstrapArgs {
     #[arg(long)]
     pub goal: Option<String>,
 
-    #[arg(long)]
-    pub pause_after_bootstrap: bool,
+    #[arg(long, short = 'y')]
+    pub yes: bool,
 
     #[command(flatten)]
     pub overrides: NodeOverrides,

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -10,6 +10,48 @@ use crate::config::NodeConfig;
 use crate::github::RepoRef;
 
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
+    let repo_root = scaffold(ctx, args)?;
+
+    if !args.yes {
+        use std::io::IsTerminal;
+        if std::io::stdin().is_terminal() {
+            eprintln!("\nReview your project before continuing:");
+            eprintln!("  \u{2192} PROGRAM.md");
+            eprintln!("  \u{2192} PREPARE.md");
+            eprintln!("  \u{2192} .polyresearch-node.toml\n");
+
+            let confirmed = dialoguer::Confirm::new()
+                .with_prompt("Spawn bootstrap agent?")
+                .default(true)
+                .interact_opt()
+                .map_err(|e| eyre!("prompt failed: {e}"))?;
+
+            if confirmed != Some(true) {
+                eprintln!("Aborted. To spawn the agent later, re-run:");
+                eprintln!("  polyresearch bootstrap {} --yes", args.url);
+                return Ok(());
+            }
+        } else {
+            return Err(eyre!(
+                "non-interactive terminal; pass --yes to spawn the bootstrap agent"
+            ));
+        }
+    }
+
+    spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose)?;
+
+    // Post-agent cleanup: re-normalize in case the agent mangled required sections,
+    // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
+    normalize_program_md(&repo_root)?;
+    commit_and_push_setup_files(&repo_root)?;
+
+    eprintln!("Bootstrap complete.");
+    Ok(())
+}
+
+/// Clone/fork, write templates, initialize node config, and normalize PROGRAM.md.
+/// Does not spawn any agents or require interactive input.
+pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<std::path::PathBuf> {
     let upstream = RepoRef::from_user_input(&args.url)?;
     let clone_url = upstream.clone_url();
     eprintln!("Bootstrapping polyresearch project from {}", upstream.slug());
@@ -20,7 +62,6 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         ctx.repo_root.join(&upstream.name)
     };
 
-    // Step 1: Clone or fork-then-clone
     if args.no_fork {
         clone_if_needed(&clone_url, &repo_root)?;
     } else if let Some(fork_owner) = &args.fork {
@@ -29,27 +70,11 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         auto_clone_or_fork(&upstream, &repo_root)?;
     }
 
-    // Step 2: Write templates
     write_templates(&repo_root, args.goal.as_deref())?;
-
-    // Step 3: Initialize node config (with any CLI overrides)
     initialize_node(&repo_root, &args.overrides)?;
-
-    // Step 4: Spawn agent for project-specific setup
-    if !args.pause_after_bootstrap {
-        spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose)?;
-    } else {
-        eprintln!("Pausing after bootstrap. Edit PROGRAM.md and PREPARE.md manually.");
-    }
-
-    // Step 5: Normalize PROGRAM.md
     normalize_program_md(&repo_root)?;
 
-    // Step 6: Commit and push setup files
-    commit_and_push_setup_files(&repo_root)?;
-
-    eprintln!("Bootstrap complete.");
-    Ok(())
+    Ok(repo_root)
 }
 
 fn auto_clone_or_fork(upstream: &RepoRef, repo_root: &Path) -> Result<()> {

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -264,23 +264,22 @@ async fn scenario_bootstrap_fresh() {
             fork: None,
             no_fork: true,
             goal: Some("Optimize throughput".to_string()),
-            pause_after_bootstrap: true,
+            yes: false,
             overrides: NodeOverrides::default(),
         }),
     );
 
-    commands::bootstrap::run(
+    commands::bootstrap::scaffold(
         &ctx,
         &BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
             no_fork: true,
             goal: Some("Optimize throughput".to_string()),
-            pause_after_bootstrap: true,
+            yes: false,
             overrides: NodeOverrides::default(),
         },
     )
-    .await
     .unwrap();
 
     assert!(repo.path.join("PROGRAM.md").exists(), "PROGRAM.md created");
@@ -326,23 +325,22 @@ async fn scenario_bootstrap_idempotent() {
             fork: None,
             no_fork: true,
             goal: None,
-            pause_after_bootstrap: true,
+            yes: false,
             overrides: NodeOverrides::default(),
         }),
     );
 
-    commands::bootstrap::run(
+    commands::bootstrap::scaffold(
         &ctx,
         &BootstrapArgs {
             url: "https://github.com/test/repo".to_string(),
             fork: None,
             no_fork: true,
             goal: None,
-            pause_after_bootstrap: true,
+            yes: false,
             overrides: NodeOverrides::default(),
         },
     )
-    .await
     .unwrap();
 
     let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();


### PR DESCRIPTION
## Summary

- Replace `--pause-after-bootstrap` with a `--yes` / `-y` flag that inverts the default: bootstrap now pauses for the user to review `PROGRAM.md`, `PREPARE.md`, and `.polyresearch-node.toml` before spawning the bootstrap agent.
- Interactive terminals get a `dialoguer::Confirm` prompt ("Spawn bootstrap agent? [Y/n]"). Non-interactive terminals (CI, piped stdin) exit with a message to pass `--yes`.
- Move `normalize_program_md` before the confirmation gate so it always runs regardless of user response.

## Test plan

- [x] All 198 existing tests pass (`cargo test` — 122 unit, 65 e2e, 11 scenario)
- [ ] Manual: run `polyresearch bootstrap <url>` in an interactive terminal and verify the prompt appears
- [ ] Manual: press Enter to confirm, verify agent spawns
- [ ] Manual: press `n` or Ctrl+C, verify clean abort message
- [ ] Manual: run with `--yes` / `-y`, verify prompt is skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the default `bootstrap` workflow and introduces new behavior in non-interactive environments (now errors unless `--yes` is provided).
> 
> **Overview**
> `bootstrap` now *defaults to pausing for human review* and asks for an interactive confirmation before spawning the bootstrap agent; `--yes` (`-y`) skips the prompt and runs immediately, while non-interactive stdin now fails fast with guidance to pass `--yes`.
> 
> The bootstrapping flow is refactored to separate a new non-interactive `scaffold()` (clone/fork, write templates, init node, normalize `PROGRAM.md`) from the agent-spawn + post-agent normalize/commit+push steps, and docs/tests are updated accordingly. A new `dialoguer` dependency is added for the confirmation prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5684921afdc430e16ad9a8fa9580362eb36c4654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->