### PR TITLE
Cap rate limit retry delays at 300s and apply jitter to prevent thundering herd

### DIFF
--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -1005,10 +1005,10 @@ fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -
         RateLimitKind::Secondary => parse_retry_after(stderr)
             .map(|d| capped_delay(server_jittered_delay(d)))
             .or_else(|| {
-                Some(jittered_delay(Duration::from_secs(
+                Some(capped_delay(jittered_delay(Duration::from_secs(
                     SECONDARY_RETRY_DELAYS_SECS
                         [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
-                )))
+                ))))
             }),
     }
 }
@@ -1135,6 +1135,14 @@ mod tests {
             delay >= base / 2 && delay <= base + base / 2,
             "secondary fallback delay {delay:?} outside jittered range of {base:?}"
         );
+        let last_attempt = SECONDARY_RETRY_DELAYS_SECS.len() - 1;
+        for _ in 0..100 {
+            let d = resolve_rate_limit_delay(RateLimitKind::Secondary, last_attempt, stderr).unwrap();
+            assert!(
+                d <= MAX_RETRY_DELAY,
+                "secondary fallback delay {d:?} exceeded MAX_RETRY_DELAY at max attempt"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -999,11 +999,11 @@ fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -
                 } else {
                     wait
                 };
-                jittered_delay(capped_delay(wait + Duration::from_secs(1)))
+                capped_delay(server_jittered_delay(wait + Duration::from_secs(1)))
             })
         }),
         RateLimitKind::Secondary => parse_retry_after(stderr)
