### PR TITLE
Add configurable agent timeout to kill stuck subprocesses

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use color_eyre::eyre::{Context, Result, eyre};
 use regex::Regex;
@@ -88,12 +90,25 @@ pub struct ThesisProposal {
     pub body: String,
 }
 
+#[derive(Debug)]
+pub enum AgentOutcome {
+    Completed(Option<ExperimentResult>),
+    TimedOut,
+}
+
+fn read_to_vec(mut r: impl std::io::Read + Send + 'static) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let _ = r.read_to_end(&mut buf);
+    buf
+}
+
 pub fn spawn_experiment(
     agent_command: &str,
     worktree_path: &Path,
     prompt: &str,
     verbose: bool,
-) -> Result<Option<ExperimentResult>> {
+    timeout: Duration,
+) -> Result<AgentOutcome> {
     let parts = shell_words(agent_command);
     if parts.is_empty() {
         return Err(eyre!("agent command is empty"));
@@ -103,9 +118,39 @@ pub fn spawn_experiment(
     cmd.args(&parts[1..]);
     cmd.current_dir(worktree_path);
     cmd.arg(prompt);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
 
-    eprintln!("Spawning agent in {}...", worktree_path.display());
-    let output = cmd.output().wrap_err("failed to spawn agent")?;
+    eprintln!("Spawning agent in {} (timeout {}s)...", worktree_path.display(), timeout.as_secs());
+    let mut child = cmd.spawn().wrap_err("failed to spawn agent")?;
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_thread = stdout_pipe.map(|r| thread::spawn(move || read_to_vec(r)));
+    let stderr_thread = stderr_pipe.map(|r| thread::spawn(move || read_to_vec(r)));
+
+    let deadline = Instant::now() + timeout;
+    let timed_out = loop {
+        match child.try_wait().wrap_err("failed to poll agent process")? {
+            Some(_status) => break false,
+            None if Instant::now() >= deadline => {
+                eprintln!("Agent timed out after {}s, killing pid {}...", timeout.as_secs(), child.id());
+                let _ = child.kill();
+                let _ = child.wait();
+                break true;
+            }
+            None => thread::sleep(Duration::from_secs(1)),
+        }
+    };
+
+    if timed_out {
+        return Ok(AgentOutcome::TimedOut);
+    }
+
+    let stdout = stdout_thread.and_then(|h| h.join().ok()).unwrap_or_default();
+    let stderr = stderr_thread.and_then(|h| h.join().ok()).unwrap_or_default();
+    let status = child.wait().wrap_err("failed to wait on agent")?;
+    let output = Output { status, stdout, stderr };
 
     if !output.status.success() {
         log_subprocess_failure("Agent", &output, verbose, Some(agent_command), Some(worktree_path));
@@ -117,10 +162,10 @@ pub fn spawn_experiment(
             .wrap_err("failed to read .polyresearch/result.json")?;
         let result: ExperimentResult = serde_json::from_str(&contents)
             .wrap_err("failed to parse .polyresearch/result.json")?;
-        return Ok(Some(result));
+        return Ok(AgentOutcome::Completed(Some(result)));
     }
 
-    Ok(None)
+    Ok(AgentOutcome::Completed(None))
 }
 
 pub fn recover_from_logs(worktree_path: &Path) -> Option<RecoveredMetric> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -72,6 +72,16 @@ pub struct NodeOverrides {
     pub agent_timeout: Option<u64>,
 }
 
+impl NodeOverrides {
+    pub fn has_any(&self) -> bool {
+        self.capacity.is_some()
+            || self.api_budget.is_some()
+            || self.request_delay.is_some()
+            || self.agent_command.is_some()
+            || self.agent_timeout.is_some()
+    }
+}
+
 #[derive(Debug, Args, Clone)]
 pub struct InitArgs {
     #[arg(long)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -67,6 +67,9 @@ pub struct NodeOverrides {
 
     #[arg(long)]
     pub agent_command: Option<String>,
+
+    #[arg(long)]
+    pub agent_timeout: Option<u64>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -319,11 +319,7 @@ fn replace_goal_section(template: &str, goal: &str) -> String {
 
 fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
     commands::ensure_node_config(repo_root)?;
-    if overrides.capacity.is_some()
-        || overrides.api_budget.is_some()
-        || overrides.request_delay.is_some()
-        || overrides.agent_command.is_some()
-    {
+    if overrides.has_any() {
         let config = NodeConfig::load(repo_root)?;
         config.with_overrides(overrides).save(repo_root)?;
     }
@@ -343,6 +339,10 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, ve
                 .clone()
                 .unwrap_or_else(|| "claude -p --dangerously-skip-permissions".to_string())
         });
+    let timeout_secs = node_config
+        .as_ref()
+        .map(|c| c.agent.timeout_secs)
+        .unwrap_or(crate::config::DEFAULT_AGENT_TIMEOUT_SECS);
 
     let base_prompt = include_str!("../../prompts/bootstrap-setup.md");
     let prompt = format!(
@@ -351,7 +351,7 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, ve
     );
 
     eprintln!("Spawning agent for initial setup...");
-    let timeout = std::time::Duration::from_secs(crate::config::DEFAULT_AGENT_TIMEOUT_SECS);
+    let timeout = std::time::Duration::from_secs(timeout_secs);
     let _ = crate::agent::spawn_experiment(&agent_command, repo_root, &prompt, verbose, timeout);
     Ok(())
 }

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -351,7 +351,8 @@ fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, ve
     );
 
     eprintln!("Spawning agent for initial setup...");
-    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, &prompt, verbose);
+    let timeout = std::time::Duration::from_secs(crate::config::DEFAULT_AGENT_TIMEOUT_SECS);
+    let _ = crate::agent::spawn_experiment(&agent_command, repo_root, &prompt, verbose, timeout);
     Ok(())
 }
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -233,6 +233,7 @@ async fn run_iteration(
             program,
             config,
             ctx.cli.verbose,
+            node_config.agent.timeout_secs,
         ));
         prior_attempts_list.push(worker::format_prior_attempts(thesis));
     }
