### PR TITLE
Bootstrap: auto-set lead/maintainer login from authenticated GitHub user

### DIFF
--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -265,26 +265,34 @@ fn ensure_lead_login(repo_root: &Path, login: &str) -> Result<()> {
     let contents = fs::read_to_string(&path)
         .wrap_err_with(|| format!("failed to read {}", path.display()))?;
 
-    let mut modified = contents.clone();
-    for key in ["lead_github_login", "maintainer_github_login"] {
-        for line in contents.lines() {
+    let keys = ["lead_github_login", "maintainer_github_login"];
+    let mut changed = false;
+    let modified: String = contents
+        .lines()
+        .map(|line| {
             let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix(key) {
-                if let Some(value) = rest.strip_prefix(':') {
-                    let value = value.trim();
-                    if !value.is_empty() && value != login {
-                        modified = modified.replacen(
-                            &format!("{key}: {value}"),
-                            &format!("{key}: {login}"),
-                            1,
-                        );
+            for key in &keys {
+                if let Some(rest) = trimmed.strip_prefix(*key) {
+                    if let Some(value) = rest.strip_prefix(':') {
+                        let value = value.trim();
+                        if !value.is_empty() && value != login {
+                            changed = true;
+                            return format!("{key}: {login}");
+                        }
                     }
                 }
             }
-        }
-    }
+            line.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
 
-    if modified != contents {
+    if changed {
+        let modified = if contents.ends_with('\n') && !modified.ends_with('\n') {
+            format!("{modified}\n")
+        } else {
+            modified
+        };
         fs::write(&path, &modified)
             .wrap_err_with(|| format!("failed to write {}", path.display()))?;
         eprintln!("Updated lead/maintainer login in PROGRAM.md to `{login}`");

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -10,7 +10,7 @@ use crate::config::NodeConfig;
 use crate::github::RepoRef;
 
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
-    let repo_root = scaffold(ctx, args)?;
+    let (repo_root, login) = scaffold(ctx, args)?;
 
     if !args.yes {
         use std::io::IsTerminal;
@@ -38,7 +38,7 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         }
     }
 
-    spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose)?;
+    spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose, &login)?;
 
     // Post-agent cleanup: re-normalize in case the agent mangled required sections,
     // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
@@ -51,7 +51,8 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
 
 /// Clone/fork, write templates, initialize node config, and normalize PROGRAM.md.
 /// Does not spawn any agents or require interactive input.
-pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<std::path::PathBuf> {
+/// Returns `(repo_root, github_login)` so callers can thread the login downstream.
+pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<(std::path::PathBuf, String)> {
     let upstream = RepoRef::from_user_input(&args.url)?;
     let clone_url = upstream.clone_url();
     eprintln!("Bootstrapping polyresearch project from {}", upstream.slug());
@@ -70,11 +71,14 @@ pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<std::path::Pat
         auto_clone_or_fork(&upstream, &repo_root)?;
     }
 
-    write_templates(&repo_root, args.goal.as_deref())?;
+    let login = ctx.github.current_login()?;
+
+    write_templates(&repo_root, args.goal.as_deref(), &login)?;
+    ensure_lead_login(&repo_root, &login)?;
     initialize_node(&repo_root, &args.overrides)?;
     normalize_program_md(&repo_root)?;
 
-    Ok(repo_root)
+    Ok((repo_root, login))
 }
 
 fn auto_clone_or_fork(upstream: &RepoRef, repo_root: &Path) -> Result<()> {
@@ -201,15 +205,24 @@ fn clone_if_needed(url: &str, repo_root: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
+pub fn write_templates(repo_root: &Path, goal: Option<&str>, login: &str) -> Result<()> {
     let program_path = repo_root.join("PROGRAM.md");
     if !program_path.exists() {
         let base = include_str!("../../prompts/template-program.md");
         let versioned = base.replace("{{VERSION}}", env!("CARGO_PKG_VERSION"));
+        let with_login = versioned
+            .replace(
+                "lead_github_login: replace-me",
+                &format!("lead_github_login: {login}"),
+            )
+            .replace(
+                "maintainer_github_login: replace-me",
+                &format!("maintainer_github_login: {login}"),
+            );
         let template = if let Some(goal) = goal {
-            replace_goal_section(&versioned, goal)
+            replace_goal_section(&with_login, goal)
         } else {
-            versioned
+            with_login
         };
         fs::write(&program_path, template)
             .wrap_err_with(|| format!("failed to write {}", program_path.display()))?;
@@ -235,6 +248,46 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>) -> Result<()> {
     if !polyresearch_dir.exists() {
         fs::create_dir_all(&polyresearch_dir)
             .wrap_err_with(|| format!("failed to create {}", polyresearch_dir.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Ensure `lead_github_login` and `maintainer_github_login` in an existing
+/// PROGRAM.md match the current user. Handles repos cloned from an upstream
+/// that already had polyresearch configured with a different lead.
+fn ensure_lead_login(repo_root: &Path, login: &str) -> Result<()> {
+    let path = repo_root.join("PROGRAM.md");
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let contents = fs::read_to_string(&path)
+        .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+
+    let mut modified = contents.clone();
+    for key in ["lead_github_login", "maintainer_github_login"] {
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix(key) {
+                if let Some(value) = rest.strip_prefix(':') {
+                    let value = value.trim();
+                    if !value.is_empty() && value != login {
+                        modified = modified.replacen(
+                            &format!("{key}: {value}"),
+                            &format!("{key}: {login}"),
+                            1,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    if modified != contents {
+        fs::write(&path, &modified)
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+        eprintln!("Updated lead/maintainer login in PROGRAM.md to `{login}`");
     }
 
     Ok(())
@@ -266,7 +319,7 @@ fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> R
     Ok(())
 }
 
-fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, verbose: bool) -> Result<()> {
+fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, verbose: bool, login: &str) -> Result<()> {
     let node_config = NodeConfig::load(&repo_root.to_path_buf())
         .ok()
         .map(|c| c.with_overrides(overrides));
@@ -280,10 +333,14 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, ve
                 .unwrap_or_else(|| "claude -p --dangerously-skip-permissions".to_string())
         });
 
-    let prompt = include_str!("../../prompts/bootstrap-setup.md");
+    let base_prompt = include_str!("../../prompts/bootstrap-setup.md");
+    let prompt = format!(
+        "{base_prompt}\n\nThe lead GitHub login is `{login}`. \
+         Use this exact value for lead_github_login and maintainer_github_login in PROGRAM.md."
+    );
 
     eprintln!("Spawning agent for initial setup...");
-    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, prompt, verbose);
+    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, &prompt, verbose);
     Ok(())
 }
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1877,7 +1877,7 @@ async fn bootstrap_writes_templates_when_missing() {
     assert!(!prepare_path.exists());
     assert!(!results_path.exists());
 
-    commands::bootstrap::write_templates(&repo.path, Some("Optimize latency")).unwrap();
+    commands::bootstrap::write_templates(&repo.path, Some("Optimize latency"), "test-lead").unwrap();
 
     assert!(program_path.exists());
     assert!(prepare_path.exists());
@@ -1886,6 +1886,8 @@ async fn bootstrap_writes_templates_when_missing() {
     let program = fs::read_to_string(&program_path).unwrap();
     assert!(program.contains(&format!("cli_version: {}", env!("CARGO_PKG_VERSION"))));
     assert!(program.contains("Optimize latency"));
+    assert!(program.contains("lead_github_login: test-lead"));
+    assert!(program.contains("maintainer_github_login: test-lead"));
     assert!(program.contains("## Goal"));
     assert!(program.contains("## What you CAN modify"));
     assert!(program.contains("## What you CANNOT modify"));
@@ -1902,7 +1904,7 @@ async fn bootstrap_preserves_existing_program_md() {
     let program_path = repo.path.join("PROGRAM.md");
     fs::write(&program_path, "# Existing program\nDo not overwrite.\n").unwrap();
 
-    commands::bootstrap::write_templates(&repo.path, None).unwrap();
+    commands::bootstrap::write_templates(&repo.path, None, "test-lead").unwrap();
 
     let content = fs::read_to_string(&program_path).unwrap();
     assert!(content.contains("Existing program"));
@@ -1939,7 +1941,7 @@ async fn bootstrap_commits_setup_files() {
         .unwrap();
     run_git(&repo.path, &["remote", "add", "origin", &bare.path.to_string_lossy()]);
 
-    commands::bootstrap::write_templates(&repo.path, Some("Test goal")).unwrap();
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "test-lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
     commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
 
@@ -1986,7 +1988,7 @@ async fn bootstrap_commit_is_idempotent() {
         .unwrap();
     run_git(&repo.path, &["remote", "add", "origin", &bare.path.to_string_lossy()]);
 
-    commands::bootstrap::write_templates(&repo.path, None).unwrap();
+    commands::bootstrap::write_templates(&repo.path, None, "test-lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
     commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
 
@@ -2002,6 +2004,65 @@ async fn bootstrap_commit_is_idempotent() {
     let log = String::from_utf8(log_output.stdout).unwrap();
     let setup_commits: Vec<&str> = log.lines().filter(|l| l.contains("Add polyresearch setup files")).collect();
     assert_eq!(setup_commits.len(), 1, "expected exactly one setup commit, got: {log}");
+}
+
+// --- Bootstrap login tests ---
+
+#[tokio::test]
+async fn bootstrap_write_templates_substitutes_login() {
+    let repo = TestRepo::new("bootstrap-login-sub");
+    init_git_repo(&repo.path);
+
+    commands::bootstrap::write_templates(&repo.path, None, "my-user").unwrap();
+
+    let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    assert!(
+        program.contains("lead_github_login: my-user"),
+        "lead login should be substituted, got: {program}"
+    );
+    assert!(
+        program.contains("maintainer_github_login: my-user"),
+        "maintainer login should be substituted, got: {program}"
+    );
+    assert!(
+        !program.contains("replace-me"),
+        "replace-me placeholder should not remain"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_ensure_lead_login_fixes_upstream_owner() {
+    let repo = TestRepo::new("bootstrap-ensure-login");
+    init_git_repo(&repo.path);
+
+    let upstream_program = "\
+# Research Program
+
+cli_version: 0.5.0
+lead_github_login: upstream-owner
+maintainer_github_login: upstream-owner
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+
+## Goal
+
+Do stuff.
+";
+    fs::write(repo.path.join("PROGRAM.md"), upstream_program).unwrap();
+
+    // write_templates should skip (file already exists)
+    commands::bootstrap::write_templates(&repo.path, None, "fork-user").unwrap();
+    let before = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    assert!(
+        before.contains("lead_github_login: upstream-owner"),
+        "write_templates should not overwrite existing file"
+    );
+
+    // scaffold would call ensure_lead_login after write_templates;
+    // test it indirectly through write_templates + normalize to verify the
+    // full scaffold path. Since ensure_lead_login is private, we verify
+    // through the scaffold function using the scenario test infrastructure.
+    // Here we just verify write_templates preserves existing content.
 }
 
 // --- Contribute claimability tests ---

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -430,6 +430,74 @@ Do stuff.
     );
 }
 
+#[tokio::test]
+async fn scenario_bootstrap_login_fix_does_not_clobber_prose() {
+    let repo = ScenarioRepo::new("boot-prose-safe");
+    repo.init_git();
+
+    let program_with_prose = "\
+# Research Program
+
+cli_version: 0.5.2
+lead_github_login: upstream-owner
+maintainer_github_login: upstream-owner
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+
+## Goal
+
+Ensure lead_github_login: upstream-owner appears in docs unchanged.
+
+## What you CAN modify
+
+- `src/`
+
+## What you CANNOT modify
+
+- `PROGRAM.md`
+";
+    fs::write(repo.path.join("PROGRAM.md"), program_with_prose).unwrap();
+
+    let github = Arc::new(ScenarioGitHub::new("fork-user"));
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        github,
+        "fork-user",
+        false,
+        Commands::Bootstrap(BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: None,
+            yes: false,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    commands::bootstrap::scaffold(
+        &ctx,
+        &BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: None,
+            yes: false,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .unwrap();
+
+    let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    assert!(
+        program.contains("lead_github_login: fork-user"),
+        "config line should be updated, got: {program}"
+    );
+    assert!(
+        program.contains("Ensure lead_github_login: upstream-owner appears in docs unchanged."),
+        "prose mention should be preserved, got: {program}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Contribute scenarios
 // ---------------------------------------------------------------------------

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -358,6 +358,78 @@ async fn scenario_bootstrap_idempotent() {
     );
 }
 
+#[tokio::test]
+async fn scenario_bootstrap_fixes_upstream_login() {
+    let repo = ScenarioRepo::new("boot-fix-login");
+    repo.init_git();
+
+    let upstream_program = "\
+# Research Program
+
+cli_version: 0.5.2
+lead_github_login: upstream-owner
+maintainer_github_login: upstream-owner
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+
+## Goal
+
+Do stuff.
+
+## What you CAN modify
+
+- `src/`
+
+## What you CANNOT modify
+
+- `PROGRAM.md`
+";
+    fs::write(repo.path.join("PROGRAM.md"), upstream_program).unwrap();
+
+    let github = Arc::new(ScenarioGitHub::new("fork-user"));
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        github,
+        "fork-user",
+        false,
+        Commands::Bootstrap(BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: None,
+            yes: false,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    commands::bootstrap::scaffold(
+        &ctx,
+        &BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: None,
+            yes: false,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .unwrap();
+
+    let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    assert!(
+        program.contains("lead_github_login: fork-user"),
+        "lead login should be updated to fork user, got: {program}"
+    );
+    assert!(
+        program.contains("maintainer_github_login: fork-user"),
+        "maintainer login should be updated to fork user, got: {program}"
+    );
+    assert!(
+        !program.contains("upstream-owner"),
+        "upstream owner should be replaced"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Contribute scenarios
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `polyresearch bootstrap` now resolves the authenticated GitHub user via `ctx.github.current_login()` and writes it directly into `PROGRAM.md` instead of leaving `replace-me` for the agent to guess.
- New `ensure_lead_login()` patches pre-existing `PROGRAM.md` files cloned from upstream repos that already had a different lead configured.
- The bootstrap agent prompt now includes the correct login so the agent cannot overwrite it with the upstream owner.

Fixes a bug where forking a repo and bootstrapping would set `lead_github_login` to the upstream owner (e.g. `motdotla`) instead of the fork owner (e.g. `alanzabihi`), causing `polyresearch lead` to reject with a lead-only guard error.

## Test plan

- [x] `bootstrap_write_templates_substitutes_login` -- verifies new templates get the real login, not `replace-me`
- [x] `scenario_bootstrap_fixes_upstream_login` -- verifies pre-existing PROGRAM.md from upstream gets corrected
- [x] All 217 existing tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `bootstrap` scaffolding/template generation and test updates, with straightforward string substitutions and line-level patching of `PROGRAM.md`. Main risk is accidentally rewriting `PROGRAM.md` login lines in unexpected formats, mitigated by new scenario/e2e coverage.
> 
> **Overview**
> `polyresearch bootstrap` now resolves the authenticated GitHub login via `ctx.github.current_login()` and threads it through scaffolding to **write the correct `lead_github_login`/`maintainer_github_login` into `PROGRAM.md`** instead of leaving placeholders.
> 
> When bootstrapping repos that already contain a `PROGRAM.md` from an upstream owner, a new `ensure_lead_login` step rewrites only the `lead_github_login` and `maintainer_github_login` config lines to the current user, and the setup-agent prompt explicitly instructs the agent to keep those exact values. Tests were updated and expanded to assert login substitution and upstream-login correction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54401c25708ba3274245529f9e40cca30a28ec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->