### PR TITLE
Recover merge failures via rebase and clean up branches on close

### DIFF
--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -213,11 +213,13 @@ pub struct DecisionExecuted {
     pub confirmations: u64,
 }
 
+/// Rebase the thesis branch onto origin/main and force-push.
+/// Returns the new HEAD SHA on success so callers can update protocol records.
 fn try_rebase_onto_main(
     repo_root: &PathBuf,
     head_ref_name: &str,
     pr_number: u64,
-) -> Result<()> {
+) -> Result<String> {
     run_git(repo_root, &["fetch", "origin", "main", head_ref_name])?;
 
     let temp_dir = std::env::temp_dir().join(format!("poly-rebase-{pr_number}"));
@@ -235,14 +237,15 @@ fn try_rebase_onto_main(
         &["worktree", "add", &temp_path, &remote_ref, "--detach"],
     )?;
 
-    let rebase_result = (|| -> Result<()> {
+    let rebase_result = (|| -> Result<String> {
         run_git(&temp_dir, &["checkout", "-B", head_ref_name, &remote_ref])?;
         run_git(&temp_dir, &["rebase", "origin/main"])?;
+        let new_sha = run_git(&temp_dir, &["rev-parse", "HEAD"])?;
         run_git(
             &temp_dir,
             &["push", "--force-with-lease", "origin", head_ref_name],
         )?;
-        Ok(())
+        Ok(new_sha)
     })();
 
     if rebase_result.is_err() {
@@ -279,6 +282,10 @@ pub fn execute_decision(
 ) -> Result<DecisionExecuted> {
     let result = match outcome {
         Outcome::Accepted => {
+            // Track the effective SHA: stays as-is for direct merge,
+            // updated to the post-rebase SHA if rebase was needed.
+            let mut effective_sha = candidate_sha.clone();
+
             let merge_ok = match github.merge_pull_request(pr_number) {
                 Ok(_) => true,
                 Err(merge_err) => {
@@ -287,15 +294,18 @@ pub fn execute_decision(
                             "Merge of PR #{pr_number} failed ({merge_err:#}), attempting rebase onto main"
                         );
                         match try_rebase_onto_main(root, head_ref_name, pr_number) {
-                            Ok(()) => match github.merge_pull_request(pr_number) {
-                                Ok(_) => true,
-                                Err(retry_err) => {
-                                    eprintln!(
-                                        "Merge retry after rebase failed ({retry_err:#}), falling back to stale"
-                                    );
-                                    false
+                            Ok(new_sha) => {
+                                effective_sha = new_sha;
+                                match github.merge_pull_request(pr_number) {
+                                    Ok(_) => true,
+                                    Err(retry_err) => {
+                                        eprintln!(
+                                            "Merge retry after rebase failed ({retry_err:#}), falling back to stale"
+                                        );
+                                        false
+                                    }
                                 }
-                            },
+                            }
                             Err(rebase_err) => {
                                 eprintln!(
                                     "Rebase failed ({rebase_err:#}), falling back to stale decision"
@@ -315,7 +325,7 @@ pub fn execute_decision(
             if merge_ok {
                 let comment = ProtocolComment::Decision {
                     thesis: thesis_number,
-                    candidate_sha,
+                    candidate_sha: effective_sha,
                     outcome,
                     confirmations,
                 };

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -223,6 +223,12 @@ fn try_rebase_onto_main(
     let temp_dir = std::env::temp_dir().join(format!("poly-rebase-{pr_number}"));
     let temp_path = temp_dir.to_string_lossy().into_owned();
 
+    // Clean up any stale worktree from a prior crash (follows the
+    // cleanup-on-entry pattern used by worker::create_baseline_worktree).
+    let _ = run_git(repo_root, &["worktree", "remove", &temp_path, "--force"]);
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    let _ = run_git(repo_root, &["worktree", "prune"]);
+
     let remote_ref = format!("origin/{head_ref_name}");
     run_git(
         repo_root,

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
@@ -7,7 +8,7 @@ use std::sync::Arc;
 
 use crate::cli::PrArgs;
 use crate::commands::guards::{ensure_current_ledger, ensure_lead, require_decidable_pr};
-use crate::commands::{AppContext, print_value};
+use crate::commands::{AppContext, print_value, run_git};
 use crate::comments::{Observation, Outcome, ProtocolComment};
 use crate::github::GitHubApi;
 use crate::ledger::Ledger;
@@ -62,9 +63,11 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
     let result = if !ctx.cli.dry_run {
         execute_decision(
             &ctx.github,
+            Some(&ctx.repo_root),
             args.pr,
             thesis.issue.number,
             candidate_sha,
+            &pr_state.pr.head_ref_name,
             outcome,
             confirmations,
             ctx.config.required_confirmations,
@@ -210,43 +213,119 @@ pub struct DecisionExecuted {
     pub confirmations: u64,
 }
 
+fn try_rebase_onto_main(
+    repo_root: &PathBuf,
+    head_ref_name: &str,
+    pr_number: u64,
+) -> Result<()> {
+    run_git(repo_root, &["fetch", "origin", "main", head_ref_name])?;
+
+    let temp_dir = std::env::temp_dir().join(format!("poly-rebase-{pr_number}"));
+    let temp_path = temp_dir.to_string_lossy().into_owned();
+
+    let remote_ref = format!("origin/{head_ref_name}");
+    run_git(
+        repo_root,
+        &["worktree", "add", &temp_path, &remote_ref, "--detach"],
+    )?;
+
+    let rebase_result = (|| -> Result<()> {
+        run_git(&temp_dir, &["checkout", "-B", head_ref_name, &remote_ref])?;
+        run_git(&temp_dir, &["rebase", "origin/main"])?;
+        run_git(
+            &temp_dir,
+            &["push", "--force-with-lease", "origin", head_ref_name],
+        )?;
+        Ok(())
+    })();
+
+    if rebase_result.is_err() {
+        let _ = run_git(&temp_dir, &["rebase", "--abort"]);
+    }
+    let _ = run_git(repo_root, &["worktree", "remove", &temp_path, "--force"]);
+    let _ = std::fs::remove_dir_all(&temp_dir);
+
+    rebase_result
+}
+
+fn close_pr_and_cleanup(
+    github: &Arc<dyn GitHubApi>,
+    pr_number: u64,
+    head_ref_name: &str,
+) -> Result<()> {
+    github.close_pull_request(pr_number)?;
+    if let Err(e) = github.delete_ref(head_ref_name) {
+        eprintln!("Failed to delete branch {head_ref_name}: {e:#}");
+    }
+    Ok(())
+}
+
 pub fn execute_decision(
     github: &Arc<dyn GitHubApi>,
+    repo_root: Option<&PathBuf>,
     pr_number: u64,
     thesis_number: u64,
     candidate_sha: String,
+    head_ref_name: &str,
     outcome: Outcome,
     confirmations: u64,
     required_confirmations: u64,
 ) -> Result<DecisionExecuted> {
     let result = match outcome {
         Outcome::Accepted => {
-            match github.merge_pull_request(pr_number) {
-                Ok(_) => {
-                    let comment = ProtocolComment::Decision {
-                        thesis: thesis_number,
-                        candidate_sha,
-                        outcome,
-                        confirmations,
-                    };
-                    github.post_issue_comment(pr_number, &comment.render())?;
-                    github.close_issue(thesis_number)?;
-                    DecisionExecuted { outcome, confirmations }
-                }
+            let merge_ok = match github.merge_pull_request(pr_number) {
+                Ok(_) => true,
                 Err(merge_err) => {
-                    eprintln!(
-                        "Merge of PR #{pr_number} failed ({merge_err:#}), falling back to stale decision"
-                    );
-                    let comment = ProtocolComment::Decision {
-                        thesis: thesis_number,
-                        candidate_sha,
-                        outcome: Outcome::Stale,
-                        confirmations: 0,
-                    };
-                    github.post_issue_comment(pr_number, &comment.render())?;
-                    github.close_pull_request(pr_number)?;
-                    DecisionExecuted { outcome: Outcome::Stale, confirmations: 0 }
+                    if let Some(root) = repo_root {
+                        eprintln!(
+                            "Merge of PR #{pr_number} failed ({merge_err:#}), attempting rebase onto main"
+                        );
+                        match try_rebase_onto_main(root, head_ref_name, pr_number) {
+                            Ok(()) => match github.merge_pull_request(pr_number) {
+                                Ok(_) => true,
+                                Err(retry_err) => {
+                                    eprintln!(
+                                        "Merge retry after rebase failed ({retry_err:#}), falling back to stale"
+                                    );
+                                    false
+                                }
+                            },
+                            Err(rebase_err) => {
+                                eprintln!(
+                                    "Rebase failed ({rebase_err:#}), falling back to stale decision"
+                                );
+                                false
+                            }
+                        }
+                    } else {
+                        eprintln!(
+                            "Merge of PR #{pr_number} failed ({merge_err:#}), falling back to stale decision"
+                        );
+                        false
+                    }
                 }
+            };
+
+            if merge_ok {
+                let comment = ProtocolComment::Decision {
+                    thesis: thesis_number,
+                    candidate_sha,
+                    outcome,
+                    confirmations,
+                };
+                github.post_issue_comment(pr_number, &comment.render())?;
+                github.close_issue(thesis_number)?;
+                DecisionExecuted { outcome, confirmations }
+            } else {
+                let comment = ProtocolComment::Decision {
+                    thesis: thesis_number,
+                    candidate_sha,
+                    outcome: Outcome::Stale,
+                    confirmations: 0,
+                };
+                github.post_issue_comment(pr_number, &comment.render())?;
+                close_pr_and_cleanup(github, pr_number, head_ref_name)?;
+                DecisionExecuted { outcome: Outcome::Stale, confirmations: 0 }
             }
         }
         Outcome::InfraFailure | Outcome::Stale => {
@@ -257,7 +336,7 @@ pub fn execute_decision(
                 confirmations,
             };
             github.post_issue_comment(pr_number, &comment.render())?;
-            github.close_pull_request(pr_number)?;
+            close_pr_and_cleanup(github, pr_number, head_ref_name)?;
             DecisionExecuted { outcome, confirmations }
         }
         Outcome::NonImprovement | Outcome::Disagreement | Outcome::PolicyRejection => {
@@ -268,7 +347,7 @@ pub fn execute_decision(
                 confirmations,
             };
             github.post_issue_comment(pr_number, &comment.render())?;
-            github.close_pull_request(pr_number)?;
+            close_pr_and_cleanup(github, pr_number, head_ref_name)?;
             if required_confirmations > 0 || !matches!(outcome, Outcome::NonImprovement) {
                 github.close_issue(thesis_number)?;
             }

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -225,9 +225,11 @@ pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &
 
             let result = decide::execute_decision(
                 &ctx.github,
+                Some(&ctx.repo_root),
                 pr_state.pr.number,
                 thesis.issue.number,
                 candidate_sha,
+                &pr_state.pr.head_ref_name,
                 outcome,
                 confirmations,
                 config.required_confirmations,

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -150,6 +150,7 @@ pub trait GitHubApi: Send + Sync {
     ) -> Result<PullRequest>;
     fn close_pull_request(&self, pr_number: u64) -> Result<serde_json::Value>;
     fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value>;
+    fn delete_ref(&self, ref_name: &str) -> Result<()>;
 }
 
 impl GitHubClient {
@@ -401,6 +402,21 @@ impl GitHubClient {
         )
     }
 
+    pub fn delete_ref(&self, ref_name: &str) -> Result<()> {
+        let endpoint = format!(
+            "repos/{}/{}/git/refs/heads/{ref_name}",
+            self.repo.owner, self.repo.name
+        );
+        let mut command = Command::new("gh");
+        command
+            .arg("api")
+            .arg("--method")
+            .arg("DELETE")
+            .arg(&endpoint);
+        run_text_command(command, false)?;
+        Ok(())
+    }
+
     fn gh_json_typed<T, const N: usize>(&self, args: [&str; N]) -> Result<T>
     where
         T: DeserializeOwned,
@@ -533,6 +549,10 @@ impl GitHubApi for GitHubClient {
 
     fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
         GitHubClient::merge_pull_request(self, pr_number)
+    }
+
+    fn delete_ref(&self, ref_name: &str) -> Result<()> {
+        GitHubClient::delete_ref(self, ref_name)
     }
 }
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -289,6 +289,10 @@ impl GitHubApi for MockGitHubClient {
         self.merged_prs.lock().unwrap().push(pr_number);
         Ok(serde_json::json!({"merged": true}))
     }
+
+    fn delete_ref(&self, _ref_name: &str) -> Result<()> {
+        Ok(())
+    }
 }
 
 struct TestRepo {

--- a/cli/tests/scenario_mock.rs
+++ b/cli/tests/scenario_mock.rs
@@ -21,6 +21,8 @@ struct ScenarioState {
     closed_prs: Vec<u64>,
     merged_prs: Vec<u64>,
     assigned_issues: Vec<(u64, Vec<String>)>,
+    deleted_refs: Vec<String>,
+    merge_attempt_counts: HashMap<u64, usize>,
 }
 
 #[allow(dead_code)]
@@ -45,6 +47,8 @@ impl ScenarioGitHub {
                 closed_prs: Vec::new(),
                 merged_prs: Vec::new(),
                 assigned_issues: Vec::new(),
+                deleted_refs: Vec::new(),
+                merge_attempt_counts: HashMap::new(),
             }),
         }
     }
@@ -144,6 +148,12 @@ impl ScenarioGitHub {
         if let Some(pr) = s.pull_requests.iter_mut().find(|pr| pr.number == pr_number) {
             pr.mergeable = Some(status.to_string());
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_branch_deleted(&self, branch: &str) -> bool {
+        let s = self.state.lock().unwrap();
+        s.deleted_refs.contains(&branch.to_string())
     }
 
     pub fn comment_bodies_on(&self, issue_or_pr: u64) -> Vec<String> {
@@ -373,8 +383,12 @@ impl GitHubApi for ScenarioGitHub {
 
     fn merge_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
         let mut s = self.state.lock().unwrap();
+        let attempt = s.merge_attempt_counts.entry(pr_number).or_insert(0);
+        *attempt += 1;
+        let current_attempt = *attempt;
+
         if let Some(pr) = s.pull_requests.iter().find(|pr| pr.number == pr_number) {
-            if pr.mergeable.as_deref() == Some("CONFLICTING") {
+            if pr.mergeable.as_deref() == Some("CONFLICTING") && current_attempt <= 1 {
                 return Err(eyre!("405 Method Not Allowed: pull request is not mergeable"));
             }
         }
@@ -384,5 +398,11 @@ impl GitHubApi for ScenarioGitHub {
             pr.merged_at = Some(chrono::Utc::now());
         }
         Ok(serde_json::json!({"merged": true}))
+    }
+
+    fn delete_ref(&self, ref_name: &str) -> Result<()> {
+        let mut s = self.state.lock().unwrap();
+        s.deleted_refs.push(ref_name.to_string());
+        Ok(())
     }
 }

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -922,9 +922,11 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
 
     let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
         70,
         70,
         "sha".to_string(),
+        "thesis/70-test",
         polyresearch::comments::Outcome::NonImprovement,
         0,
         0,
@@ -940,6 +942,10 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
     assert!(
         !github.is_issue_closed(70),
         "thesis should stay open in zero-conf non_improvement"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/70-test"),
+        "branch should be deleted on non_improvement"
     );
 }
 
@@ -964,9 +970,11 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
 
     let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
         71,
         71,
         "sha".to_string(),
+        "thesis/71-test",
         polyresearch::comments::Outcome::Disagreement,
         0,
         0,
@@ -982,6 +990,10 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
     assert!(
         github.is_issue_closed(71),
         "thesis should be closed for disagreement even in zero-conf"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/71-test"),
+        "branch should be deleted on disagreement"
     );
 }
 
@@ -1006,9 +1018,11 @@ fn execute_decision_accepted_merges_and_closes() {
 
     let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
         72,
         72,
         "sha".to_string(),
+        "thesis/72-test",
         polyresearch::comments::Outcome::Accepted,
         0,
         0,
@@ -1180,9 +1194,11 @@ fn execute_decision_falls_back_on_merge_failure() {
 
     let result = commands::decide::execute_decision(
         &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
         73,
         73,
         "sha-conflict".to_string(),
+        "thesis/73-test",
         polyresearch::comments::Outcome::Accepted,
         5,
         0,
@@ -1226,6 +1242,355 @@ fn execute_decision_falls_back_on_merge_failure() {
     assert!(
         !has_accepted,
         "should NOT have posted accepted decision on failed merge"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/73-test"),
+        "branch should be deleted on stale fallback"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Merge recovery and branch cleanup tests (issue #97)
+// ---------------------------------------------------------------------------
+
+/// Set up a bare "remote" and a working clone with a thesis branch that
+/// diverges from an advanced main. Returns (clone_path, bare_path) both
+/// inside the given `parent` directory. The caller owns the `parent`
+/// `ScenarioRepo` whose Drop cleans everything up.
+fn setup_diverged_repo(
+    parent: &ScenarioRepo,
+    conflict: bool,
+) -> (PathBuf, PathBuf) {
+    let bare_path = parent.path.join("remote.git");
+    let clone_path = parent.path.join("work");
+
+    fs::create_dir_all(&bare_path).unwrap();
+    run_git(&bare_path, &["init", "--bare"]);
+
+    // Clone from the parent dir so git creates the "work" subdirectory
+    run_git(
+        &parent.path,
+        &["clone", &bare_path.to_string_lossy(), "work"],
+    );
+    run_git(&clone_path, &["config", "user.name", "Test"]);
+    run_git(&clone_path, &["config", "user.email", "test@test.com"]);
+    fs::write(clone_path.join("README.md"), "initial\n").unwrap();
+    run_git(&clone_path, &["add", "README.md"]);
+    run_git(&clone_path, &["commit", "-m", "init"]);
+    run_git(&clone_path, &["branch", "-M", "main"]);
+    run_git(&clone_path, &["push", "-u", "origin", "main"]);
+
+    // Create thesis branch with changes
+    run_git(&clone_path, &["checkout", "-b", "thesis/99-test"]);
+    if conflict {
+        fs::write(clone_path.join("README.md"), "thesis change\n").unwrap();
+        run_git(&clone_path, &["add", "README.md"]);
+    } else {
+        fs::write(clone_path.join("feature.txt"), "thesis work\n").unwrap();
+        run_git(&clone_path, &["add", "feature.txt"]);
+    }
+    run_git(&clone_path, &["commit", "-m", "thesis work"]);
+    run_git(&clone_path, &["push", "-u", "origin", "thesis/99-test"]);
+
+    // Advance main (simulating another thesis merged)
+    run_git(&clone_path, &["checkout", "main"]);
+    if conflict {
+        fs::write(clone_path.join("README.md"), "main advance conflicts\n").unwrap();
+        run_git(&clone_path, &["add", "README.md"]);
+    } else {
+        fs::write(clone_path.join("other.txt"), "another thesis\n").unwrap();
+        run_git(&clone_path, &["add", "other.txt"]);
+    }
+    run_git(&clone_path, &["commit", "-m", "advance main"]);
+    run_git(&clone_path, &["push", "origin", "main"]);
+
+    (clone_path, bare_path)
+}
+
+#[test]
+fn execute_decision_rebase_and_retry_on_merge_conflict() {
+    let parent = ScenarioRepo::new("rebase-retry");
+    let (clone_path, _bare_path) = setup_diverged_repo(&parent, false);
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_pull_request(PullRequest {
+        number: 80,
+        title: "Candidate".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/99-test".to_string(),
+        head_ref_oid: Some("sha-rebase".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: Some("CONFLICTING".to_string()),
+    });
+
+    let result = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        Some(&clone_path),
+        80,
+        80,
+        "sha-rebase".to_string(),
+        "thesis/99-test",
+        polyresearch::comments::Outcome::Accepted,
+        0,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.outcome,
+        polyresearch::comments::Outcome::Accepted,
+        "PR should be accepted after rebase-and-retry"
+    );
+    assert!(
+        github.is_pr_merged(80),
+        "PR should be merged after successful rebase"
+    );
+    assert!(
+        github.is_issue_closed(80),
+        "thesis should be closed on accepted"
+    );
+    assert!(
+        !github.is_branch_deleted("thesis/99-test"),
+        "branch should NOT be deleted on successful merge"
+    );
+}
+
+#[test]
+fn execute_decision_stale_fallback_when_rebase_fails() {
+    let parent = ScenarioRepo::new("rebase-conflict");
+    let (clone_path, _bare_path) = setup_diverged_repo(&parent, true);
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_pull_request(PullRequest {
+        number: 81,
+        title: "Candidate".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/99-test".to_string(),
+        head_ref_oid: Some("sha-conflict".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: Some("CONFLICTING".to_string()),
+    });
+
+    let result = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        Some(&clone_path),
+        81,
+        81,
+        "sha-conflict".to_string(),
+        "thesis/99-test",
+        polyresearch::comments::Outcome::Accepted,
+        3,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.outcome,
+        polyresearch::comments::Outcome::Stale,
+        "outcome should be Stale when rebase fails due to true conflict"
+    );
+    assert!(
+        !github.is_pr_merged(81),
+        "conflicting PR should NOT be merged"
+    );
+    assert!(
+        github.is_pr_closed(81),
+        "conflicting PR should be closed as stale"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/99-test"),
+        "branch should be deleted on stale fallback"
+    );
+}
+
+#[test]
+fn execute_decision_branch_cleanup_on_non_improvement() {
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_pull_request(PullRequest {
+        number: 82,
+        title: "Candidate".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/82-opt".to_string(),
+        head_ref_oid: Some("sha-noimprov".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: None,
+    });
+
+    let result = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
+        82,
+        82,
+        "sha-noimprov".to_string(),
+        "thesis/82-opt",
+        polyresearch::comments::Outcome::NonImprovement,
+        0,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(result.outcome, polyresearch::comments::Outcome::NonImprovement);
+    assert!(
+        github.is_pr_closed(82),
+        "PR should be closed on non_improvement"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/82-opt"),
+        "remote branch should be deleted on non_improvement so thesis can be retried"
+    );
+
+    // Verify the thesis can create a new PR (branch is gone)
+    let new_pr = github
+        .create_pull_request("thesis/82-opt", "New attempt", "retry", "main")
+        .unwrap();
+    assert!(new_pr.number > 0, "should create a new PR without error");
+}
+
+#[test]
+fn execute_decision_branch_cleanup_on_stale() {
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_pull_request(PullRequest {
+        number: 83,
+        title: "Candidate".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/83-stale".to_string(),
+        head_ref_oid: Some("sha-stale".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: None,
+    });
+
+    let result = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
+        83,
+        83,
+        "sha-stale".to_string(),
+        "thesis/83-stale",
+        polyresearch::comments::Outcome::Stale,
+        0,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(result.outcome, polyresearch::comments::Outcome::Stale);
+    assert!(
+        github.is_pr_closed(83),
+        "PR should be closed on stale"
+    );
+    assert!(
+        github.is_branch_deleted("thesis/83-stale"),
+        "remote branch should be deleted on stale so thesis can be retried"
+    );
+
+    // Verify thesis can create a new PR
+    let new_pr = github
+        .create_pull_request("thesis/83-stale", "New attempt", "retry", "main")
+        .unwrap();
+    assert!(new_pr.number > 0, "should create a new PR without error");
+}
+
+#[test]
+fn execute_decision_concurrent_merge_scenario() {
+    let parent = ScenarioRepo::new("concurrent");
+    let (clone_path, _bare_path) = setup_diverged_repo(&parent, false);
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+
+    // First thesis PR: merges directly (no conflict)
+    github.seed_pull_request(PullRequest {
+        number: 84,
+        title: "First thesis".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/84-first".to_string(),
+        head_ref_oid: Some("sha-first".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: None,
+    });
+
+    // Second thesis PR: CONFLICTING because first thesis advanced main
+    github.seed_pull_request(PullRequest {
+        number: 85,
+        title: "Second thesis".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/99-test".to_string(),
+        head_ref_oid: Some("sha-second".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        merged_at: None,
+        author: None,
+        url: None,
+        mergeable: Some("CONFLICTING".to_string()),
+    });
+
+    // Merge first thesis directly
+    let result1 = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        Some(&clone_path),
+        84,
+        84,
+        "sha-first".to_string(),
+        "thesis/84-first",
+        polyresearch::comments::Outcome::Accepted,
+        0,
+        0,
+    )
+    .unwrap();
+    assert_eq!(result1.outcome, polyresearch::comments::Outcome::Accepted);
+    assert!(github.is_pr_merged(84));
+
+    // Second thesis should succeed via rebase-and-retry
+    let result2 = commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        Some(&clone_path),
+        85,
+        85,
+        "sha-second".to_string(),
+        "thesis/99-test",
+        polyresearch::comments::Outcome::Accepted,
+        0,
+        0,
+    )
+    .unwrap();
+    assert_eq!(
+        result2.outcome,
+        polyresearch::comments::Outcome::Accepted,
+        "second thesis should be accepted via rebase-and-retry, not discarded as stale"
+    );
+    assert!(
+        github.is_pr_merged(85),
+        "second PR should be merged after rebase"
     );
 }
 

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -1359,6 +1359,18 @@ fn execute_decision_rebase_and_retry_on_merge_conflict() {
         !github.is_branch_deleted("thesis/99-test"),
         "branch should NOT be deleted on successful merge"
     );
+
+    // Verify the Decision comment records the post-rebase SHA, not the
+    // stale pre-rebase placeholder.
+    let pr_bodies = github.comment_bodies_on(80);
+    let decision_body = pr_bodies
+        .iter()
+        .find(|b| b.contains("polyresearch:decision"))
+        .expect("should have posted a decision comment");
+    assert!(
+        !decision_body.contains("sha-rebase"),
+        "decision comment should contain the post-rebase SHA, not the stale pre-rebase value"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #97.

- When `execute_decision` tries to merge an accepted PR and the merge fails (e.g. HTTP 405 because the base branch advanced), the system now attempts a `git rebase origin/main` in a temporary worktree and retries the merge. The stale fallback only triggers when the rebase itself fails (true semantic conflict).
- On all non-merge PR close paths (non_improvement, stale, infra_failure, disagreement, policy_rejection), the remote branch is now deleted via `DELETE /git/refs/heads/{branch}` so the thesis can be retried cleanly without "PR already exists" errors.
- Adds `delete_ref` to the `GitHubApi` trait and implements it on `GitHubClient` and both test mocks.

## Test plan

- [x] `execute_decision_rebase_and_retry_on_merge_conflict` -- thesis branch behind main, rebase succeeds, PR merges as Accepted
- [x] `execute_decision_stale_fallback_when_rebase_fails` -- true semantic conflict, rebase fails, falls back to Stale
- [x] `execute_decision_falls_back_on_merge_failure` (updated) -- no repo_root available, immediate stale fallback preserved
- [x] `execute_decision_branch_cleanup_on_non_improvement` -- PR closed + branch deleted, new PR can be created
- [x] `execute_decision_branch_cleanup_on_stale` -- same for stale path
- [x] `execute_decision_concurrent_merge_scenario` -- two thesis PRs, first merges, second recovers via rebase
- [x] Existing branch deletion assertions added to non_improvement, disagreement, and stale fallback tests
- [x] All 31 scenario tests pass, all 103 e2e tests pass (1 pre-existing failure unrelated)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR decision/merge automation and adds local git operations (worktrees, rebase, force-push) plus remote branch deletion, which could affect repositories if edge cases or permissions differ.
> 
> **Overview**
> Improves `execute_decision` to recover from accepted-PR merge failures by optionally rebasing the PR branch onto `origin/main` in a temporary git worktree, force-pushing, and retrying the merge; the protocol decision comment records the post-rebase SHA when this succeeds.
> 
> Adds branch cleanup on all non-merge close paths by extending `GitHubApi` with `delete_ref` and calling it after closing PRs (with best-effort error handling), plus updates `lead`/`decide` call sites and expands scenario/e2e mocks and tests to cover rebase-retry behavior and branch deletion expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0193e503ee87df186ed7480c29d9fc6b4e4bbdad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->