-            .map(|d| jittered_delay(capped_delay(d)))
+            .map(|d| capped_delay(server_jittered_delay(d)))
             .or_else(|| {
                 Some(jittered_delay(Duration::from_secs(
                     SECONDARY_RETRY_DELAYS_SECS
@@ -1040,7 +1040,18 @@ fn capped_delay(delay: Duration) -> Duration {
     delay.min(MAX_RETRY_DELAY)
 }
 
-/// Applies ±50% jitter so concurrent agents that hit the same rate limit
+/// Applies [100%, 150%] upward-only jitter to a server-provided delay so
+/// concurrent agents spread out without ever retrying before the limit resets.
+fn server_jittered_delay(base: Duration) -> Duration {
+    let base_millis = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    if base_millis == 0 {
+        return base;
+    }
+    let high = base_millis.saturating_add(base_millis / 2);
+    Duration::from_millis(rand::rng().random_range(base_millis..=high))
+}
+
+/// Applies ±50% jitter to a client-side fallback backoff so concurrent agents
 /// don't all wake up at the same instant.
 fn jittered_delay(base: Duration) -> Duration {
     let base_millis = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
@@ -1106,7 +1117,13 @@ mod tests {
     fn retry_duration_is_capped_at_max() {
         let parsed = parse_retry_after("HTTP 429\nRetry-After: 3000").unwrap();
         assert_eq!(parsed, Duration::from_secs(3000));
-        assert_eq!(capped_delay(parsed), MAX_RETRY_DELAY);
+        for _ in 0..100 {
+            let result = capped_delay(server_jittered_delay(parsed));
+            assert!(
+                result <= MAX_RETRY_DELAY,
+                "capped server-jittered delay {result:?} exceeded MAX_RETRY_DELAY"
+            );
+        }
     }
 
     #[test]
@@ -1134,6 +1151,34 @@ mod tests {
             seen.insert(jittered_delay(base).as_millis());
         }
         assert!(seen.len() >= 2, "jittered_delay produced no variation across 100 calls");
+    }
+
+    #[test]
+    fn server_jittered_delay_stays_within_100_to_150_percent() {
+        let base = Duration::from_secs(90);
+        let high = base + base / 2;
+        for _ in 0..1_000 {
+            let jittered = server_jittered_delay(base);
+            assert!(
+                jittered >= base && jittered <= high,
+                "server jittered delay {jittered:?} fell outside [{base:?}, {high:?}]"
+            );
+        }
+    }
+
+    #[test]
+    fn server_jittered_delay_noops_for_zero_base() {
+        assert_eq!(server_jittered_delay(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn server_jitter_varies_across_calls() {
+        let base = Duration::from_secs(90);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            seen.insert(server_jittered_delay(base).as_millis());
+        }
+        assert!(seen.len() >= 2, "server_jittered_delay produced no variation across 100 calls");
     }
 
     #[test]

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -19,6 +19,7 @@ use crate::throttle;
 const COMMENT_FETCH_CONCURRENCY_LIMIT: usize = 2;
 const TRANSIENT_RETRY_DELAYS_SECS: [u64; 3] = [5, 10, 20];
 const SECONDARY_RETRY_DELAYS_SECS: [u64; 3] = [90, 180, 300];
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepoRef {
@@ -992,16 +993,23 @@ fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -
             status.resources.core.reset_at().map(|reset_at| {
                 let wait = (reset_at - Utc::now())
                     .to_std()
-                    .unwrap_or_else(|_| Duration::from_secs(0));
-                wait + Duration::from_secs(1)
+                    .unwrap_or(Duration::from_secs(5));
+                let wait = if wait.is_zero() {
+                    Duration::from_secs(5)
+                } else {
+                    wait
+                };
+                jittered_delay(capped_delay(wait + Duration::from_secs(1)))
             })
         }),
-        RateLimitKind::Secondary => parse_retry_after(stderr).or_else(|| {
-            Some(jittered_delay(Duration::from_secs(
-                SECONDARY_RETRY_DELAYS_SECS
-                    [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
-            )))
-        }),
+        RateLimitKind::Secondary => parse_retry_after(stderr)
+            .map(|d| jittered_delay(capped_delay(d)))
+            .or_else(|| {
+                Some(jittered_delay(Duration::from_secs(
+                    SECONDARY_RETRY_DELAYS_SECS
+                        [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
+                )))
+            }),
     }
 }
 
@@ -1028,9 +1036,12 @@ fn parse_retry_after(stderr: &str) -> Option<Duration> {
     Some(Duration::from_secs(seconds))
 }
 
-/// Applies ±50% jitter to a client-side fallback backoff so three agents that
-/// hit the same rate limit at the same moment don't all wake up at the same time.
-/// Only used when the server does not provide an explicit `Retry-After`.
+fn capped_delay(delay: Duration) -> Duration {
+    delay.min(MAX_RETRY_DELAY)
+}
+
+/// Applies ±50% jitter so concurrent agents that hit the same rate limit
+/// don't all wake up at the same instant.
 fn jittered_delay(base: Duration) -> Duration {
     let base_millis = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
     if base_millis == 0 {
@@ -1089,6 +1100,64 @@ mod tests {
     #[test]
     fn jittered_delay_noops_for_zero_base() {
         assert_eq!(jittered_delay(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn retry_duration_is_capped_at_max() {
+        let parsed = parse_retry_after("HTTP 429\nRetry-After: 3000").unwrap();
+        assert_eq!(parsed, Duration::from_secs(3000));
+        assert_eq!(capped_delay(parsed), MAX_RETRY_DELAY);
+    }
+
+    #[test]
+    fn secondary_rate_limit_uses_short_backoff() {
+        let stderr = "secondary rate limit hit";
+        let delay = resolve_rate_limit_delay(RateLimitKind::Secondary, 0, stderr).unwrap();
+        let base = Duration::from_secs(SECONDARY_RETRY_DELAYS_SECS[0]);
+        assert!(
+            delay >= base / 2 && delay <= base + base / 2,
+            "secondary fallback delay {delay:?} outside jittered range of {base:?}"
+        );
+    }
+
+    #[test]
+    fn primary_rate_limit_cap_limits_large_values() {
+        assert_eq!(capped_delay(Duration::from_secs(2861)), MAX_RETRY_DELAY);
+        assert_eq!(capped_delay(Duration::from_secs(120)), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn jitter_varies_across_calls() {
+        let base = Duration::from_secs(90);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            seen.insert(jittered_delay(base).as_millis());
+        }
+        assert!(seen.len() >= 2, "jittered_delay produced no variation across 100 calls");
+    }
+
+    #[test]
+    fn cap_applies_to_parsed_retry_after() {
+        let large = parse_retry_after("Retry-After: 5000").unwrap();
+        assert_eq!(capped_delay(large), MAX_RETRY_DELAY);
+
+        let small = parse_retry_after("Retry-After: 60").unwrap();
+        assert_eq!(capped_delay(small), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn zero_or_negative_reset_time_produces_small_delay() {
+        assert_eq!(capped_delay(Duration::from_secs(5)), Duration::from_secs(5));
+        assert_eq!(capped_delay(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_retry_after_extracts_value_from_stderr() {
+        assert_eq!(
+            parse_retry_after("HTTP 429\nRetry-After: 120"),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(parse_retry_after("no header here"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a `MAX_RETRY_DELAY` (300s) cap to all rate limit retry durations in `resolve_rate_limit_delay`, preventing the 50-minute waits observed for limits that reset in 60 seconds.
- Applies `jittered_delay` to server-provided values (primary reset timestamps and parsed `Retry-After` headers) so concurrent projects don't wake and burst simultaneously.
- Handles zero/negative reset deltas with a 5-second floor instead of sleeping for 0 seconds.
- Adds 7 unit tests covering the cap, jitter variation, parse_retry_after, and edge cases.

Closes #99

## Test plan

- [x] `cargo build` succeeds
- [x] All 141 unit tests pass (including 7 new tests)
- [x] Pre-existing e2e failure (`contribute_auto_submit_recreates_missing_worktree`) confirmed unrelated — fails identically on `origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core retry/backoff timing for GitHub API calls, which could alter request patterns under rate limiting and affect perceived reliability if mis-tuned.
> 
> **Overview**
> Improves GitHub CLI retry behavior under rate limiting by **capping all computed retry sleeps to 300s** and adding **jitter to server-derived delays** (primary `rate_limit` reset time and secondary `Retry-After`) to reduce thundering-herd retries.
> 
> `resolve_rate_limit_delay` now floors zero/negative primary reset deltas to 5s and introduces `server_jittered_delay` (upward-only) plus `capped_delay`; new unit tests cover delay capping, jitter variability/bounds, and `Retry-After` parsing edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da81dc205a43118a339c6c63d7163614a65c58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->