### PR TITLE
Close conflicting PRs as stale instead of looping forever

### DIFF
--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use color_eyre::eyre::{Context, Result, eyre};
+use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use std::sync::Arc;
@@ -217,11 +217,26 @@ pub fn execute_decision(
 ) -> Result<()> {
     match outcome {
         Outcome::Accepted => {
-            github
-                .merge_pull_request(pr_number)
-                .wrap_err("merge failed — decision NOT posted (resolve conflict first)")?;
-            github.post_issue_comment(pr_number, &comment.render())?;
-            github.close_issue(thesis_number)?;
+            match github.merge_pull_request(pr_number) {
+                Ok(_) => {
+                    github.post_issue_comment(pr_number, &comment.render())?;
+                    github.close_issue(thesis_number)?;
+                }
+                Err(merge_err) => {
+                    eprintln!(
+                        "Merge of PR #{pr_number} failed ({merge_err:#}), falling back to stale decision"
+                    );
+                    let candidate_sha = extract_candidate_sha(comment);
+                    let stale_comment = ProtocolComment::Decision {
+                        thesis: thesis_number,
+                        candidate_sha,
+                        outcome: Outcome::Stale,
+                        confirmations: 0,
+                    };
+                    github.post_issue_comment(pr_number, &stale_comment.render())?;
+                    github.close_pull_request(pr_number)?;
+                }
+            }
         }
         Outcome::InfraFailure | Outcome::Stale => {
             github.post_issue_comment(pr_number, &comment.render())?;
@@ -236,6 +251,13 @@ pub fn execute_decision(
         }
     }
     Ok(())
+}
+
+fn extract_candidate_sha(comment: &ProtocolComment) -> String {
+    match comment {
+        ProtocolComment::Decision { candidate_sha, .. } => candidate_sha.clone(),
+        _ => String::new(),
+    }
 }
 
 fn all_observations(reviews: &[ReviewRecord], observation: Observation) -> bool {

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -65,7 +65,7 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
         outcome,
         confirmations,
     };
-    if !ctx.cli.dry_run {
+    let actual_outcome = if !ctx.cli.dry_run {
         execute_decision(
             &ctx.github,
             args.pr,
@@ -73,13 +73,15 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
             outcome,
             &comment,
             ctx.config.required_confirmations,
-        )?;
-    }
+        )?
+    } else {
+        outcome
+    };
 
     let output = DecideOutput {
         pr: args.pr,
         thesis: thesis.issue.number,
-        outcome,
+        outcome: actual_outcome,
         confirmations,
     };
 
