### PR TITLE
Fix hardcoded 'main' branch across all CLI code paths

### DIFF
--- a/cli/prompts/template-program.md
+++ b/cli/prompts/template-program.md
@@ -1,6 +1,7 @@
 # Research Program
 
 cli_version: {{VERSION}}
+default_branch: {{DEFAULT_BRANCH}}
 lead_github_login: replace-me
 maintainer_github_login: replace-me
 metric_tolerance: 0.01

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -209,7 +209,10 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>, login: &str) -> Res
     let program_path = repo_root.join("PROGRAM.md");
     if !program_path.exists() {
         let base = include_str!("../../prompts/template-program.md");
-        let versioned = base.replace("{{VERSION}}", env!("CARGO_PKG_VERSION"));
+        let detected_branch = detect_default_branch(repo_root);
+        let versioned = base
+            .replace("{{VERSION}}", env!("CARGO_PKG_VERSION"))
+            .replace("{{DEFAULT_BRANCH}}", &detected_branch);
         let with_login = versioned
             .replace(
                 "lead_github_login: replace-me",
@@ -396,6 +399,39 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
         Err(err) => eprintln!("Committed setup files locally. Push failed (run `git push` manually): {err}"),
     }
     Ok(())
+}
+
+fn detect_default_branch(repo_root: &Path) -> String {
+    let output = Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+        .current_dir(repo_root)
+        .output()
+        .ok();
+    if let Some(output) = output {
+        if output.status.success() {
+            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let branch = branch.strip_prefix("origin/").unwrap_or(&branch).to_string();
+            if !branch.is_empty() {
+                return branch;
+            }
+        }
+    }
+
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(repo_root)
+        .output()
+        .ok();
+    if let Some(output) = output {
+        if output.status.success() {
+            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !branch.is_empty() {
+                return branch;
+            }
+        }
+    }
+
+    "main".to_string()
 }
 
 pub fn normalize_program_md(repo_root: &Path) -> Result<()> {

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -402,36 +402,7 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
 }
 
 fn detect_default_branch(repo_root: &Path) -> String {
-    let output = Command::new("git")
-        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-        .current_dir(repo_root)
-        .output()
-        .ok();
-    if let Some(output) = output {
-        if output.status.success() {
-            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let branch = branch.strip_prefix("origin/").unwrap_or(&branch).to_string();
-            if !branch.is_empty() {
-                return branch;
-            }
-        }
-    }
-
-    let output = Command::new("git")
-        .args(["branch", "--show-current"])
-        .current_dir(repo_root)
-        .output()
-        .ok();
-    if let Some(output) = output {
-        if output.status.success() {
-            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !branch.is_empty() {
-                return branch;
-            }
-        }
-    }
-
-    "main".to_string()
+    crate::config::detect_default_branch_from_git(repo_root)
 }
 
 pub fn normalize_program_md(repo_root: &Path) -> Result<()> {

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -83,8 +83,9 @@ pub(crate) fn claim_selected_thesis(
                 .to_string();
         (branch, worktree_path)
     } else {
+        let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
         let workspace =
-            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title)?;
+            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title, &default_branch)?;
         (
             workspace.branch,
             workspace.worktree_path.display().to_string(),

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -157,7 +157,8 @@ pub(crate) fn decide_with_peer_review(
     }
 
     let tolerance = ctx.config.tolerance()?;
-    let main_head = crate::commands::run_git(&ctx.repo_root, &["rev-parse", "main"])?;
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+    let main_head = crate::commands::run_git(&ctx.repo_root, &["rev-parse", &default_branch])?;
     if pr_state
         .reviews
         .iter()

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -91,12 +91,12 @@ pub fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_bra
     }
 
     let current = commands::current_branch(&ctx.repo_root)?;
