### PR TITLE
Stop filtering submit duties from contribute blocking check

### DIFF
--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -162,15 +162,10 @@ async fn run_iteration(
         repo_state = RepositoryState::derive(&ctx.github, config).await?;
     }
 
-    // Check for non-submit blocking duties.
     let duty_report = crate::commands::duties::check(ctx, &repo_state)?;
-    let non_submit_blocking: Vec<_> = duty_report
-        .blocking
-        .iter()
-        .filter(|d| d.category != "submit")
-        .collect();
-    if !non_submit_blocking.is_empty() {
-        let items: Vec<String> = non_submit_blocking
+    if !duty_report.blocking.is_empty() {
+        let items: Vec<String> = duty_report
+            .blocking
             .iter()
             .map(|d| format!("  [{}] {}", d.category, d.message))
             .collect();


### PR DESCRIPTION
## Summary

- Remove the `submit` category filter from the blocking duty check in `contribute.rs` so that unresolved submit duties properly block the contribute loop after a failed auto-submit.
- After auto-submit, the code re-derives state, which naturally clears resolved submit duties. The filter was redundant for the success path and incorrect for the failure path (silently ignoring persistent submit duties).

Fixes #89

Depends on `e2e-scenario-tests` (#85) for the `contribute_once_errors_on_unresolvable_submit_duty` test.

## Test plan

- [x] `cargo check` passes
- [x] All 134 unit tests pass
- [x] All 69 e2e tests pass
- [x] All 15 scenario tests pass
- [ ] `contribute_once_errors_on_unresolvable_submit_duty` passes after #85 merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logic change in the `contribute` duty gate; low risk but may cause `contribute` to stop/retry more often when submit-related duties remain unresolved.
> 
> **Overview**
> `contribute` now considers **all** blocking duties (including `submit`) when deciding whether to continue an iteration, instead of filtering out `submit`-category blockers.
> 
> This makes a failed auto-submit correctly halt/retry (or error in `--once`) until submit duties are resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 235587f698762abc873acdea99abda84f2fa3990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->