### PR TITLE
Fix batch-claim and duties to allow reclaim after infra_failure release

### DIFF
--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -5,6 +5,7 @@ use crate::cli::BatchClaimArgs;
 use crate::commands::claim::{ClaimOutput, claim_selected_thesis};
 use crate::commands::duties;
 use crate::commands::{AppContext, node_active_claims, print_value, read_node_id};
+use crate::comments::ReleaseReason;
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
 
 #[derive(Debug, Serialize)]
@@ -131,7 +132,12 @@ fn select_claimable_theses<'a>(
         .filter(|thesis| thesis.approved)
         .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
         .filter(|thesis| thesis.active_claims.is_empty())
-        .filter(|thesis| !thesis.releases.iter().any(|release| release.node == node))
+        .filter(|thesis| {
+            !thesis
+                .releases
+                .iter()
+                .any(|release| release.node == node && release.reason == ReleaseReason::NoImprovement)
+        })
         .collect::<Vec<_>>();
     theses.sort_by_key(|thesis| thesis.issue.number);
     theses.truncate(count);

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::Result;
 use serde::Serialize;
 
 use crate::commands::{AppContext, print_value, read_node_id};
-use crate::comments::Observation;
+use crate::comments::{Observation, ReleaseReason};
 use crate::ledger::Ledger;
 use crate::state::{RepositoryState, ThesisPhase};
 
@@ -344,7 +344,7 @@ fn check_contributor_idle_state(
                 && !thesis
                     .releases
                     .iter()
-                    .any(|release| release.node == node_id)
+                    .any(|release| release.node == node_id && release.reason == ReleaseReason::NoImprovement)
         })
         .count();
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1390,14 +1390,14 @@ async fn duties_reports_no_claimable_work_when_all_theses_were_released_by_node(
     let mut thesis_one = make_approved_thesis(1);
     thesis_one.releases.push(ReleaseRecord {
         node: "node-a".to_string(),
-        reason: ReleaseReason::InfraFailure,
+        reason: ReleaseReason::NoImprovement,
         created_at: chrono::Utc::now(),
     });
 
     let mut thesis_two = make_approved_thesis(2);
     thesis_two.releases.push(ReleaseRecord {
         node: "node-a".to_string(),
-        reason: ReleaseReason::Timeout,
+        reason: ReleaseReason::NoImprovement,
         created_at: chrono::Utc::now(),
     });
 


### PR DESCRIPTION
## Summary

- Fix `select_claimable_theses` in `batch_claim.rs` to only filter out `no_improvement` releases (not `infra_failure` or `timeout`)
- Fix `check_contributor_idle_state` in `duties.rs` with the same predicate correction
- Update existing e2e test that relied on the buggy behavior to use `NoImprovement` releases

## Spec reference

> A thesis is claimable by a node when ALL of these are true:
> - The node has not previously released the thesis with `no_improvement` (infra_failure releases do NOT permanently blacklist -- the node can retry after the infra issue is resolved)

The correct predicate already existed in `contribute.rs`; this PR aligns `batch_claim.rs` and `duties.rs` to match.

Closes #87

## Test plan

- [x] `cargo check` passes
- [x] All 218 existing tests pass (134 unit + 69 e2e + 15 scenarios)
- Expect `batch_claim_allows_reclaim_after_infra_failure_release` and `duties_counts_infra_failure_released_thesis_as_claimable` from PR #85 to pass once that branch rebases onto this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts claimability predicates used by `batch-claim` and `duties`, which can change what work nodes pick up and when they become “idle”; mistakes here could lead to duplicate/undesired retries or reduced throughput.
> 
> **Overview**
> Aligns claimability logic in `batch_claim` and `duties` to **only** treat prior releases with reason `NoImprovement` as a per-node blacklist, allowing nodes to re-claim theses they previously released due to `InfraFailure`/`Timeout`.
> 
> Updates the affected e2e test fixture to use `NoImprovement` releases to match the corrected behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014d46af71f524ef4c80521e1600f241114ed0f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->