-    if current != default_branch && current != "main" {
+    if current != default_branch {
         eprintln!("Warning: not on {default_branch} branch, skipping sync commit");
         return Ok(());
     }
 
-    commands::run_git(&ctx.repo_root, &["pull", "--rebase"])?;
+    commands::run_git(&ctx.repo_root, &["pull", "origin", default_branch, "--ff-only"])?;
 
     let mut ledger = Ledger::load(&ctx.repo_root)?;
     let missing = ledger.missing_rows(repo_state);

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -240,6 +240,7 @@ pub fn create_thesis_worktree(
     repo_root: &PathBuf,
     issue_number: u64,
     title: &str,
+    default_branch: &str,
 ) -> Result<ThesisWorkspace> {
     let slug = slugify(title);
     let branch = format!("thesis/{issue_number}-{slug}");
@@ -267,7 +268,7 @@ pub fn create_thesis_worktree(
     let worktree_path_arg = worktree_path.to_string_lossy().into_owned();
     run_git(
         repo_root,
-        &["worktree", "add", "-b", &branch, &worktree_path_arg, "main"],
+        &["worktree", "add", "-b", &branch, &worktree_path_arg, default_branch],
     )?;
 
     Ok(ThesisWorkspace {

--- a/cli/src/commands/review.rs
+++ b/cli/src/commands/review.rs
@@ -33,7 +33,8 @@ pub async fn run(ctx: &AppContext, args: &ReviewArgs) -> Result<()> {
         .head_ref_oid
         .clone()
         .ok_or_else(|| eyre!("PR #{} does not expose a head SHA", args.pr))?;
-    let base_sha = run_git(&ctx.repo_root, &["merge-base", "main", &candidate_sha])?;
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+    let base_sha = run_git(&ctx.repo_root, &["merge-base", &default_branch, &candidate_sha])?;
     let env_sha = compute_env_sha(&ctx.repo_root.join(".polyresearch"))?;
 
     let comment = ProtocolComment::Review {

--- a/cli/src/commands/submit.rs
+++ b/cli/src/commands/submit.rs
@@ -44,6 +44,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         push_current_branch(&ctx.repo_root)?;
     }
 
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
     let pr = if ctx.cli.dry_run {
         None
     } else {
@@ -60,7 +61,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
                     args.issue, improved_attempt.metric, improved_attempt.summary
                 ),
             },
-            "main",
+            &default_branch,
         )?)
     };
 

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -19,8 +19,9 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     let missing_rows = ledger.missing_rows(&repo_state);
 
     if !ctx.cli.dry_run && !missing_rows.is_empty() {
-        if current_branch(&ctx.repo_root)? != "main" {
-            return Err(eyre!("`polyresearch sync` must run from the `main` branch"));
+        let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+        if current_branch(&ctx.repo_root)? != default_branch {
+            return Err(eyre!("`polyresearch sync` must run from the `{default_branch}` branch"));
         }
         ledger.append_rows(&missing_rows)?;
         commit_file(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -397,18 +397,29 @@ impl ProtocolConfig {
         if let Some(branch) = &self.default_branch {
             return Ok(branch.clone());
         }
-        let output = std::process::Command::new("git")
-            .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-            .current_dir(repo_root)
-            .output()
-            .wrap_err("failed to detect default branch")?;
-        if output.status.success() {
-            let branch = String::from_utf8(output.stdout)?.trim().to_string();
-            let branch = branch.strip_prefix("origin/").unwrap_or(&branch).to_string();
-            return Ok(branch);
-        }
-        Ok("main".to_string())
+        Ok(detect_default_branch_from_git(repo_root))
     }
+}
+
+/// Detect the repository's default branch from git remote metadata.
+/// Checks `refs/remotes/origin/HEAD` first, then falls back to `"main"`.
+pub fn detect_default_branch_from_git(repo_root: &Path) -> String {
+    let output = std::process::Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+        .current_dir(repo_root)
+        .output()
+        .ok();
+    if let Some(output) = output {
+        if output.status.success() {
+            let raw = String::from_utf8_lossy(&output.stdout);
+            let branch = raw.trim();
+            let branch = branch.strip_prefix("origin/").unwrap_or(branch);
+            if !branch.is_empty() {
+                return branch.to_string();
+            }
+        }
+    }
+    "main".to_string()
 }
 
 #[derive(Debug, Clone)]

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -42,23 +42,35 @@ impl ScenarioRepo {
     }
 
     fn init_git(&self) {
+        self.init_git_on_branch("main");
+    }
+
+    fn init_git_on_branch(&self, branch: &str) {
         run_git(&self.path, &["init"]);
         run_git(&self.path, &["config", "user.name", "Test"]);
         run_git(&self.path, &["config", "user.email", "test@test.com"]);
         fs::write(self.path.join("README.md"), "test\n").unwrap();
         run_git(&self.path, &["add", "README.md"]);
         run_git(&self.path, &["commit", "-m", "init"]);
-        run_git(&self.path, &["branch", "-M", "main"]);
+        run_git(&self.path, &["branch", "-M", branch]);
     }
 
     fn write_program_md(&self, lead: &str) {
+        self.write_program_md_with_branch(lead, None);
+    }
+
+    fn write_program_md_with_branch(&self, lead: &str, default_branch: Option<&str>) {
+        let branch_line = match default_branch {
+            Some(b) => format!("default_branch: {b}\n"),
+            None => String::new(),
+        };
         fs::write(
             self.path.join("PROGRAM.md"),
             format!(
                 r#"# Research Program
 
 cli_version: {version}
-lead_github_login: {lead}
+{branch_line}lead_github_login: {lead}
 maintainer_github_login: {lead}
 metric_tolerance: 0.01
 metric_direction: higher_is_better
@@ -2224,4 +2236,238 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
         "should have exactly one unique decision comment on PR #163, found {}: {:?}",
         unique_decisions.len(), unique_decisions
     );
+}
+
+// ---------------------------------------------------------------------------
+// Default branch scenarios (issue #95)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_sync_accepts_master_default_branch() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("sync-master");
+    repo.init_git_on_branch("master");
+    repo.write_program_md_with_branch("lead", Some("master"));
+    repo.write_prepare_md();
+    repo.write_results_tsv();
+    repo.write_node_config("test-node", "echo noop");
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Sync,
+    );
+
+    let result = commands::sync::run(&ctx).await;
+    assert!(result.is_ok(), "sync should succeed on master with default_branch: master: {result:?}");
+}
+
+#[tokio::test]
+async fn scenario_sync_rejects_wrong_branch_with_config() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("sync-wrong-branch");
+    repo.init_git_on_branch("master");
+    repo.write_program_md_with_branch("lead", Some("master"));
+    repo.write_prepare_md();
+    repo.write_results_tsv();
+    repo.write_node_config("test-node", "echo noop");
+    repo.commit_all("setup");
+
+    run_git(&repo.path, &["checkout", "-b", "feature-branch"]);
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 1,
+        title: "Test thesis".to_string(),
+        body: Some("Test".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label { name: "thesis".to_string() }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author { login: "lead".to_string() }),
+        url: None,
+    };
+    let approval_comment = IssueComment {
+        id: 100,
+        body: ProtocolComment::Approval { thesis: 1 }.render(),
+        user: CommentUser { login: "lead".to_string() },
+        created_at: now - chrono::Duration::hours(1),
+        updated_at: None,
+    };
+    let claim_comment = IssueComment {
+        id: 101,
+        body: ProtocolComment::Claim { thesis: 1, node: "worker".to_string() }.render(),
+        user: CommentUser { login: "contrib".to_string() },
+        created_at: now - chrono::Duration::minutes(50),
+        updated_at: None,
+    };
+    let attempt_comment = IssueComment {
+        id: 102,
+        body: ProtocolComment::Attempt {
+            thesis: 1,
+            branch: "thesis/1-test".to_string(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Test".to_string(),
+            annotations: None,
+        }.render(),
+        user: CommentUser { login: "contrib".to_string() },
+        created_at: now - chrono::Duration::minutes(40),
+        updated_at: None,
+    };
+
+    let pr = PullRequest {
+        number: 2,
+        title: "Thesis #1: Test thesis".to_string(),
+        body: Some("References #1".to_string()),
+        state: "MERGED".to_string(),
+        head_ref_name: "thesis/1-test".to_string(),
+        head_ref_oid: Some("abc".to_string()),
+        base_ref_name: Some("master".to_string()),
+        created_at: now - chrono::Duration::minutes(30),
+        closed_at: None,
+        merged_at: Some(now - chrono::Duration::minutes(20)),
+        author: Some(Author { login: "contrib".to_string() }),
+        url: None,
+        mergeable: None,
+    };
+    let policy_pass_comment = IssueComment {
+        id: 199,
+        body: ProtocolComment::PolicyPass {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+        }.render(),
+        user: CommentUser { login: "lead".to_string() },
+        created_at: now - chrono::Duration::minutes(18),
+        updated_at: None,
+    };
+    let decision_comment = IssueComment {
+        id: 200,
+        body: ProtocolComment::Decision {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+            outcome: polyresearch::comments::Outcome::Accepted,
+            confirmations: 0,
+        }.render(),
+        user: CommentUser { login: "lead".to_string() },
+        created_at: now - chrono::Duration::minutes(15),
+        updated_at: None,
+    };
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(1, vec![approval_comment, claim_comment, attempt_comment]);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(2, vec![policy_pass_comment, decision_comment]);
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Sync,
+    );
+
+    let result = commands::sync::run(&ctx).await;
+    assert!(result.is_err(), "sync should reject when not on default branch");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("master"), "error should mention 'master' branch, got: {err_msg}");
+}
+
+#[test]
+fn create_thesis_worktree_uses_config_default_branch() {
+    let repo = ScenarioRepo::new("worktree-master");
+    repo.init_git_on_branch("master");
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// test\n").unwrap();
+    run_git(&repo.path, &["add", "-A"]);
+    run_git(&repo.path, &["commit", "-m", "add src"]);
+
+    let workspace = commands::create_thesis_worktree(
+        &repo.path,
+        99,
+        "Test worktree on master",
+        "master",
+    )
+    .unwrap();
+
+    assert!(workspace.worktree_path.exists(), "worktree should exist");
+    assert!(workspace.branch.starts_with("thesis/99-"), "branch should have thesis prefix");
+
+    let worktree_branch = commands::current_branch(&workspace.worktree_path).unwrap();
+    assert_eq!(worktree_branch, workspace.branch, "worktree should be on thesis branch");
+
+    let _ = commands::run_git(&repo.path, &[
+        "worktree", "remove", "--force",
+        &workspace.worktree_path.to_string_lossy(),
+    ]);
+}
+
+#[tokio::test]
+async fn scenario_bootstrap_writes_default_branch() {
+    let repo = ScenarioRepo::new("boot-default-branch");
+    repo.init_git_on_branch("master");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        github,
+        "lead",
+        false,
+        Commands::Bootstrap(BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: Some("Test goal".to_string()),
+            yes: false,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    commands::bootstrap::scaffold(
+        &ctx,
+        &BootstrapArgs {
+            url: "https://github.com/test/repo".to_string(),
+            fork: None,
+            no_fork: true,
+            goal: Some("Test goal".to_string()),
+            yes: false,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .unwrap();
+
+    let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    assert!(
+        program.contains("default_branch:"),
+        "PROGRAM.md should contain default_branch field, got:\n{program}"
+    );
+}
+
+#[test]
+fn resolve_default_branch_returns_config_value() {
+    let repo = ScenarioRepo::new("resolve-config");
+    repo.init_git_on_branch("master");
+    repo.write_program_md_with_branch("lead", Some("master"));
+
+    let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
+    let branch = config.resolve_default_branch(&repo.path).unwrap();
+    assert_eq!(branch, "master", "should return config value");
+}
+
+#[test]
+fn resolve_default_branch_falls_back_to_main() {
+    let repo = ScenarioRepo::new("resolve-fallback");
+    repo.init_git_on_branch("main");
+    repo.write_program_md("lead");
+
+    let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
+    let branch = config.resolve_default_branch(&repo.path).unwrap();
+    assert_eq!(branch, "main", "should fall back to 'main' when not set and git detection unavailable");
 }


### PR DESCRIPTION
## Summary

Fixes #95

- Replace every hardcoded `"main"` branch reference with `resolve_default_branch()` across 7 code paths: `sync.rs`, `lead.rs` (branch check + git pull), `mod.rs` (worktree creation), `submit.rs` (PR base), `review.rs` (merge-base), and `decide.rs` (rev-parse for peer review staleness)
- Change `sync_if_stale` git pull from bare `git pull --rebase` to explicit `git pull origin <branch> --ff-only` to prevent "Cannot rebase onto multiple branches" failures when thesis worktree branches exist
- Enhance bootstrap to detect the repo's actual default branch and write `default_branch` into generated PROGRAM.md files

## Test plan

- [x] `scenario_sync_accepts_master_default_branch` -- sync succeeds on a repo using `master` with `default_branch: master` in PROGRAM.md
- [x] `scenario_sync_rejects_wrong_branch_with_config` -- sync errors when on a feature branch, and the error message mentions the configured default branch (`master`)
- [x] `create_thesis_worktree_uses_config_default_branch` -- worktree is based off `master` when that is configured
- [x] `scenario_bootstrap_writes_default_branch` -- generated PROGRAM.md contains `default_branch` field
- [x] `resolve_default_branch_returns_config_value` -- config value takes priority
- [x] `resolve_default_branch_falls_back_to_main` -- falls back to `main` when unset
- [x] All 134 unit tests pass, all 32 scenario tests pass, all 103 passing e2e tests continue to pass (1 pre-existing failure unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple git-branch-sensitive flows (syncing, worktrees, PR creation, review/decide validation), so mis-detection or misconfiguration of `default_branch` could break common CLI operations; changes are well-covered by new scenario tests.
> 
> **Overview**
> Removes hardcoded `main` branch assumptions across the CLI by introducing/using `ProtocolConfig::resolve_default_branch()` (with git-remote detection fallback) for sync, worktree creation, PR submission base branch, review merge-base computation, and peer-review staleness checks.
> 
> Bootstrap now writes `default_branch` into generated `PROGRAM.md` (via updated template and branch detection), and `lead` sync switches to an explicit `git pull origin <default_branch> --ff-only` flow. Scenario tests are expanded to cover `master`-default repos and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da769aa4a2711daaef2ebff4a1a559c059f24374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->