### PR TITLE
Bump version to v0.5.3

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -14,7 +14,7 @@ assignment_timeout: 24h
 review_timeout: 12h
 min_queue_depth: 5
 max_queue_depth: 10
-cli_version: 0.5.2
+cli_version: 0.5.3
 
 ## Goal
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "polyresearch"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyresearch"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "Distributed autoresearch across multiple machines and contributors"
 license = "MIT"

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -366,7 +366,7 @@ async fn scenario_bootstrap_fixes_upstream_login() {
     let upstream_program = "\
 # Research Program
 
-cli_version: 0.5.2
+cli_version: 0.5.3
 lead_github_login: upstream-owner
 maintainer_github_login: upstream-owner
 metric_tolerance: 0.01
@@ -438,7 +438,7 @@ async fn scenario_bootstrap_login_fix_does_not_clobber_prose() {
     let program_with_prose = "\
 # Research Program
 
-cli_version: 0.5.2
+cli_version: 0.5.3
 lead_github_login: upstream-owner
 maintainer_github_login: upstream-owner
 metric_tolerance: 0.01


### PR DESCRIPTION
## Summary
- Bumps CLI version from 0.5.2 to 0.5.3 in `Cargo.toml`, `Cargo.lock`, `PROGRAM.md`, and test fixtures in `scenarios.rs`.

## Test plan
- [x] Full unit test suite passes (134/134)
- [x] Scenario tests pass (26/26)
- [x] E2E tests pass (103/104, 4 ignored; 1 pre-existing failure unrelated to version bump)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump only; no logic changes beyond updating version strings in config, crate metadata, lockfile, and test fixtures.
> 
> **Overview**
> Updates all version references from `0.5.2` to `0.5.3`, including `PROGRAM.md`’s `cli_version`, the Rust crate version in `cli/Cargo.toml`/`cli/Cargo.lock`, and the hardcoded `cli_version` strings in scenario tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df5eb877aa11d03d1ff3619014b2f6ded5f0b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->