### PR TITLE
Release v0.5.2

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.5.1
+cli_version: 0.5.2
 
 ## Goal
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.5.1 to 0.5.2 in `cli/Cargo.toml`, `Cargo.lock`, and `PROGRAM.md`

## Release steps
After merge:
```bash
git tag v0.5.2 <merge-commit-sha>
git push origin v0.5.2
```
The `v*.*.*` tag push triggers the release workflow which builds binaries, publishes a GitHub Release, and publishes to crates.io.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump only; no functional or behavioral code changes, just metadata used for packaging/release.
> 
> **Overview**
> Updates the `polyresearch` CLI version from `0.5.1` to `0.5.2` in `cli/Cargo.toml`, `cli/Cargo.lock`, and `PROGRAM.md` to align the repo metadata with the `v0.5.2` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc894f27269cedd4477505c5c9b7d7e91a0febf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->