@@ -214,13 +216,14 @@ pub fn execute_decision(
     outcome: Outcome,
     comment: &ProtocolComment,
     required_confirmations: u64,
-) -> Result<()> {
-    match outcome {
+) -> Result<Outcome> {
+    let actual = match outcome {
         Outcome::Accepted => {
             match github.merge_pull_request(pr_number) {
                 Ok(_) => {
                     github.post_issue_comment(pr_number, &comment.render())?;
                     github.close_issue(thesis_number)?;
+                    Outcome::Accepted
                 }
                 Err(merge_err) => {
                     eprintln!(
@@ -235,12 +238,14 @@ pub fn execute_decision(
                     };
                     github.post_issue_comment(pr_number, &stale_comment.render())?;
                     github.close_pull_request(pr_number)?;
+                    Outcome::Stale
                 }
             }
         }
         Outcome::InfraFailure | Outcome::Stale => {
             github.post_issue_comment(pr_number, &comment.render())?;
             github.close_pull_request(pr_number)?;
+            outcome
         }
         Outcome::NonImprovement | Outcome::Disagreement | Outcome::PolicyRejection => {
             github.post_issue_comment(pr_number, &comment.render())?;
@@ -248,9 +253,10 @@ pub fn execute_decision(
             if required_confirmations > 0 || !matches!(outcome, Outcome::NonImprovement) {
                 github.close_issue(thesis_number)?;
             }
+            outcome
         }
-    }
-    Ok(())
+    };
+    Ok(actual)
 }
 
 fn extract_candidate_sha(comment: &ProtocolComment) -> String {

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -59,30 +59,25 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
         pr_state.reviews.len() as u64
     };
 
-    let comment = ProtocolComment::Decision {
-        thesis: thesis.issue.number,
-        candidate_sha,
-        outcome,
-        confirmations,
-    };
-    let actual_outcome = if !ctx.cli.dry_run {
+    let result = if !ctx.cli.dry_run {
         execute_decision(
             &ctx.github,
             args.pr,
             thesis.issue.number,
+            candidate_sha,
             outcome,
-            &comment,
+            confirmations,
             ctx.config.required_confirmations,
         )?
     } else {
-        outcome
+        DecisionExecuted { outcome, confirmations }
     };
 
     let output = DecideOutput {
         pr: args.pr,
         thesis: thesis.issue.number,
-        outcome: actual_outcome,
-        confirmations,
+        outcome: result.outcome,
+        confirmations: result.confirmations,
     };
 
     print_value(ctx, &output, |value| {
@@ -209,61 +204,78 @@ pub(crate) fn decide_with_peer_review(
     Ok(Outcome::Disagreement)
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct DecisionExecuted {
+    pub outcome: Outcome,
+    pub confirmations: u64,
+}
+
 pub fn execute_decision(
     github: &Arc<dyn GitHubApi>,
     pr_number: u64,
     thesis_number: u64,
+    candidate_sha: String,
     outcome: Outcome,
-    comment: &ProtocolComment,
+    confirmations: u64,
     required_confirmations: u64,
-) -> Result<Outcome> {
-    let actual = match outcome {
+) -> Result<DecisionExecuted> {
+    let result = match outcome {
         Outcome::Accepted => {
             match github.merge_pull_request(pr_number) {
                 Ok(_) => {
+                    let comment = ProtocolComment::Decision {
+                        thesis: thesis_number,
+                        candidate_sha,
+                        outcome,
+                        confirmations,
+                    };
                     github.post_issue_comment(pr_number, &comment.render())?;
                     github.close_issue(thesis_number)?;
-                    Outcome::Accepted
+                    DecisionExecuted { outcome, confirmations }
                 }
                 Err(merge_err) => {
                     eprintln!(
                         "Merge of PR #{pr_number} failed ({merge_err:#}), falling back to stale decision"
                     );
-                    let candidate_sha = extract_candidate_sha(comment);
-                    let stale_comment = ProtocolComment::Decision {
+                    let comment = ProtocolComment::Decision {
                         thesis: thesis_number,
                         candidate_sha,
                         outcome: Outcome::Stale,
                         confirmations: 0,
                     };
-                    github.post_issue_comment(pr_number, &stale_comment.render())?;
+                    github.post_issue_comment(pr_number, &comment.render())?;
                     github.close_pull_request(pr_number)?;
-                    Outcome::Stale
+                    DecisionExecuted { outcome: Outcome::Stale, confirmations: 0 }
                 }
             }
         }
         Outcome::InfraFailure | Outcome::Stale => {
+            let comment = ProtocolComment::Decision {
+                thesis: thesis_number,
+                candidate_sha,
+                outcome,
+                confirmations,
+            };
             github.post_issue_comment(pr_number, &comment.render())?;
             github.close_pull_request(pr_number)?;
-            outcome
+            DecisionExecuted { outcome, confirmations }
         }
         Outcome::NonImprovement | Outcome::Disagreement | Outcome::PolicyRejection => {
+            let comment = ProtocolComment::Decision {
+                thesis: thesis_number,
+                candidate_sha,
+                outcome,
+                confirmations,
+            };
             github.post_issue_comment(pr_number, &comment.render())?;
             github.close_pull_request(pr_number)?;
             if required_confirmations > 0 || !matches!(outcome, Outcome::NonImprovement) {
                 github.close_issue(thesis_number)?;
             }
-            outcome
+            DecisionExecuted { outcome, confirmations }
         }
     };
-    Ok(actual)
-}
-
-fn extract_candidate_sha(comment: &ProtocolComment) -> String {
-    match comment {
-        ProtocolComment::Decision { candidate_sha, .. } => candidate_sha.clone(),
-        _ => String::new(),
-    }
+    Ok(result)
 }
 
 fn all_observations(reviews: &[ReviewRecord], observation: Observation) -> bool {

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -230,7 +230,7 @@ fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &Repo
                 confirmations,
             };
 
-            decide::execute_decision(
+            let actual_outcome = decide::execute_decision(
                 &ctx.github,
                 pr_state.pr.number,
                 thesis.issue.number,
@@ -239,7 +239,7 @@ fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &Repo
                 config.required_confirmations,
             )?;
 
-            eprintln!("PR #{} decided as {outcome}", pr_state.pr.number);
+            eprintln!("PR #{} decided as {actual_outcome}", pr_state.pr.number);
         }
     }
     Ok(())

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -192,6 +192,21 @@ fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &Repo
                 continue;
             }
 
+            if pr_state.pr.mergeable.as_deref() == Some("CONFLICTING") {
+                eprintln!("PR #{} has merge conflicts, closing as stale...", pr_state.pr.number);
+                if !ctx.cli.dry_run {
+                    let stale_comment = ProtocolComment::Decision {
+                        thesis: thesis.issue.number,
+                        candidate_sha: pr_state.pr.head_ref_oid.clone().unwrap_or_default(),
+                        outcome: Outcome::Stale,
+                        confirmations: 0,
+                    };
+                    ctx.github.post_issue_comment(pr_state.pr.number, &stale_comment.render())?;
+                    ctx.github.close_pull_request(pr_state.pr.number)?;
+                }
+                continue;
+            }
+
             eprintln!("Deciding PR #{}...", pr_state.pr.number);
 
             if ctx.cli.dry_run {

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -80,7 +80,6 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     }
 
     eprintln!("results.tsv is stale, syncing...");
-    let mut ledger = ledger;
     let missing = ledger.missing_rows(repo_state);
     if missing.is_empty() {
         return Ok(());
@@ -94,6 +93,14 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     let current = commands::current_branch(&ctx.repo_root)?;
     if current != default_branch && current != "main" {
         eprintln!("Warning: not on {default_branch} branch, skipping sync commit");
+        return Ok(());
+    }
+
+    commands::run_git(&ctx.repo_root, &["pull", "--rebase"])?;
+
+    let mut ledger = Ledger::load(&ctx.repo_root)?;
+    let missing = ledger.missing_rows(repo_state);
+    if missing.is_empty() {
         return Ok(());
     }
 

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -80,6 +80,7 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     }
 
     eprintln!("results.tsv is stale, syncing...");
+    let mut ledger = ledger;
     let missing = ledger.missing_rows(repo_state);
     if missing.is_empty() {
         return Ok(());
@@ -93,14 +94,6 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     let current = commands::current_branch(&ctx.repo_root)?;
     if current != default_branch && current != "main" {
         eprintln!("Warning: not on {default_branch} branch, skipping sync commit");
-        return Ok(());
-    }
-
-    commands::run_git(&ctx.repo_root, &["pull", "--rebase"])?;
-
-    let mut ledger = Ledger::load(&ctx.repo_root)?;
-    let missing = ledger.missing_rows(repo_state);
-    if missing.is_empty() {
         return Ok(());
     }
 
@@ -223,23 +216,17 @@ fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &Repo
             let candidate_sha = pr_state.pr.head_ref_oid.clone().unwrap_or_default();
             let confirmations = if required == 0 { 0 } else { pr_state.reviews.len() as u64 };
 
-            let comment = ProtocolComment::Decision {
-                thesis: thesis.issue.number,
-                candidate_sha,
-                outcome,
-                confirmations,
-            };
-
-            let actual_outcome = decide::execute_decision(
+            let result = decide::execute_decision(
                 &ctx.github,
                 pr_state.pr.number,
                 thesis.issue.number,
+                candidate_sha,
                 outcome,
-                &comment,
+                confirmations,
                 config.required_confirmations,
             )?;
 
-            eprintln!("PR #{} decided as {actual_outcome}", pr_state.pr.number);
+            eprintln!("PR #{} decided as {}", pr_state.pr.number, result.outcome);
         }
     }
     Ok(())

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -309,7 +309,7 @@ impl GitHubClient {
             "--limit",
             "1000",
             "--json",
-            "number,title,body,state,headRefName,headRefOid,baseRefName,createdAt,closedAt,mergedAt,author,url",
+            "number,title,body,state,headRefName,headRefOid,baseRefName,createdAt,closedAt,mergedAt,author,url,mergeable",
         ])
     }
 
@@ -321,7 +321,7 @@ impl GitHubClient {
             "--repo",
             &self.repo.slug(),
             "--json",
-            "number,title,body,state,headRefName,headRefOid,baseRefName,createdAt,closedAt,mergedAt,author,url",
+            "number,title,body,state,headRefName,headRefOid,baseRefName,createdAt,closedAt,mergedAt,author,url,mergeable",
         ])
     }
 
@@ -725,6 +725,8 @@ pub struct PullRequest {
     pub author: Option<Author>,
     #[serde(default)]
     pub url: Option<String>,
+    #[serde(default)]
+    pub mergeable: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -669,6 +669,7 @@ mod tests {
                     merged_at: None,
                     author: None,
                     url: None,
+                    mergeable: None,
                 },
                 thesis_number: Some(1),
                 policy_pass: true,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2383,6 +2383,7 @@ fn env_sha_none_vs_some_triggers_disagreement() {
             merged_at: None,
             author: None,
             url: None,
+            mergeable: None,
         },
         thesis_number: Some(5),
         policy_pass: true,

--- a/cli/tests/scenario_mock.rs
+++ b/cli/tests/scenario_mock.rs
@@ -136,6 +136,14 @@ impl ScenarioGitHub {
             .collect()
     }
 
+    #[allow(dead_code)]
+    pub fn set_pr_mergeable(&self, pr_number: u64, status: &str) {
+        let mut s = self.state.lock().unwrap();
+        if let Some(pr) = s.pull_requests.iter_mut().find(|pr| pr.number == pr_number) {
+            pr.mergeable = Some(status.to_string());
+        }
+    }
+
     pub fn comment_bodies_on(&self, issue_or_pr: u64) -> Vec<String> {
         let s = self.state.lock().unwrap();
         let mut bodies = Vec::new();
@@ -340,6 +348,7 @@ impl GitHubApi for ScenarioGitHub {
                 login: s.login.clone(),
             }),
             url: Some(format!("https://github.com/test/repo/pull/{number}")),
+            mergeable: Some("MERGEABLE".to_string()),
         };
         s.pull_requests.push(pr.clone());
         Ok(pr)
@@ -357,6 +366,11 @@ impl GitHubApi for ScenarioGitHub {
 
     fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
         let mut s = self.state.lock().unwrap();
+        if let Some(pr) = s.pull_requests.iter().find(|pr| pr.number == pr_number) {
+            if pr.mergeable.as_deref() == Some("CONFLICTING") {
+                return Err(eyre!("405 Method Not Allowed: pull request is not mergeable"));
+            }
+        }
         s.merged_prs.push(pr_number);
         if let Some(pr) = s.pull_requests.iter_mut().find(|pr| pr.number == pr_number) {
             pr.state = "MERGED".to_string();

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -787,7 +787,7 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
         confirmations: 0,
     };
 
-    commands::decide::execute_decision(
+    let actual = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         70,
         70,
@@ -797,6 +797,7 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
     )
     .unwrap();
 
+    assert_eq!(actual, polyresearch::comments::Outcome::NonImprovement);
     assert!(
         github.is_pr_closed(70),
         "PR should be closed on non_improvement"
@@ -833,7 +834,7 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
         confirmations: 0,
     };
 
-    commands::decide::execute_decision(
+    let actual = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         71,
         71,
@@ -843,6 +844,7 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
     )
     .unwrap();
 
+    assert_eq!(actual, polyresearch::comments::Outcome::Disagreement);
     assert!(
         github.is_pr_closed(71),
         "PR should be closed on disagreement"
@@ -879,7 +881,7 @@ fn execute_decision_accepted_merges_and_closes() {
         confirmations: 0,
     };
 
-    commands::decide::execute_decision(
+    let actual = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         72,
         72,
@@ -889,6 +891,7 @@ fn execute_decision_accepted_merges_and_closes() {
     )
     .unwrap();
 
+    assert_eq!(actual, polyresearch::comments::Outcome::Accepted);
     assert!(github.is_pr_merged(72), "PR should be merged on accepted");
     assert!(
         github.is_issue_closed(72),
@@ -1057,7 +1060,7 @@ fn execute_decision_falls_back_on_merge_failure() {
         confirmations: 0,
     };
 
-    let result = commands::decide::execute_decision(
+    let actual = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         73,
         73,
@@ -1066,7 +1069,12 @@ fn execute_decision_falls_back_on_merge_failure() {
         0,
     );
 
-    assert!(result.is_ok(), "should not propagate merge error: {result:?}");
+    assert!(actual.is_ok(), "should not propagate merge error: {actual:?}");
+    assert_eq!(
+        actual.unwrap(),
+        polyresearch::comments::Outcome::Stale,
+        "returned outcome should be Stale, not Accepted"
+    );
     assert!(
         !github.is_pr_merged(73),
         "conflicting PR should NOT be merged"

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -780,24 +780,19 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
         mergeable: None,
     });
 
-    let comment = ProtocolComment::Decision {
-        thesis: 70,
-        candidate_sha: "sha".to_string(),
-        outcome: polyresearch::comments::Outcome::NonImprovement,
-        confirmations: 0,
-    };
-
-    let actual = commands::decide::execute_decision(
+    let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         70,
         70,
+        "sha".to_string(),
         polyresearch::comments::Outcome::NonImprovement,
-        &comment,
+        0,
         0,
     )
     .unwrap();
 
-    assert_eq!(actual, polyresearch::comments::Outcome::NonImprovement);
+    assert_eq!(result.outcome, polyresearch::comments::Outcome::NonImprovement);
+    assert_eq!(result.confirmations, 0);
     assert!(
         github.is_pr_closed(70),
         "PR should be closed on non_improvement"
@@ -827,24 +822,19 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
         mergeable: None,
     });
 
-    let comment = ProtocolComment::Decision {
-        thesis: 71,
-        candidate_sha: "sha".to_string(),
-        outcome: polyresearch::comments::Outcome::Disagreement,
-        confirmations: 0,
-    };
-
-    let actual = commands::decide::execute_decision(
+    let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         71,
         71,
+        "sha".to_string(),
         polyresearch::comments::Outcome::Disagreement,
-        &comment,
+        0,
         0,
     )
     .unwrap();
 
-    assert_eq!(actual, polyresearch::comments::Outcome::Disagreement);
+    assert_eq!(result.outcome, polyresearch::comments::Outcome::Disagreement);
+    assert_eq!(result.confirmations, 0);
     assert!(
         github.is_pr_closed(71),
         "PR should be closed on disagreement"
@@ -874,24 +864,19 @@ fn execute_decision_accepted_merges_and_closes() {
         mergeable: None,
     });
 
-    let comment = ProtocolComment::Decision {
-        thesis: 72,
-        candidate_sha: "sha".to_string(),
-        outcome: polyresearch::comments::Outcome::Accepted,
-        confirmations: 0,
-    };
-
-    let actual = commands::decide::execute_decision(
+    let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         72,
         72,
+        "sha".to_string(),
         polyresearch::comments::Outcome::Accepted,
-        &comment,
+        0,
         0,
     )
     .unwrap();
 
-    assert_eq!(actual, polyresearch::comments::Outcome::Accepted);
+    assert_eq!(result.outcome, polyresearch::comments::Outcome::Accepted);
+    assert_eq!(result.confirmations, 0);
     assert!(github.is_pr_merged(72), "PR should be merged on accepted");
     assert!(
         github.is_issue_closed(72),
@@ -1053,27 +1038,26 @@ fn execute_decision_falls_back_on_merge_failure() {
         mergeable: Some("CONFLICTING".to_string()),
     });
 
-    let comment = ProtocolComment::Decision {
-        thesis: 73,
-        candidate_sha: "sha-conflict".to_string(),
-        outcome: polyresearch::comments::Outcome::Accepted,
-        confirmations: 0,
-    };
-
-    let actual = commands::decide::execute_decision(
+    let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
         73,
         73,
+        "sha-conflict".to_string(),
         polyresearch::comments::Outcome::Accepted,
-        &comment,
+        5,
         0,
     );
 
-    assert!(actual.is_ok(), "should not propagate merge error: {actual:?}");
+    assert!(result.is_ok(), "should not propagate merge error: {result:?}");
+    let result = result.unwrap();
     assert_eq!(
-        actual.unwrap(),
+        result.outcome,
         polyresearch::comments::Outcome::Stale,
         "returned outcome should be Stale, not Accepted"
+    );
+    assert_eq!(
+        result.confirmations, 0,
+        "returned confirmations should be 0 for stale fallback, not the original value"
     );
     assert!(
         !github.is_pr_merged(73),

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -570,6 +570,7 @@ async fn scenario_lead_accept_pr() {
             login: "contributor".to_string(),
         }),
         url: Some("https://github.com/test/repo/pull/50".to_string()),
+        mergeable: Some("MERGEABLE".to_string()),
     };
 
     let policy_pass = ProtocolComment::PolicyPass {
@@ -691,6 +692,7 @@ async fn scenario_lead_reject_non_improvement() {
             login: "contributor".to_string(),
         }),
         url: Some("https://github.com/test/repo/pull/51".to_string()),
+        mergeable: Some("MERGEABLE".to_string()),
     };
 
     let policy_pass = ProtocolComment::PolicyPass {
@@ -775,6 +777,7 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
         merged_at: None,
         author: None,
         url: None,
+        mergeable: None,
     });
 
     let comment = ProtocolComment::Decision {
@@ -820,6 +823,7 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
         merged_at: None,
         author: None,
         url: None,
+        mergeable: None,
     });
 
     let comment = ProtocolComment::Decision {
@@ -865,6 +869,7 @@ fn execute_decision_accepted_merges_and_closes() {
         merged_at: None,
         author: None,
         url: None,
+        mergeable: None,
     });
 
     let comment = ProtocolComment::Decision {
@@ -888,6 +893,207 @@ fn execute_decision_accepted_merges_and_closes() {
     assert!(
         github.is_issue_closed(72),
         "thesis should be closed on accepted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Conflicting PR handling (issue #80)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_lead_closes_conflicting_pr_as_stale() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("lead-conflict");
+    repo.init_git();
+    repo.write_full_setup("lead", "lead-node", "echo noop");
+    repo.commit_all("setup");
+
+    let now = chrono::Utc::now();
+    let (issue, mut issue_comments) = make_approved_thesis(45, "Optimize hot path", "lead");
+
+    issue_comments.push(IssueComment {
+        id: 4501,
+        body: ProtocolComment::Claim {
+            thesis: 45,
+            node: "worker-c".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(30),
+        updated_at: None,
+    });
+
+    issue_comments.push(IssueComment {
+        id: 4502,
+        body: ProtocolComment::Attempt {
+            thesis: 45,
+            branch: "thesis/45-optimize-hot-path".to_string(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Hot path optimization".to_string(),
+            annotations: None,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(20),
+        updated_at: None,
+    });
+
+    let pr = PullRequest {
+        number: 55,
+        title: "Thesis #45: Optimize hot path".to_string(),
+        body: Some("References #45".to_string()),
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/45-optimize-hot-path".to_string(),
+        head_ref_oid: Some("conflict-sha".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(15),
+        closed_at: None,
+        merged_at: None,
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
+        url: Some("https://github.com/test/repo/pull/55".to_string()),
+        mergeable: Some("CONFLICTING".to_string()),
+    };
+
+    let pr_comments = vec![IssueComment {
+        id: 5501,
+        body: ProtocolComment::PolicyPass {
+            thesis: 45,
+            candidate_sha: "conflict-sha".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(10),
+        updated_at: None,
+    }];
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(45, issue_comments);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(55, pr_comments);
+    github.seed_pr_files(55, vec![polyresearch::github::PullRequestFile {
+        filename: "src/hot_path.js".to_string(),
+    }]);
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_ok(), "lead should succeed: {result:?}");
+    assert!(
+        !github.is_pr_merged(55),
+        "conflicting PR #55 should NOT be merged"
+    );
+    assert!(
+        github.is_pr_closed(55),
+        "conflicting PR #55 should be closed"
+    );
+    assert!(
+        !github.is_issue_closed(45),
+        "thesis #45 should stay open for retry"
+    );
+
+    let pr_bodies = github.comment_bodies_on(55);
+    let has_stale_decision = pr_bodies
+        .iter()
+        .any(|b| b.contains("polyresearch:decision") && b.contains("stale"));
+    assert!(
+        has_stale_decision,
+        "should have posted stale decision on conflicting PR #55"
+    );
+}
+
+#[test]
+fn execute_decision_falls_back_on_merge_failure() {
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_pull_request(PullRequest {
+        number: 73,
+        title: "Candidate".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/73-test".to_string(),
+        head_ref_oid: Some("sha-conflict".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: Some("CONFLICTING".to_string()),
+    });
+
+    let comment = ProtocolComment::Decision {
+        thesis: 73,
+        candidate_sha: "sha-conflict".to_string(),
+        outcome: polyresearch::comments::Outcome::Accepted,
+        confirmations: 0,
+    };
+
+    let result = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        73,
+        73,
+        polyresearch::comments::Outcome::Accepted,
+        &comment,
+        0,
+    );
+
+    assert!(result.is_ok(), "should not propagate merge error: {result:?}");
+    assert!(
+        !github.is_pr_merged(73),
+        "conflicting PR should NOT be merged"
+    );
+    assert!(
+        github.is_pr_closed(73),
+        "conflicting PR should be closed as stale fallback"
+    );
+    assert!(
+        !github.is_issue_closed(73),
+        "thesis should stay open when merge fails (stale fallback)"
+    );
+
+    let pr_bodies = github.comment_bodies_on(73);
+    let has_stale = pr_bodies
+        .iter()
+        .any(|b| b.contains("polyresearch:decision") && b.contains("stale"));
+    assert!(
+        has_stale,
+        "should have posted stale decision comment as fallback"
+    );
+    let has_accepted = pr_bodies
+        .iter()
+        .any(|b| b.contains("polyresearch:decision") && b.contains("accepted"));
+    assert!(
+        !has_accepted,
+        "should NOT have posted accepted decision on failed merge"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #80. When multiple agents modify the same file in parallel and one PR is merged first, the remaining PRs become conflicting. Previously the lead would decide these as "Accepted", attempt to merge (409 conflict), and error out without recording a decision -- repeating forever.

- **Primary fix (Option A):** `decide_ready_prs` in the lead loop now checks `PR.mergeable == "CONFLICTING"` before deciding. Conflicting PRs are closed with a `Stale` decision comment, leaving the thesis open for retry.
- **Safety net (Option B):** `execute_decision` catches merge failures on `Accepted` outcomes and falls back to posting a `Stale` decision instead of propagating the error.
- Adds `mergeable` field to `PullRequest` struct and fetches it via `gh pr list/view --json`.

## Test plan

- [x] New scenario test `scenario_lead_closes_conflicting_pr_as_stale` -- full lead loop with a CONFLICTING PR
- [x] New unit test `execute_decision_falls_back_on_merge_failure` -- safety net path
- [x] All 214 existing tests pass (134 unit + 67 e2e + 13 scenario)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR decision/merge flow in `lead`/`decide`, including new handling for merge-conflict states and swallowing merge errors; mistakes could incorrectly close PRs or leave theses in the wrong state.
> 
> **Overview**
> Prevents the lead loop from repeatedly failing on merge-conflict PRs by detecting `PullRequest.mergeable == "CONFLICTING"` and immediately closing those PRs with a `Stale` decision comment (leaving the thesis open for retry).
> 
> Adds a safety net in `execute_decision`: `Accepted` now attempts the merge and, if it fails, posts a `Stale` decision and closes the PR instead of propagating the error. This refactors decision execution to return `DecisionExecuted` (actual outcome/confirmations) and updates callers/tests accordingly, and extends GitHub PR fetching/state/mocks to include the `mergeable` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b95f754a70cf8987733c2a8431cf4df2fe4d9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->