### PR TITLE
Fix lead sync push after PR merge (missing git pull)

### DIFF
--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -80,7 +80,6 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     }
 
     eprintln!("results.tsv is stale, syncing...");
-    let mut ledger = ledger;
     let missing = ledger.missing_rows(repo_state);
     if missing.is_empty() {
         return Ok(());
@@ -94,6 +93,14 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     let current = commands::current_branch(&ctx.repo_root)?;
     if current != default_branch && current != "main" {
         eprintln!("Warning: not on {default_branch} branch, skipping sync commit");
+        return Ok(());
+    }
+
+    commands::run_git(&ctx.repo_root, &["pull", "--rebase"])?;
+
+    let mut ledger = Ledger::load(&ctx.repo_root)?;
+    let missing = ledger.missing_rows(repo_state);
+    if missing.is_empty() {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Adds `git pull --rebase` before the commit+push sequence in `sync_if_stale` so the lead's local branch incorporates remote merge commits before pushing.
- Re-loads the ledger and re-computes missing rows after the pull, since the remote may already contain some of the rows that appeared missing.

Closes #79

## Test plan

- [ ] Verify `cargo check` passes with no warnings
- [ ] Run the lead loop on a project after a PR has been merged via the GitHub API -- the sync push should succeed instead of failing with "non-fast-forward"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to the `lead` sync flow, with the main risk being altered git behavior (rebase/pull) during automation.
> 
> **Overview**
> Prevents `lead` sync from failing with non-fast-forward pushes by running `git pull --rebase` before appending to `results.tsv` and pushing.
> 
> After pulling, it reloads the ledger and recomputes missing rows so it won’t commit/push rows that were already synced remotely (e.g., via a merged PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bf2cb2ae592810e94377b798b879f5834f6476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->