### PR TITLE
Fix contribute loop: guard auto-submit for resolved theses and run inline lead duties

### DIFF
--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -113,10 +113,8 @@ async fn run_iteration(
         if thesis.issue.state != "OPEN" {
             continue;
         }
-        let already_resolved = thesis.pull_requests.iter().any(|pr| {
-            pr.pr.state == "MERGED" || pr.decision.is_some()
-        });
-        if already_resolved {
+        let has_merged_pr = thesis.pull_requests.iter().any(|pr| pr.pr.state == "MERGED");
+        if has_merged_pr {
             continue;
         }
         let has_improved = thesis.attempts.iter().any(|a| {

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -110,6 +110,15 @@ async fn run_iteration(
         if !thesis.is_claimed_by(node_id) {
             continue;
         }
+        if thesis.issue.state != "OPEN" {
+            continue;
+        }
+        let already_resolved = thesis.pull_requests.iter().any(|pr| {
+            pr.pr.state == "MERGED" || pr.decision.is_some()
+        });
+        if already_resolved {
+            continue;
+        }
         let has_improved = thesis.attempts.iter().any(|a| {
             a.observation == Observation::Improved
                 && thesis
@@ -162,6 +171,30 @@ async fn run_iteration(
         repo_state = RepositoryState::derive(&ctx.github, config).await?;
     }
 
+    let is_lead = ctx
+        .config
+        .lead_github_login
+        .as_deref()
+        .map(|lead| {
+            ctx.github
+                .current_login()
+                .map(|l| l == lead)
+                .unwrap_or(false)
+        })
+        .unwrap_or(false);
+    if is_lead && !ctx.cli.dry_run {
+        if let Err(e) = crate::commands::lead::sync_if_stale(ctx, &repo_state, default_branch) {
+            eprintln!("Warning: lead sync failed: {e}");
+        }
+        if let Err(e) = crate::commands::lead::policy_check_open_prs(ctx, &repo_state) {
+            eprintln!("Warning: lead policy-check failed: {e}");
+        }
+        let updated = RepositoryState::derive(&ctx.github, config).await?;
+        if let Err(e) = crate::commands::lead::decide_ready_prs(ctx, config, &updated) {
+            eprintln!("Warning: lead decide failed: {e}");
+        }
+        repo_state = RepositoryState::derive(&ctx.github, config).await?;
+    }
     let duty_report = crate::commands::duties::check(ctx, &repo_state)?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -73,7 +73,7 @@ async fn run_iteration(
     Ok(())
 }
 
-fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch: &str) -> Result<()> {
+pub fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch: &str) -> Result<()> {
     let ledger = Ledger::load(&ctx.repo_root)?;
     if ledger.is_current(repo_state) {
         return Ok(());
@@ -111,7 +111,7 @@ fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch:
     Ok(())
 }
 
-fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> Result<()> {
+pub fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> Result<()> {
     for thesis in &repo_state.theses {
         for pr_state in &thesis.pull_requests {
             if pr_state.pr.state != "OPEN" || pr_state.policy_pass || pr_state.decision.is_some() {
@@ -172,7 +172,7 @@ fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> Resu
     Ok(())
 }
 
-fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &RepositoryState) -> Result<()> {
+pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &RepositoryState) -> Result<()> {
     let required = config.required_confirmations as usize;
 
     let ledger = if config.required_confirmations == 0 {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -239,11 +239,31 @@ impl GitHubApi for MockGitHubClient {
     }
 
     fn list_pull_request_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>> {
-        Ok(self
+        let mut comments = self
             .pr_comments
             .get(&pr_number)
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        let latest = comments
+            .iter()
+            .map(|c| c.created_at)
+            .max()
+            .unwrap_or_else(chrono::Utc::now);
+        let posted = self.posted_issue_comments.lock().unwrap();
+        for (idx, (num, body)) in posted.iter().enumerate() {
+            if *num == pr_number {
+                comments.push(IssueComment {
+                    id: 60_000 + idx as u64,
+                    body: body.clone(),
+                    user: CommentUser {
+                        login: self.current_login.clone(),
+                    },
+                    created_at: latest + chrono::Duration::seconds(1 + idx as i64),
+                    updated_at: None,
+                });
+            }
+        }
+        Ok(comments)
     }
 
     fn list_pull_request_files(&self, pr_number: u64) -> Result<Vec<PullRequestFile>> {
@@ -2195,6 +2215,161 @@ async fn contribute_blocks_on_non_submit_duties() {
     }).await;
 
     assert!(result.is_ok() || result.unwrap_err().to_string().contains("blocking"));
+}
+
+#[tokio::test]
+async fn contribute_skips_auto_submit_for_closed_thesis_with_merged_pr() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("contribute-skip-closed");
+    init_git_repo(&repo.path);
+    write_node_config(&repo.path, "test-node");
+    write_program_md(&repo.path);
+    set_node_id_env("test-node");
+
+    let fixture = load_issue_fixture("improved_no_submit_issue.json");
+    let mut closed_issue = fixture.issue.clone();
+    closed_issue.state = "CLOSED".to_string();
+    closed_issue.closed_at = Some(chrono::Utc::now());
+
+    let merged_pr = PullRequest {
+        number: 7,
+        title: format!("Thesis #{}: merged", closed_issue.number),
+        body: Some(format!("References #{}", closed_issue.number)),
+        state: "MERGED".to_string(),
+        head_ref_name: format!("thesis/{}-test-slug", closed_issue.number),
+        head_ref_oid: Some("abc123".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: Some(chrono::Utc::now()),
+        merged_at: Some(chrono::Utc::now()),
+        author: Some(polyresearch::github::Author {
+            login: "alice".to_string(),
+        }),
+        url: None,
+        mergeable: None,
+    };
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![closed_issue.clone()],
+        HashMap::from([(closed_issue.number, fixture.comments.clone())]),
+        vec![merged_pr],
+        HashMap::new(),
+    ));
+
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "contribute should succeed without attempting auto-submit on closed thesis, got: {:?}",
+        result.unwrap_err()
+    );
+}
+
+#[tokio::test]
+async fn contribute_runs_inline_lead_duties_for_policy_check() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("contribute-inline-lead");
+    init_git_repo(&repo.path);
+    write_node_config(&repo.path, "test-node");
+    write_program_md(&repo.path);
+    set_node_id_env("test-node");
+
+    let fixture = load_issue_fixture("improved_no_submit_issue.json");
+
+    let open_pr = PullRequest {
+        number: 10,
+        title: format!("Thesis #{}: test", fixture.issue.number),
+        body: Some(format!("References #{}", fixture.issue.number)),
+        state: "OPEN".to_string(),
+        head_ref_name: format!("thesis/{}-test-slug", fixture.issue.number),
+        head_ref_oid: Some("def456".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: Some(polyresearch::github::Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+        mergeable: None,
+    };
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![open_pr],
+        HashMap::new(),
+    ));
+
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    let posted = mock.posted_issue_comments.lock().unwrap();
+    let policy_pass_posted = posted
+        .iter()
+        .any(|(_, body)| body.contains("polyresearch:policy-pass"));
+    assert!(
+        policy_pass_posted,
+        "inline lead duties should have posted a policy-pass comment, posted: {:?}",
+        *posted
+    );
+
+    if let Err(err) = result {
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("policy-check"),
+            "contribute should not block on policy-check when running as lead, got: {msg}"
+        );
+    }
 }
 
 // --- Config tests ---


### PR DESCRIPTION
## Summary

- Auto-submit no longer retries theses whose issue is closed or that already have a merged/decided PR, fixing the infinite "No commits between master and..." retry loop.
- When the contributor is also the lead, policy-check, decide, and sync duties are executed inline before the blocking-duty check, preventing the "[policy-check] PR #N: open without policy-check" stall.
- Mock `list_pull_request_comments` now merges dynamically posted comments, matching real GitHub behavior.

## Test plan

- [x] `contribute_skips_auto_submit_for_closed_thesis_with_merged_pr` — verifies auto-submit is skipped for closed issues with merged PRs
- [x] `contribute_runs_inline_lead_duties_for_policy_check` — verifies policy-pass is posted inline and the loop does not block on policy-check
- [x] Full `cargo test` suite passes (220 tests, 0 failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contribute-loop control flow to skip resolved work and to execute lead-only actions automatically when authenticated as lead, which can affect PR/issue state and git pushes if mis-triggered. Test coverage was updated, but the new inline lead path and auto-submit guards could still change runtime behavior in production repos.
> 
> **Overview**
> Fixes the `contribute` loop to **skip auto-submit** for theses that are no longer actionable (non-`OPEN` issues and any thesis that already has a `MERGED` PR), avoiding repeated “no commits between …” retry behavior.
> 
> When the current GitHub user matches `lead_github_login`, `contribute` now runs lead duties inline (sync stale `results.tsv`, policy-check open PRs, and decide ready PRs) *before* enforcing blocking duties, preventing the loop from stalling on lead-only duty items.
> 
> Updates the e2e GitHub mock to return dynamically posted PR comments (matching issue-comment behavior), and adds tests covering the new skip/inline-lead behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb860b4ee74d1a58acdb46788e8e428100416c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->