@@ -259,6 +260,7 @@ async fn run_iteration(
             program,
             config,
             ctx.cli.verbose,
+            node_config.agent.timeout_secs,
         ));
         prior_attempts_list.push(worker::format_prior_attempts(thesis));
     }
@@ -295,6 +297,7 @@ fn build_worker_context(
     program: &ProgramSpec,
     config: &ProtocolConfig,
     verbose: bool,
+    agent_timeout_secs: u64,
 ) -> WorkerContext {
     WorkerContext {
         issue_number: thesis.issue.number,
@@ -308,6 +311,7 @@ fn build_worker_context(
         protected_globs: program.cannot_modify.clone(),
         metric_direction: config.metric_direction,
         verbose,
+        agent_timeout_secs,
     }
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -124,35 +124,11 @@ pub fn write_node_config(
     node: &str,
     overrides: &crate::cli::NodeOverrides,
 ) -> Result<()> {
-    let existing = NodeConfig::load(repo_root).ok();
-    let existing_budget = existing
-        .as_ref()
-        .map(|config| config.api_budget)
-        .unwrap_or_else(|| NodeConfig::load_api_budget(repo_root));
-    let existing_request_delay_ms = existing
-        .as_ref()
-        .map(|config| config.request_delay_ms)
-        .unwrap_or_else(|| NodeConfig::load_request_delay_ms(repo_root));
-    let existing_capacity = existing
-        .as_ref()
-        .map(|config| config.capacity)
-        .unwrap_or(crate::config::DEFAULT_CAPACITY);
-    let existing_agent = existing.as_ref().map(|config| config.agent.clone());
-    NodeConfig::new(
-        node.to_string(),
-        overrides.capacity.unwrap_or(existing_capacity),
-        overrides.api_budget.unwrap_or(existing_budget),
-        overrides.request_delay.unwrap_or(existing_request_delay_ms),
-        overrides
-            .agent_command
-            .as_ref()
-            .map(|cmd| crate::config::AgentConfig {
-                command: cmd.clone(),
-                ..Default::default()
-            })
-            .or(existing_agent),
-    )
-    .save(repo_root)
+    let mut config = NodeConfig::load(repo_root).unwrap_or_else(|_| {
+        NodeConfig::new(node, crate::config::DEFAULT_CAPACITY, crate::config::DEFAULT_API_BUDGET, crate::config::DEFAULT_REQUEST_DELAY_MS, None)
+    });
+    config.node_id = node.to_string();
+    config.with_overrides(overrides).save(repo_root)
 }
 
 pub fn ensure_node_config(repo_root: &Path) -> Result<()> {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -148,6 +148,7 @@ pub fn write_node_config(
             .as_ref()
             .map(|cmd| crate::config::AgentConfig {
                 command: cmd.clone(),
+                ..Default::default()
             })
             .or(existing_agent),
     )

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_API_BUDGET: u64 = 5_000;
 pub const DEFAULT_REQUEST_DELAY_MS: u64 = 100;
 pub const DEFAULT_CAPACITY: u8 = 75;
+pub const DEFAULT_AGENT_TIMEOUT_SECS: u64 = 600;
 pub const NODE_ID_ENV_VAR: &str = "POLYRESEARCH_NODE_ID";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,14 +25,21 @@ pub enum MetricDirection {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentConfig {
     pub command: String,
+    #[serde(default = "default_agent_timeout_secs")]
+    pub timeout_secs: u64,
 }
 
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             command: "claude -p --dangerously-skip-permissions".to_string(),
+            timeout_secs: DEFAULT_AGENT_TIMEOUT_SECS,
         }
     }
+}
+
+fn default_agent_timeout_secs() -> u64 {
+    DEFAULT_AGENT_TIMEOUT_SECS
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -147,9 +155,10 @@ impl NodeConfig {
             self.request_delay_ms = normalize_request_delay_ms(d);
         }
         if let Some(ref cmd) = overrides.agent_command {
-            self.agent = AgentConfig {
-                command: cmd.clone(),
-            };
+            self.agent.command = cmd.clone();
+        }
+        if let Some(t) = overrides.agent_timeout {
+            self.agent.timeout_secs = t;
         }
         self
     }
@@ -1117,18 +1126,20 @@ Do something.
             api_budget: Some(9000),
             request_delay: Some(300),
             agent_command: Some("my-agent run".to_string()),
+            agent_timeout: Some(120),
         };
         let updated = config.with_overrides(&overrides);
         assert_eq!(updated.capacity, 80);
         assert_eq!(updated.api_budget, 9000);
         assert_eq!(updated.request_delay_ms, 300);
         assert_eq!(updated.agent.command, "my-agent run");
