### PR TITLE
Improve error messages when CLI commands fail

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.0", features = ["derive", "env"] }
 color-eyre = "0.6.5"
 crossterm = "0.29.0"
 globset = "0.4.18"

--- a/cli/README.md
+++ b/cli/README.md
@@ -137,6 +137,13 @@ polyresearch status --json
 polyresearch status --tui
 ```
 
+Debug agent subprocess failures by showing the full command line and working directory:
+
+```bash
+polyresearch --verbose contribute --once
+POLYRESEARCH_VERBOSE=1 polyresearch lead --once
+```
+
 Debug GitHub traffic when you need to inspect request pacing or rate-limit headers:
 
 ```bash
@@ -206,6 +213,7 @@ These flags apply to every command.
 | `--github-debug` | bool | `false` | Log GitHub API requests and responses |
 | `--json` | bool | `false` | Output structured JSON instead of human-readable text |
 | `--dry-run` | bool | `false` | Preview actions without side effects |
+| `--verbose` | bool | `false` | Show full subprocess commands and working directories on failure (env: `POLYRESEARCH_VERBOSE`) |
 
 ### Node overrides
 

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -1,10 +1,47 @@
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 use color_eyre::eyre::{Context, Result, eyre};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+
+const STDOUT_TAIL_LIMIT: usize = 2000;
+
+fn log_subprocess_failure(label: &str, output: &Output, verbose: bool, command_line: Option<&str>, work_dir: Option<&Path>) {
+    let code = output.status.code()
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "signal".into());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if verbose {
+        if let Some(cmd) = command_line {
+            eprintln!("[verbose] Command: {cmd}");
+        }
+        if let Some(dir) = work_dir {
+            eprintln!("[verbose] Working directory: {}", dir.display());
+        }
+        eprintln!("[verbose] Exit code: {code}");
+    }
+
+    eprintln!("{label} exited with status {code}");
+    if !stderr.trim().is_empty() {
+        eprintln!("  stderr: {}", stderr.trim());
+    }
+    if !stdout.trim().is_empty() {
+        let trimmed = stdout.trim();
+        let display = if trimmed.len() > STDOUT_TAIL_LIMIT {
+            &trimmed[trimmed.len() - STDOUT_TAIL_LIMIT..]
+        } else {
+            trimmed
+        };
+        eprintln!("  stdout (last): {display}");
+    }
+    if stderr.trim().is_empty() && stdout.trim().is_empty() {
+        eprintln!("  (no output captured from subprocess)");
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentResult {
@@ -50,6 +87,7 @@ pub fn spawn_experiment(
     agent_command: &str,
     worktree_path: &Path,
     prompt: &str,
+    verbose: bool,
 ) -> Result<Option<ExperimentResult>> {
     let parts = shell_words(agent_command);
     if parts.is_empty() {
@@ -65,8 +103,7 @@ pub fn spawn_experiment(
     let output = cmd.output().wrap_err("failed to spawn agent")?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("Agent exited with non-zero status: {stderr}");
+        log_subprocess_failure("Agent", &output, verbose, Some(agent_command), Some(worktree_path));
     }
 
     let result_path = worktree_path.join(".polyresearch/result.json");
@@ -150,6 +187,7 @@ pub fn spawn_thesis_generation(
     agent_command: &str,
     worktree_path: &Path,
     prompt: &str,
+    verbose: bool,
 ) -> Result<Vec<ThesisProposal>> {
     let parts = shell_words(agent_command);
     if parts.is_empty() {
@@ -165,8 +203,7 @@ pub fn spawn_thesis_generation(
     let output = cmd.output().wrap_err("failed to spawn agent for thesis generation")?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("Thesis generation agent exited with non-zero status: {stderr}");
+        log_subprocess_failure("Thesis generation agent", &output, verbose, Some(agent_command), Some(worktree_path));
     }
 
     let proposals_path = worktree_path.join(".polyresearch/thesis-proposals.json");
@@ -241,6 +278,8 @@ fn run_harness_in(harness: &HarnessSpec, work_dir: &Path) -> Result<Option<f64>>
         .wrap_err("failed to run evaluation harness")?;
 
     if !output.status.success() {
+        let cmd_line = format!("{} {}", harness.runner, script_path.display());
+        log_subprocess_failure("Evaluation harness", &output, false, Some(&cmd_line), Some(work_dir));
         return Ok(None);
     }
 

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -8,6 +8,16 @@ use serde::{Deserialize, Serialize};
 
 const STDOUT_TAIL_LIMIT: usize = 2000;
 
+/// Truncate a string to at most `max_bytes` from the end, cutting at a valid
+/// UTF-8 char boundary so we never panic on multi-byte characters.
+fn tail_str(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let cut = s.len() - max_bytes;
+    &s[s.ceil_char_boundary(cut)..]
+}
+
 fn log_subprocess_failure(label: &str, output: &Output, verbose: bool, command_line: Option<&str>, work_dir: Option<&Path>) {
     let code = output.status.code()
         .map(|c| c.to_string())
@@ -31,12 +41,7 @@ fn log_subprocess_failure(label: &str, output: &Output, verbose: bool, command_l
     }
     if !stdout.trim().is_empty() {
         let trimmed = stdout.trim();
-        let display = if trimmed.len() > STDOUT_TAIL_LIMIT {
-            &trimmed[trimmed.len() - STDOUT_TAIL_LIMIT..]
-        } else {
-            trimmed
-        };
-        eprintln!("  stdout (last): {display}");
+        eprintln!("  stdout (last): {}", tail_str(trimmed, STDOUT_TAIL_LIMIT));
     }
     if stderr.trim().is_empty() && stdout.trim().is_empty() {
         eprintln!("  (no output captured from subprocess)");
@@ -165,13 +170,14 @@ pub fn recover_from_logs(worktree_path: &Path) -> Option<RecoveredMetric> {
 pub fn run_harness_directly(
     worktree_path: &Path,
     baseline_path: &Path,
+    verbose: bool,
 ) -> Result<Option<RecoveredMetric>> {
     let Some(harness) = find_harness(worktree_path) else {
         return Ok(None);
     };
 
-    let candidate_metric = run_harness_in(&harness, worktree_path)?;
-    let baseline_metric = run_harness_in(&harness, baseline_path)?;
+    let candidate_metric = run_harness_in(&harness, worktree_path, verbose)?;
+    let baseline_metric = run_harness_in(&harness, baseline_path, verbose)?;
 
     match (candidate_metric, baseline_metric) {
         (Some(candidate), Some(baseline)) => Ok(Some(RecoveredMetric {
@@ -269,7 +275,7 @@ fn find_harness(worktree_path: &Path) -> Option<HarnessSpec> {
     None
 }
 
-fn run_harness_in(harness: &HarnessSpec, work_dir: &Path) -> Result<Option<f64>> {
+fn run_harness_in(harness: &HarnessSpec, work_dir: &Path, verbose: bool) -> Result<Option<f64>> {
     let script_path = work_dir.join(harness.relative_path);
     let output = Command::new(harness.runner)
         .arg(&script_path)
@@ -279,7 +285,7 @@ fn run_harness_in(harness: &HarnessSpec, work_dir: &Path) -> Result<Option<f64>>
 
     if !output.status.success() {
         let cmd_line = format!("{} {}", harness.runner, script_path.display());
-        log_subprocess_failure("Evaluation harness", &output, false, Some(&cmd_line), Some(work_dir));
+        log_subprocess_failure("Evaluation harness", &output, verbose, Some(&cmd_line), Some(work_dir));
         return Ok(None);
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -19,6 +19,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub dry_run: bool,
 
+    /// Show full subprocess commands and working directories on failure.
+    /// For GitHub API tracing, use --github-debug instead.
+    #[arg(long, global = true, env = "POLYRESEARCH_VERBOSE")]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -36,7 +36,7 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
 
     // Step 4: Spawn agent for project-specific setup
     if !args.pause_after_bootstrap {
-        spawn_setup_agent(&repo_root, &args.overrides)?;
+        spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose)?;
     } else {
         eprintln!("Pausing after bootstrap. Edit PROGRAM.md and PREPARE.md manually.");
     }
@@ -248,7 +248,7 @@ fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> R
     Ok(())
 }
 
-fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
+fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, verbose: bool) -> Result<()> {
     let node_config = NodeConfig::load(&repo_root.to_path_buf())
         .ok()
         .map(|c| c.with_overrides(overrides));
@@ -265,7 +265,7 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides) ->
     let prompt = include_str!("../../prompts/bootstrap-setup.md");
 
     eprintln!("Spawning agent for initial setup...");
-    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, prompt);
+    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, prompt, verbose);
     Ok(())
 }
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -230,6 +230,7 @@ async fn run_iteration(
             default_branch,
             program,
             config,
+            ctx.cli.verbose,
         ));
         prior_attempts_list.push(worker::format_prior_attempts(thesis));
     }
@@ -255,6 +256,7 @@ async fn run_iteration(
             default_branch,
             program,
             config,
+            ctx.cli.verbose,
         ));
         prior_attempts_list.push(worker::format_prior_attempts(thesis));
     }
@@ -290,6 +292,7 @@ fn build_worker_context(
     default_branch: &str,
     program: &ProgramSpec,
     config: &ProtocolConfig,
+    verbose: bool,
 ) -> WorkerContext {
     WorkerContext {
         issue_number: thesis.issue.number,
@@ -302,6 +305,7 @@ fn build_worker_context(
         editable_globs: program.can_modify.clone(),
         protected_globs: program.cannot_modify.clone(),
         metric_direction: config.metric_direction,
+        verbose,
     }
 }
 

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -264,8 +264,9 @@ async fn generate_if_needed(
     let prompt = agent::thesis_generation_prompt(capped);
     let repo_root = ctx.repo_root.clone();
     let agent_cmd = agent_command.to_string();
+    let verbose = ctx.cli.verbose;
     let proposals = tokio::task::spawn_blocking(move || {
-        agent::spawn_thesis_generation(&agent_cmd, &repo_root, &prompt)
+        agent::spawn_thesis_generation(&agent_cmd, &repo_root, &prompt, verbose)
     })
     .await
     .map_err(|e| eyre!("thesis generation task failed: {e}"))??;

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -802,7 +802,7 @@ fn run_command_with_retries(command: &mut Command, idempotent: bool) -> Result<S
 
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let Some(retry) = classify_retry(&stderr, idempotent) else {
-            return Err(eyre!("GitHub CLI command failed: {stderr}"));
+            return Err(error_with_hint(&stderr));
         };
 
         let retry_after = match retry {
@@ -826,7 +826,7 @@ fn run_command_with_retries(command: &mut Command, idempotent: bool) -> Result<S
 
         if attempt >= max_retries {
             return match retry {
-                RetryReason::Transient => Err(eyre!("GitHub CLI command failed: {stderr}")),
+                RetryReason::Transient => Err(error_with_hint(&stderr)),
                 RetryReason::RateLimited(kind) => Err(GitHubCliError::RateLimited {
                     kind,
                     retry_after_secs: retry_after.as_secs(),
@@ -925,6 +925,42 @@ fn classify_retry(stderr: &str, idempotent: bool) -> Option<RetryReason> {
     }
 
     None
+}
+
+fn classify_error_hint(stderr: &str) -> Option<&'static str> {
+    let lowered = stderr.to_ascii_lowercase();
+
+    if lowered.contains("has disabled issues") {
+        return Some("Enable Issues in your repository settings: gh api repos/OWNER/REPO --method PATCH -f has_issues=true");
+    }
+
+    if lowered.contains("could not authenticate")
+        || lowered.contains("authentication token")
+        || lowered.contains("auth token")
+        || lowered.contains("not logged in")
+    {
+        return Some("Run: gh auth login");
+    }
+
+    if lowered.contains("not found (http 404)") || lowered.contains("could not resolve") {
+        return Some("Check that the repository exists and you have access: gh repo view OWNER/REPO");
+    }
+
+    if lowered.contains("permission denied")
+        || lowered.contains("must have admin")
+        || lowered.contains("resource not accessible")
+    {
+        return Some("Check your permissions: gh api repos/OWNER/REPO --jq .permissions");
+    }
+
+    None
+}
+
+fn error_with_hint(stderr: &str) -> color_eyre::Report {
+    match classify_error_hint(stderr) {
+        Some(hint) => eyre!("GitHub CLI command failed: {stderr}\n  Hint: {hint}"),
+        None => eyre!("GitHub CLI command failed: {stderr}"),
+    }
 }
 
 fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -> Option<Duration> {

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -942,7 +942,7 @@ fn classify_error_hint(stderr: &str) -> Option<&'static str> {
         return Some("Run: gh auth login");
     }
 
-    if lowered.contains("not found (http 404)") || lowered.contains("could not resolve") {
+    if lowered.contains("http 404") || lowered.contains("could not resolve") {
         return Some("Check that the repository exists and you have access: gh repo view OWNER/REPO");
     }
 

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -23,6 +23,7 @@ pub struct WorkerContext {
     pub editable_globs: Vec<String>,
     pub protected_globs: Vec<String>,
     pub metric_direction: MetricDirection,
+    pub verbose: bool,
 }
 
 #[derive(Debug)]
@@ -116,6 +117,7 @@ impl ThesisWorker {
             &self.ctx.agent_command,
             &self.worktree_path,
             prompt,
+            self.ctx.verbose,
         )?;
 
         if result.is_some() {

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -138,7 +138,7 @@ impl ThesisWorker {
 
         let baseline_path = self.create_baseline_worktree()?;
         let harness_result =
-            agent::run_harness_directly(&self.worktree_path, &baseline_path);
+            agent::run_harness_directly(&self.worktree_path, &baseline_path, self.ctx.verbose);
         self.remove_baseline_worktree(&baseline_path);
 
         match harness_result {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1502,6 +1502,7 @@ fn make_ctx(
             github_debug: false,
             json: false,
             dry_run,
+            verbose: false,
             command,
         },
         repo_root,
@@ -2476,6 +2477,7 @@ fn worker_context_carries_protected_globs() {
         editable_globs: vec!["src/**".to_string()],
         protected_globs: vec!["docs/**".to_string(), "config/".to_string()],
         metric_direction: polyresearch::config::MetricDirection::HigherIsBetter,
+        verbose: false,
     };
 
     assert_eq!(wctx.protected_globs.len(), 2);

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -172,6 +172,7 @@ fn make_scenario_ctx(
             github_debug: false,
             json: false,
             dry_run,
+            verbose: false,
             command,
         },
         repo_root,


### PR DESCRIPTION
## Summary

Closes #72.

- When agent subprocesses exit non-zero, both stdout and stderr are now printed with the actual exit code. Previously only stderr was shown (and could be empty, producing a confusing `"non-zero status: "` message).
- Known `gh` CLI error patterns (disabled issues, auth failures, 404s, permission errors) now include actionable remediation hints in the error message.
- New `--verbose` global flag (also `POLYRESEARCH_VERBOSE` env) prints full subprocess command lines and working directories when a subprocess fails, so users can reproduce failures manually.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (all 11 scenario tests + e2e tests)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Manual: run `polyresearch --verbose contribute --once` with a bad agent command to verify verbose output
- [ ] Manual: trigger a "disabled issues" error to verify remediation hint appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI diagnostics (logging and error message formatting) and add a new optional `--verbose` flag, without altering protocol behavior or data handling.
> 
> **Overview**
> Improves failure diagnostics across the CLI by adding a global `--verbose` flag (also `POLYRESEARCH_VERBOSE`) and wiring it through bootstrap/lead/contribute/worker flows.
> 
> When agent or harness subprocesses fail, the CLI now prints exit status plus both `stderr` and a truncated tail of `stdout`, and in verbose mode also prints the full command line and working directory to aid repro.
> 
> GitHub CLI (`gh`) failures now attach actionable remediation hints for common errors (disabled Issues, auth problems, 404/access, permission errors), and docs/tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028d7ed2f51ffd6663e79dffa10bd12d0a5b31bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->