### PR TITLE
Add audit severity grading to unblock lead on non-critical findings

### DIFF
--- a/cli/src/commands/audit.rs
+++ b/cli/src/commands/audit.rs
@@ -12,6 +12,7 @@ struct AuditOutput {
     ledger_current: bool,
     invalid_count: usize,
     suspicious_count: usize,
+    info_count: usize,
     findings: Vec<crate::validation::AuditFinding>,
 }
 
@@ -23,7 +24,7 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     if !ledger_current {
         findings.push(AuditFinding {
             scope: AuditScope::Repository,
-            severity: AuditSeverity::Invalid,
+            severity: AuditSeverity::Info,
             message: "results.tsv is stale compared with canonical history".to_string(),
             comment_id: None,
             author: None,
@@ -38,24 +39,30 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
         .iter()
         .filter(|finding| matches!(finding.severity, AuditSeverity::Suspicious))
         .count();
+    let info_count = findings
+        .iter()
+        .filter(|finding| matches!(finding.severity, AuditSeverity::Info))
+        .count();
 
     let output = AuditOutput {
         repo: ctx.repo.slug(),
         ledger_current,
         invalid_count,
         suspicious_count,
+        info_count,
         findings,
     };
 
     print_value(ctx, &output, |value| {
-        if value.invalid_count == 0 && value.suspicious_count == 0 && value.ledger_current {
+        if value.invalid_count == 0 && value.suspicious_count == 0 && value.info_count == 0 && value.ledger_current {
             format!("Audit clean for {}.", value.repo)
         } else {
             format!(
-                "Audit for {}: {} invalid, {} suspicious, results.tsv current: {}",
+                "Audit for {}: {} invalid, {} suspicious, {} info, results.tsv current: {}",
                 value.repo,
                 value.invalid_count,
                 value.suspicious_count,
+                value.info_count,
                 if value.ledger_current { "yes" } else { "no" }
             )
         }

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -133,10 +133,15 @@ pub fn require_decidable_pr<'a>(
 }
 
 pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<()> {
-    if !repo_state.audit_findings.is_empty() {
+    let blocking_count = repo_state
+        .audit_findings
+        .iter()
+        .filter(|f| f.severity.is_blocking())
+        .count();
+    if blocking_count > 0 {
         return Err(eyre!(
-            "cannot {} while audit findings are present; run `polyresearch audit` and resolve them through `polyresearch admin ...` first",
-            action
+            "cannot {} while {} critical audit finding(s) are present; run `polyresearch audit` and resolve them through `polyresearch admin ...` first",
+            action, blocking_count
         ));
     }
     Ok(())

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -256,9 +256,18 @@ async fn generate_if_needed(
         }
     }
 
-    if !repo_state.audit_findings.is_empty() {
-        eprintln!("Skipping thesis generation: audit findings present");
+    let blocking_count = repo_state
+        .audit_findings
+        .iter()
+        .filter(|f| f.severity.is_blocking())
+        .count();
+    if blocking_count > 0 {
+        eprintln!("Skipping thesis generation: {blocking_count} critical audit finding(s) present");
         return Ok(());
+    }
+    let non_blocking = repo_state.audit_findings.len() - blocking_count;
+    if non_blocking > 0 {
+        eprintln!("Note: {non_blocking} non-blocking audit finding(s) present (run `polyresearch audit`)");
     }
 
     let needed = config.min_queue_depth.saturating_sub(repo_state.queue_depth);

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -18,6 +18,7 @@ struct StatusOutput {
     ledger_current: bool,
     invalid_count: usize,
     suspicious_count: usize,
+    info_count: usize,
     maintainer_pending_count: usize,
     maintainer_rejected_count: usize,
     maintainer_items: Vec<String>,
@@ -42,6 +43,11 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
         .iter()
         .filter(|finding| matches!(finding.severity, AuditSeverity::Suspicious))
         .count();
+    let info_count = repo_state
+        .audit_findings
+        .iter()
+        .filter(|finding| matches!(finding.severity, AuditSeverity::Info))
+        .count();
     let maintainer_items = maintainer_items(&repo_state, ctx.config.auto_approve);
     let maintainer_pending_count = maintainer_items
         .iter()
@@ -62,6 +68,7 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
         ledger_current: ledger.is_current(&repo_state),
         invalid_count,
         suspicious_count,
+        info_count,
         maintainer_pending_count,
         maintainer_rejected_count,
         maintainer_items,
@@ -88,8 +95,8 @@ pub async fn run(ctx: &AppContext, args: &StatusArgs) -> Result<()> {
             best,
             if value.ledger_current { "yes" } else { "no" }
         ) + &format!(
-            "\nAudit findings: {} invalid, {} suspicious",
-            value.invalid_count, value.suspicious_count
+            "\nAudit findings: {} invalid, {} suspicious, {} info",
+            value.invalid_count, value.suspicious_count, value.info_count
         );
         if value.auto_approve {
             text.push_str("\nMaintainer gate: auto-approve enabled");

--- a/cli/src/tui/views.rs
+++ b/cli/src/tui/views.rs
@@ -55,6 +55,12 @@ fn draw_summary(
         .iter()
         .filter(|finding| matches!(finding.severity, AuditSeverity::Suspicious))
         .count();
+    let info_count = app
+        .repo_state
+        .audit_findings
+        .iter()
+        .filter(|finding| matches!(finding.severity, AuditSeverity::Info))
+        .count();
     let maintainer_pending = app
         .repo_state
         .theses
@@ -100,7 +106,7 @@ fn draw_summary(
         })
         .sum::<usize>();
     let text = format!(
-        "Repo: {} | Theses: {} | Queue: {}/{} | Best: {} | Nodes: {} | results.tsv current: {} | Findings: {} invalid / {} suspicious | Maintainer: {}",
+        "Repo: {} | Theses: {} | Queue: {}/{} | Best: {} | Nodes: {} | results.tsv current: {} | Findings: {} invalid / {} suspicious / {} info | Maintainer: {}",
         ctx.repo.slug(),
         app.repo_state.theses.len(),
         app.repo_state.queue_depth,
@@ -118,6 +124,7 @@ fn draw_summary(
         },
         invalid_count,
         suspicious_count,
+        info_count,
         if ctx.config.auto_approve {
             "auto".to_string()
         } else {
@@ -304,6 +311,7 @@ fn render_finding(finding: &AuditFinding) -> ListItem<'static> {
     let severity = match finding.severity {
         AuditSeverity::Invalid => "invalid",
         AuditSeverity::Suspicious => "suspicious",
+        AuditSeverity::Info => "info",
     };
     ListItem::new(format!("[{severity}] {scope}: {}", finding.message))
 }
@@ -312,5 +320,6 @@ fn short_finding(finding: &AuditFinding) -> String {
     match finding.severity {
         AuditSeverity::Invalid => format!("invalid: {}", finding.message),
         AuditSeverity::Suspicious => format!("suspicious: {}", finding.message),
+        AuditSeverity::Info => format!("info: {}", finding.message),
     }
 }

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -14,6 +14,13 @@ use crate::state::parse_thesis_number_from_branch;
 pub enum AuditSeverity {
     Invalid,
     Suspicious,
+    Info,
+}
+
+impl AuditSeverity {
+    pub fn is_blocking(&self) -> bool {
+        matches!(self, AuditSeverity::Invalid)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -936,6 +943,70 @@ mod tests {
                 .message
                 .contains("slash approve comment from non-maintainer actor")
         );
+    }
+
+    #[test]
+    fn severity_is_blocking_only_for_invalid() {
+        assert!(AuditSeverity::Invalid.is_blocking());
+        assert!(!AuditSeverity::Suspicious.is_blocking());
+        assert!(!AuditSeverity::Info.is_blocking());
+    }
+
+    #[test]
+    fn invalid_issue_like_produces_invalid_severity() {
+        let envelope = ProtocolEnvelope {
+            id: 1,
+            author: "alice".to_string(),
+            created_at: chrono::Utc::now(),
+            protocol: None,
+        };
+        let finding = invalid_issue_like(
+            AuditScope::Issue { number: 1 },
+            &envelope,
+            "test",
+        );
+        assert!(matches!(finding.severity, AuditSeverity::Invalid));
+        assert!(finding.severity.is_blocking());
+    }
+
+    #[test]
+    fn suspicious_issue_like_produces_suspicious_severity() {
+        let envelope = ProtocolEnvelope {
+            id: 1,
+            author: "alice".to_string(),
+            created_at: chrono::Utc::now(),
+            protocol: None,
+        };
+        let finding = suspicious_issue_like(
+            AuditScope::Issue { number: 1 },
+            &envelope,
+            "test",
+        );
+        assert!(matches!(finding.severity, AuditSeverity::Suspicious));
+        assert!(!finding.severity.is_blocking());
+    }
+
+    #[test]
+    fn duplicate_attempt_branch_is_suspicious_not_invalid() {
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/duplicate_attempt_branch_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(&fixture.lead_github_login, None);
+        let comments = envelopes(fixture.comments);
+        let validation = validate_issue(&fixture.issue, &comments, &config, None);
+
+        assert_eq!(validation.findings.len(), 1);
+        assert!(
+            validation.findings[0]
+                .message
+                .contains("duplicate attempt branch recorded more than once")
+        );
+        assert!(matches!(
+            validation.findings[0].severity,
+            AuditSeverity::Suspicious
+        ));
+        assert!(!validation.findings[0].severity.is_blocking());
     }
 
     fn envelopes(comments: Vec<IssueComment>) -> Vec<ProtocolEnvelope> {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -27,6 +27,7 @@ use polyresearch::state::{
     AttemptRecord, ClaimRecord, DecisionRecord, PullRequestState, ReleaseRecord, RepositoryState,
     ReviewRecord, ThesisPhase, ThesisState,
 };
+use polyresearch::validation::{AuditFinding, AuditScope, AuditSeverity};
 use polyresearch::worker;
 use polyresearch::agent;
 use serde::Deserialize;
@@ -899,7 +900,7 @@ async fn generate_is_blocked_by_dirty_audit() {
     assert!(
         error
             .to_string()
-            .contains("cannot proceed while audit findings are present")
+            .contains("critical audit finding(s) are present")
     );
 }
 
@@ -4420,6 +4421,121 @@ async fn contribute_counts_resumable_theses_as_available_work() {
         result.is_ok(),
         "contribute should count already-claimed thesis as resumable work: {result:?}"
     );
+}
+
+#[test]
+fn ensure_clean_audit_passes_with_only_suspicious_findings() {
+    let mut repo_state = make_repo_state(vec![], 0, 0, None);
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Issue { number: 1 },
+        severity: AuditSeverity::Suspicious,
+        message: "duplicate attempt branch recorded more than once".to_string(),
+        comment_id: Some(123),
+        author: Some("alice".to_string()),
+        created_at: Some(chrono::Utc::now()),
+    });
+    let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
+    assert!(result.is_ok(), "suspicious findings should not block: {result:?}");
+}
+
+#[test]
+fn ensure_clean_audit_passes_with_only_info_findings() {
+    let mut repo_state = make_repo_state(vec![], 0, 0, None);
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Repository,
+        severity: AuditSeverity::Info,
+        message: "results.tsv is stale compared with canonical history".to_string(),
+        comment_id: None,
+        author: None,
+        created_at: None,
+    });
+    let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
+    assert!(result.is_ok(), "info findings should not block: {result:?}");
+}
+
+#[test]
+fn ensure_clean_audit_blocks_on_invalid_findings() {
+    let mut repo_state = make_repo_state(vec![], 0, 0, None);
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Issue { number: 1 },
+        severity: AuditSeverity::Invalid,
+        message: "approval comment from non-lead actor".to_string(),
+        comment_id: Some(456),
+        author: Some("mallory".to_string()),
+        created_at: Some(chrono::Utc::now()),
+    });
+    let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
+    assert!(result.is_err(), "invalid findings must block");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("1 critical audit finding"));
+}
+
+#[test]
+fn ensure_clean_audit_blocks_on_invalid_even_with_non_blocking_present() {
+    let mut repo_state = make_repo_state(vec![], 0, 0, None);
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Issue { number: 1 },
+        severity: AuditSeverity::Suspicious,
+        message: "duplicate policy-pass comment".to_string(),
+        comment_id: Some(100),
+        author: Some("alice".to_string()),
+        created_at: Some(chrono::Utc::now()),
+    });
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Repository,
+        severity: AuditSeverity::Info,
+        message: "results.tsv is stale".to_string(),
+        comment_id: None,
+        author: None,
+        created_at: None,
+    });
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Issue { number: 2 },
+        severity: AuditSeverity::Invalid,
+        message: "decision comment from non-lead actor".to_string(),
+        comment_id: Some(200),
+        author: Some("mallory".to_string()),
+        created_at: Some(chrono::Utc::now()),
+    });
+    let result = commands::guards::ensure_clean_audit(&repo_state, "proceed");
+    assert!(result.is_err(), "must block when invalid findings are present");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("1 critical audit finding"));
+}
+
+#[test]
+fn stale_results_tsv_finding_is_info_severity() {
+    let finding = AuditFinding {
+        scope: AuditScope::Repository,
+        severity: AuditSeverity::Info,
+        message: "results.tsv is stale compared with canonical history".to_string(),
+        comment_id: None,
+        author: None,
+        created_at: None,
+    };
+    assert!(!finding.severity.is_blocking());
+    assert!(finding.comment_id.is_none());
+}
+
+#[test]
+fn computed_findings_without_comment_id_do_not_block_when_info() {
+    let mut repo_state = make_repo_state(vec![], 0, 0, None);
+    repo_state.audit_findings.push(AuditFinding {
+        scope: AuditScope::Repository,
+        severity: AuditSeverity::Info,
+        message: "computed finding with no comment_id".to_string(),
+        comment_id: None,
+        author: None,
+        created_at: None,
+    });
+    let blocking_count = repo_state
+        .audit_findings
+        .iter()
+        .filter(|f| f.severity.is_blocking())
+        .count();
+    assert_eq!(blocking_count, 0);
+    let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
+    assert!(result.is_ok(), "info findings with null comment_id should not block: {result:?}");
 }
 
 fn load_issue_fixture(name: &str) -> IssueFixture {

--- a/cli/tests/fixtures/duplicate_attempt_branch_issue.json
+++ b/cli/tests/fixtures/duplicate_attempt_branch_issue.json
@@ -1,0 +1,58 @@
+{
+  "leadGithubLogin": "lead",
+  "issue": {
+    "number": 12,
+    "title": "Duplicate attempt branch fixture",
+    "body": "Test thesis",
+    "state": "OPEN",
+    "labels": [{ "name": "thesis" }],
+    "createdAt": "2099-04-08T00:00:00Z",
+    "closedAt": null,
+    "author": { "login": "lead" },
+    "url": "https://example.test/issues/12"
+  },
+  "comments": [
+    {
+      "id": 1,
+      "body": "Polyresearch approval: thesis #12.\n\n<!-- polyresearch:approval\nthesis: 12\n-->",
+      "user": { "login": "lead" },
+      "created_at": "2099-04-08T00:01:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 2,
+      "body": "Polyresearch claim: thesis #12 by node `node-a`.\n\n<!-- polyresearch:claim\nthesis: 12\nnode: node-a\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:02:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 3,
+      "body": "Polyresearch attempt: thesis #12, branch `thesis/12-rmsnorm-1`, metric `0.9934`, observation `improved`.\n\n<!-- polyresearch:attempt\nthesis: 12\nbranch: thesis/12-rmsnorm-1\nmetric: 0.9934\nobservation: improved\nsummary: First attempt\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:03:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 4,
+      "body": "Polyresearch release: thesis #12 by node `node-a` (`reason: infra_failure`).\n\n<!-- polyresearch:release\nthesis: 12\nnode: node-a\nreason: infra_failure\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:04:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 5,
+      "body": "Polyresearch claim: thesis #12 by node `node-a`.\n\n<!-- polyresearch:claim\nthesis: 12\nnode: node-a\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:05:00Z",
+      "updated_at": null
+    },
+    {
+      "id": 6,
+      "body": "Polyresearch attempt: thesis #12, branch `thesis/12-rmsnorm-1`, metric `0.9950`, observation `improved`.\n\n<!-- polyresearch:attempt\nthesis: 12\nbranch: thesis/12-rmsnorm-1\nmetric: 0.9950\nobservation: improved\nsummary: Re-attempt after infra failure\n-->",
+      "user": { "login": "alice" },
+      "created_at": "2099-04-08T00:06:00Z",
+      "updated_at": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `Info` severity variant to `AuditSeverity` with an `is_blocking()` method that returns `true` only for `Invalid`
- Changes the stale `results.tsv` finding from `Invalid` to `Info`, fixing the permanent-deadlock path where a computed finding with no `comment_id` could never be acknowledged
- Updates `ensure_clean_audit` and `generate_if_needed` to filter by `is_blocking()` instead of `is_empty()`, so suspicious and info findings no longer block the lead loop
- Adds `info_count` to audit, status, and TUI display output

Fixes #96.

## Test plan

- [x] 4 new unit tests in `validation.rs`: severity `is_blocking()` correctness, `invalid_issue_like`/`suspicious_issue_like` produce correct severities, duplicate attempt branch is `Suspicious` not `Invalid`
- [x] 6 new integration tests in `e2e.rs`: `ensure_clean_audit` passes with only suspicious findings, passes with only info findings, blocks on invalid, blocks when invalid is mixed with non-blocking, stale `results.tsv` is info-level, computed findings without `comment_id` don't block
- [x] Updated existing `generate_is_blocked_by_dirty_audit` test for new error message format
- [x] Full test suite passes (109 passed, 1 pre-existing failure unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which audit findings block lead/guarded operations by introducing severity-based gating; misclassification could allow automation to proceed despite meaningful issues, but invalid findings still block and tests cover the new behavior.
> 
> **Overview**
> Adds `AuditSeverity::Info` plus `AuditSeverity::is_blocking()` and updates command gating (`ensure_clean_audit`, lead thesis generation) to **only block on `Invalid` findings**, allowing operations to continue when findings are merely *suspicious* or *info*.
> 
> Reclassifies the computed “`results.tsv` is stale” audit finding from `Invalid` to `Info` (avoiding deadlocks for findings without `comment_id`) and updates audit/status/TUI summaries to report `info_count` alongside invalid/suspicious. Expands unit/e2e coverage and adds a fixture to validate the new severity behavior and blocking rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4939126b627a465609c15893fd1efb10c064733a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->