+        assert_eq!(updated.agent.timeout_secs, 120);
         assert_eq!(updated.node_id, "n");
     }
 
     #[test]
     fn with_overrides_empty_leaves_unchanged() {
-        let config = NodeConfig::new("n", 50, 3000, 200, Some(AgentConfig { command: "original".to_string() }));
+        let config = NodeConfig::new("n", 50, 3000, 200, Some(AgentConfig { command: "original".to_string(), ..Default::default() }));
         let overrides = crate::cli::NodeOverrides::default();
         let updated = config.clone().with_overrides(&overrides);
         assert_eq!(updated, config);
@@ -1143,6 +1154,52 @@ Do something.
         };
         let updated = config.with_overrides(&overrides);
         assert_eq!(updated.capacity, DEFAULT_CAPACITY);
+    }
+
+    #[test]
+    fn agent_config_default_timeout() {
+        let agent = AgentConfig::default();
+        assert_eq!(agent.timeout_secs, DEFAULT_AGENT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn with_overrides_applies_agent_timeout() {
+        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let overrides = crate::cli::NodeOverrides {
+            agent_timeout: Some(120),
+            ..Default::default()
+        };
+        let updated = config.with_overrides(&overrides);
+        assert_eq!(updated.agent.timeout_secs, 120);
+        assert_eq!(updated.agent.command, AgentConfig::default().command);
+    }
+
+    #[test]
+    fn agent_config_toml_roundtrip_with_timeout() {
+        let toml_str = r#"
+node_id = "test"
+capacity = 75
+
+[agent]
+command = "my-agent"
+timeout_secs = 300
+"#;
+        let config: NodeConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.agent.timeout_secs, 300);
+        assert_eq!(config.agent.command, "my-agent");
+    }
+
+    #[test]
+    fn agent_config_toml_default_timeout_when_omitted() {
+        let toml_str = r#"
+node_id = "test"
+capacity = 75
+
+[agent]
+command = "my-agent"
+"#;
+        let config: NodeConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.agent.timeout_secs, DEFAULT_AGENT_TIMEOUT_SECS);
     }
 
     fn unique_temp_dir(name: &str) -> PathBuf {

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::{Context, Result, eyre};
 
-use crate::agent::{self, ExperimentResult, RecoveredMetric};
+use crate::agent::{self, AgentOutcome, ExperimentResult, RecoveredMetric};
 use crate::comments::{Observation, ProtocolComment, ReleaseReason};
 use crate::commands;
 use crate::config::MetricDirection;
@@ -24,6 +24,7 @@ pub struct WorkerContext {
     pub protected_globs: Vec<String>,
     pub metric_direction: MetricDirection,
     pub verbose: bool,
+    pub agent_timeout_secs: u64,
 }
 
 #[derive(Debug)]
@@ -62,6 +63,12 @@ impl WorkerOutcome {
             | Self::Failed { worktree_path, .. } => worktree_path,
         }
     }
+}
+
+pub(crate) enum ExperimentOutcome {
+    Result(ExperimentResult),
+    TimedOut,
+    NoResult,
 }
 
 pub struct ThesisWorker {
@@ -110,18 +117,24 @@ impl ThesisWorker {
         Ok(())
     }
 
-    pub fn run_experiment(&self) -> Result<Option<ExperimentResult>> {
+    fn run_experiment(&self) -> Result<ExperimentOutcome> {
         let prompt = agent::experiment_prompt();
+        let timeout = std::time::Duration::from_secs(self.ctx.agent_timeout_secs);
 
-        let result = agent::spawn_experiment(
+        let outcome = agent::spawn_experiment(
             &self.ctx.agent_command,
             &self.worktree_path,
             prompt,
             self.ctx.verbose,
+            timeout,
         )?;
 
-        if result.is_some() {
-            return Ok(result);
+        match outcome {
+            AgentOutcome::TimedOut => return Ok(ExperimentOutcome::TimedOut),
+            AgentOutcome::Completed(Some(result)) => {
+                return Ok(ExperimentOutcome::Result(result));
+            }
+            AgentOutcome::Completed(None) => {}
         }
 
         eprintln!(
@@ -131,7 +144,7 @@ impl ThesisWorker {
 
         if let Some(recovered) = agent::recover_from_logs(&self.worktree_path) {
             eprintln!("Recovered metric {:.4} from run logs", recovered.metric);
-            return Ok(Some(classify_recovered(recovered, self.ctx.metric_direction)));
+            return Ok(ExperimentOutcome::Result(classify_recovered(recovered, self.ctx.metric_direction)));
         }
 
         eprintln!("Log recovery failed; attempting direct harness execution...");
@@ -144,12 +157,12 @@ impl ThesisWorker {
         match harness_result {
             Ok(Some(recovered)) => {
                 eprintln!("Recovered metric {:.4} from direct harness", recovered.metric);
-                Ok(Some(classify_recovered(recovered, self.ctx.metric_direction)))
+                Ok(ExperimentOutcome::Result(classify_recovered(recovered, self.ctx.metric_direction)))
             }
-            Ok(None) => Ok(None),
+            Ok(None) => Ok(ExperimentOutcome::NoResult),
             Err(err) => {
                 eprintln!("Harness recovery failed: {err}");
-                Ok(None)
+                Ok(ExperimentOutcome::NoResult)
             }
         }
     }
@@ -248,8 +261,16 @@ impl ThesisWorker {
         }
 
         let result = match self.run_experiment() {
-            Ok(Some(result)) => result,
-            Ok(None) => {
+            Ok(ExperimentOutcome::Result(result)) => result,
+            Ok(ExperimentOutcome::TimedOut) => {
+                let _ = self.release(&github, ReleaseReason::Timeout, dry_run);
+                return WorkerOutcome::Failed {
+                    issue_number: self.ctx.issue_number,
+                    worktree_path: self.worktree_path.clone(),
+                    reason: format!("agent timed out after {}s", self.ctx.agent_timeout_secs),
+                };
+            }
+            Ok(ExperimentOutcome::NoResult) => {
                 let _ = self.release(&github, ReleaseReason::InfraFailure, dry_run);
                 return WorkerOutcome::Failed {
                     issue_number: self.ctx.issue_number,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2464,6 +2464,36 @@ fn node_config_agent_section_defaults_when_absent() {
     assert!(config.agent.command.contains("claude"));
 }
 
+#[test]
+fn write_node_config_persists_agent_timeout_override() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("config-agent-timeout-override");
+    let overrides = NodeOverrides {
+        agent_timeout: Some(120),
+        ..Default::default()
+    };
+    commands::write_node_config(&repo.path, "test-node", &overrides).unwrap();
+
+    let config = polyresearch::config::NodeConfig::load(&repo.path).unwrap();
+    assert_eq!(config.agent.timeout_secs, 120);
+}
+
+#[test]
+fn write_node_config_persists_agent_timeout_with_command() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("config-agent-timeout-cmd");
+    let overrides = NodeOverrides {
+        agent_command: Some("my-agent run".to_string()),
+        agent_timeout: Some(300),
+        ..Default::default()
+    };
+    commands::write_node_config(&repo.path, "test-node", &overrides).unwrap();
+
+    let config = polyresearch::config::NodeConfig::load(&repo.path).unwrap();
+    assert_eq!(config.agent.command, "my-agent run");
+    assert_eq!(config.agent.timeout_secs, 300);
+}
+
 // --- Agent module tests ---
 
 #[test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2819,6 +2819,7 @@ fn worker_context_carries_protected_globs() {
         protected_globs: vec!["docs/**".to_string(), "config/".to_string()],
         metric_direction: polyresearch::config::MetricDirection::HigherIsBetter,
         verbose: false,
+        agent_timeout_secs: polyresearch::config::DEFAULT_AGENT_TIMEOUT_SECS,
     };
 
     assert_eq!(wctx.protected_globs.len(), 2);
@@ -4251,6 +4252,7 @@ fn worker_setup_failure_returns_issue_number_for_release() {
         protected_globs: vec![],
         metric_direction: MetricDirection::HigherIsBetter,
         verbose: false,
+        agent_timeout_secs: polyresearch::config::DEFAULT_AGENT_TIMEOUT_SECS,
     };
 
     let tw = worker::ThesisWorker::new(wctx, String::new());

--- a/cli/tests/mock_agent.sh
+++ b/cli/tests/mock_agent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Mock agent for scenario tests.
-# Controlled by MOCK_AGENT_RESULT: improved, no_improvement, crashed, fail
+# Controlled by MOCK_AGENT_RESULT: improved, no_improvement, crashed, fail, hang
 RESULT_DIR="$PWD/.polyresearch"
 mkdir -p "$RESULT_DIR"
 
@@ -24,5 +24,8 @@ RESULT
         ;;
     fail)
         exit 1
+        ;;
+    hang)
+        sleep 999999
         ;;
 esac

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -115,8 +115,21 @@ Test scenario goal.
     }
 
     fn write_node_config(&self, node_id: &str, agent_command: &str) {
+        self.write_node_config_with_timeout(node_id, agent_command, None);
+    }
+
+    fn write_node_config_with_timeout(
+        &self,
+        node_id: &str,
+        agent_command: &str,
+        timeout_secs: Option<u64>,
+    ) {
+        let timeout_line = match timeout_secs {
+            Some(t) => format!("timeout_secs = {t}\n"),
+            None => String::new(),
+        };
         let content = format!(
-            "node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"{agent_command}\"\n"
+            "node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"{agent_command}\"\n{timeout_line}"
         );
         fs::write(self.path.join(".polyresearch-node.toml"), content).unwrap();
     }
@@ -126,6 +139,19 @@ Test scenario goal.
         self.write_prepare_md();
         self.write_results_tsv();
         self.write_node_config(node_id, agent_command);
+    }
+
+    fn write_full_setup_with_timeout(
+        &self,
+        lead: &str,
+        node_id: &str,
+        agent_command: &str,
+        timeout_secs: u64,
+    ) {
+        self.write_program_md(lead);
+        self.write_prepare_md();
+        self.write_results_tsv();
+        self.write_node_config_with_timeout(node_id, agent_command, Some(timeout_secs));
     }
 
     fn commit_all(&self, message: &str) {
@@ -2847,4 +2873,109 @@ fn resolve_default_branch_falls_back_to_main() {
     let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
     let branch = config.resolve_default_branch(&repo.path).unwrap();
     assert_eq!(branch, "main", "should fall back to 'main' when not set and git detection unavailable");
+}
+
+#[tokio::test]
+async fn scenario_contribute_timeout_kills_agent() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("contrib-timeout");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("hang");
+    repo.write_full_setup_with_timeout("lead", "test-node-timeout", &agent_cmd, 3);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(95, "Timeout experiment", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(95, comments);
+
+    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-timeout"); }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_ok(), "contribute should handle agent timeout gracefully: {result:?}");
+
+    let posted = github.posted_comments();
+    let has_release_timeout = posted.iter().any(|(_, body)| {
+        body.contains("polyresearch:release") && body.contains("timeout")
+    });
+    assert!(
+        has_release_timeout,
+        "expected a release comment with reason=timeout, got: {posted:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_contribute_fast_agent_unaffected_by_timeout() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("contrib-fast");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("improved");
+    repo.write_full_setup_with_timeout("lead", "test-node-fast", &agent_cmd, 60);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(96, "Fast experiment", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(96, comments);
+
+    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fast"); }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        true,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_ok(), "contribute should succeed with short-lived agent: {result:?}");
 }


### PR DESCRIPTION
## Summary

Closes #98.

- Adds `timeout_secs` to `[agent]` config (default 600s, overridable via `--agent-timeout` CLI flag) that kills agent subprocesses exceeding the deadline, releases the thesis with `reason=timeout`, and lets the contribute loop continue
- Replaces blocking `cmd.output()` in `spawn_experiment` with `spawn` + `try_wait` polling + `kill` on deadline, using only std library (no new dependencies)
- Introduces `AgentOutcome::TimedOut` variant so `execute` can distinguish timeout from other failures and release with `ReleaseReason::Timeout`

## Test plan

- [x] 4 new config unit tests: default value, override, TOML roundtrip with/without timeout
- [x] `scenario_contribute_timeout_kills_agent`: mock agent hangs, 3s timeout kills it, release comment has `reason=timeout`
- [x] `scenario_contribute_fast_agent_unaffected_by_timeout`: fast agent completes normally with a 60s timeout
- [x] All 138 lib unit tests pass
- [x] All 28 scenario tests pass (26 existing + 2 new)
- [x] All 108 e2e tests compile (existing `release_does_not_close_on_timeout` still passes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core worker/agent execution flow and process management; mistakes could prematurely kill valid runs or leave orphaned subprocesses, but changes are localized and well-covered by new tests.
> 
> **Overview**
> Adds a configurable agent subprocess timeout (new `[agent].timeout_secs`, default `600`, plus `--agent-timeout`) and threads it through `bootstrap`/`contribute` worker execution.
> 
> Refactors `agent::spawn_experiment` to run the agent via `spawn` with piped stdio, poll with `try_wait`, and `kill` the process on deadline, returning `AgentOutcome::TimedOut` so workers can release the thesis with `reason=timeout` and keep the contribute loop running.
> 
> Simplifies node config persistence to load+`with_overrides`, updates override detection via `NodeOverrides::has_any`, and expands unit/scenario/e2e tests (including a hanging mock agent) to cover timeout behavior and TOML round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21fca6bc0af2d3b25f0d70b95d3a8685954fc1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->