### PR TITLE
Fix all rustfmt and clippy warnings

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -20,8 +20,16 @@ fn tail_str(s: &str, max_bytes: usize) -> &str {
     &s[s.ceil_char_boundary(cut)..]
 }
 
-fn log_subprocess_failure(label: &str, output: &Output, verbose: bool, command_line: Option<&str>, work_dir: Option<&Path>) {
-    let code = output.status.code()
+fn log_subprocess_failure(
+    label: &str,
+    output: &Output,
+    verbose: bool,
+    command_line: Option<&str>,
+    work_dir: Option<&Path>,
+) {
+    let code = output
+        .status
+        .code()
         .map(|c| c.to_string())
         .unwrap_or_else(|| "signal".into());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -121,7 +129,11 @@ pub fn spawn_experiment(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    eprintln!("Spawning agent in {} (timeout {}s)...", worktree_path.display(), timeout.as_secs());
+    eprintln!(
+        "Spawning agent in {} (timeout {}s)...",
+        worktree_path.display(),
+        timeout.as_secs()
+    );
     let mut child = cmd.spawn().wrap_err("failed to spawn agent")?;
 
     let stdout_pipe = child.stdout.take();
@@ -134,7 +146,11 @@ pub fn spawn_experiment(
         match child.try_wait().wrap_err("failed to poll agent process")? {
             Some(_status) => break false,
             None if Instant::now() >= deadline => {
-                eprintln!("Agent timed out after {}s, killing pid {}...", timeout.as_secs(), child.id());
+                eprintln!(
+                    "Agent timed out after {}s, killing pid {}...",
+                    timeout.as_secs(),
+                    child.id()
+                );
                 let _ = child.kill();
                 let _ = child.wait();
                 break true;
@@ -147,13 +163,27 @@ pub fn spawn_experiment(
         return Ok(AgentOutcome::TimedOut);
     }
 
-    let stdout = stdout_thread.and_then(|h| h.join().ok()).unwrap_or_default();
-    let stderr = stderr_thread.and_then(|h| h.join().ok()).unwrap_or_default();
+    let stdout = stdout_thread
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_thread
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
     let status = child.wait().wrap_err("failed to wait on agent")?;
-    let output = Output { status, stdout, stderr };
+    let output = Output {
+        status,
+        stdout,
+        stderr,
+    };
 
     if !output.status.success() {
-        log_subprocess_failure("Agent", &output, verbose, Some(agent_command), Some(worktree_path));
+        log_subprocess_failure(
+            "Agent",
+            &output,
+            verbose,
+            Some(agent_command),
+            Some(worktree_path),
+        );
     }
 
     let result_path = worktree_path.join(".polyresearch/result.json");
@@ -192,15 +222,15 @@ pub fn recover_from_logs(worktree_path: &Path) -> Option<RecoveredMetric> {
 
     for entry in log_files {
         if let Ok(contents) = fs::read_to_string(entry.path()) {
-            if let Some(caps) = ops_per_sec_re.captures(&contents) {
-                if let Ok(val) = caps[1].parse::<f64>() {
-                    last_metric = Some(val);
-                }
+            if let Some(caps) = ops_per_sec_re.captures(&contents)
+                && let Ok(val) = caps[1].parse::<f64>()
+            {
+                last_metric = Some(val);
             }
-            if let Some(caps) = metric_re.captures(&contents) {
-                if let Ok(val) = caps[1].parse::<f64>() {
-                    last_metric = Some(val);
-                }
+            if let Some(caps) = metric_re.captures(&contents)
+                && let Ok(val) = caps[1].parse::<f64>()
+            {
+                last_metric = Some(val);
             }
         }
     }
@@ -251,18 +281,26 @@ pub fn spawn_thesis_generation(
     cmd.arg(prompt);
 
     eprintln!("Spawning agent for thesis generation...");
-    let output = cmd.output().wrap_err("failed to spawn agent for thesis generation")?;
+    let output = cmd
+        .output()
+        .wrap_err("failed to spawn agent for thesis generation")?;
 
     if !output.status.success() {
-        log_subprocess_failure("Thesis generation agent", &output, verbose, Some(agent_command), Some(worktree_path));
+        log_subprocess_failure(
+            "Thesis generation agent",
+            &output,
+            verbose,
+            Some(agent_command),
+            Some(worktree_path),
+        );
     }
 
     let proposals_path = worktree_path.join(".polyresearch/thesis-proposals.json");
     if proposals_path.exists() {
         let contents = fs::read_to_string(&proposals_path)
             .wrap_err("failed to read .polyresearch/thesis-proposals.json")?;
-        let proposals: Vec<ThesisProposal> = serde_json::from_str(&contents)
-            .wrap_err("failed to parse thesis-proposals.json")?;
+        let proposals: Vec<ThesisProposal> =
+            serde_json::from_str(&contents).wrap_err("failed to parse thesis-proposals.json")?;
         return Ok(proposals);
     }
 
@@ -276,8 +314,7 @@ pub fn write_thesis_context(
     prior_attempts: &str,
 ) -> Result<()> {
     let dir = worktree_path.join(".polyresearch");
-    fs::create_dir_all(&dir)
-        .wrap_err_with(|| format!("failed to create {}", dir.display()))?;
+    fs::create_dir_all(&dir).wrap_err_with(|| format!("failed to create {}", dir.display()))?;
 
     let mut content = format!("# Thesis: {thesis_title}\n\n{thesis_body}\n");
     if !prior_attempts.is_empty() {
@@ -285,8 +322,7 @@ pub fn write_thesis_context(
     }
 
     let path = dir.join("thesis.md");
-    fs::write(&path, &content)
-        .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    fs::write(&path, &content).wrap_err_with(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -313,7 +349,10 @@ fn find_harness(worktree_path: &Path) -> Option<HarnessSpec> {
 
     for &(relative_path, runner) in candidates {
         if worktree_path.join(relative_path).exists() {
-            return Some(HarnessSpec { runner, relative_path });
+            return Some(HarnessSpec {
+                runner,
+                relative_path,
+            });
         }
     }
 
@@ -330,7 +369,13 @@ fn run_harness_in(harness: &HarnessSpec, work_dir: &Path, verbose: bool) -> Resu
 
     if !output.status.success() {
         let cmd_line = format!("{} {}", harness.runner, script_path.display());
-        log_subprocess_failure("Evaluation harness", &output, verbose, Some(&cmd_line), Some(work_dir));
+        log_subprocess_failure(
+            "Evaluation harness",
+            &output,
+            verbose,
+            Some(&cmd_line),
+            Some(work_dir),
+        );
         return Ok(None);
     }
 
@@ -338,20 +383,18 @@ fn run_harness_in(harness: &HarnessSpec, work_dir: &Path, verbose: bool) -> Resu
     let metric_re = Regex::new(r"(?m)^METRIC=(\d+\.?\d*)$").ok();
     let ops_re = Regex::new(r"ops_per_sec=(\d+\.?\d*)").ok();
 
-    if let Some(re) = &metric_re {
-        if let Some(caps) = re.captures(&stdout) {
-            if let Ok(val) = caps[1].parse::<f64>() {
-                return Ok(Some(val));
-            }
-        }
+    if let Some(re) = &metric_re
+        && let Some(caps) = re.captures(&stdout)
+        && let Ok(val) = caps[1].parse::<f64>()
+    {
+        return Ok(Some(val));
     }
 
-    if let Some(re) = &ops_re {
-        if let Some(caps) = re.captures(&stdout) {
-            if let Ok(val) = caps[1].parse::<f64>() {
-                return Ok(Some(val));
-            }
-        }
+    if let Some(re) = &ops_re
+        && let Some(caps) = re.captures(&stdout)
+        && let Ok(val) = caps[1].parse::<f64>()
+    {
+        return Ok(Some(val));
     }
 
     Ok(None)
@@ -406,7 +449,8 @@ mod tests {
 
     #[test]
     fn parses_experiment_result() {
-        let json = r#"{"metric": 0.95, "baseline": 0.90, "observation": "improved", "summary": "test"}"#;
+        let json =
+            r#"{"metric": 0.95, "baseline": 0.90, "observation": "improved", "summary": "test"}"#;
         let result: ExperimentResult = serde_json::from_str(json).unwrap();
         assert!(result.is_improved());
         assert!((result.metric - 0.95).abs() < f64::EPSILON);
@@ -441,7 +485,11 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("recover-logs-{}", std::process::id()));
         let poly_dir = dir.join(".polyresearch");
         fs::create_dir_all(&poly_dir).unwrap();
-        fs::write(poly_dir.join("run-001.log"), "starting...\nops_per_sec=42.5\ndone").unwrap();
+        fs::write(
+            poly_dir.join("run-001.log"),
+            "starting...\nops_per_sec=42.5\ndone",
+        )
+        .unwrap();
 
         let result = recover_from_logs(&dir);
         assert!(result.is_some());
@@ -457,7 +505,11 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("recover-metric-{}", std::process::id()));
         let poly_dir = dir.join(".polyresearch");
         fs::create_dir_all(&poly_dir).unwrap();
-        fs::write(poly_dir.join("run-002.log"), "setup done\nMETRIC=99.5\ncomplete").unwrap();
+        fs::write(
+            poly_dir.join("run-002.log"),
+            "setup done\nMETRIC=99.5\ncomplete",
+        )
+        .unwrap();
 
         let result = recover_from_logs(&dir);
         assert!(result.is_some());

--- a/cli/src/commands/audit.rs
+++ b/cli/src/commands/audit.rs
@@ -54,7 +54,11 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     };
 
     print_value(ctx, &output, |value| {
-        if value.invalid_count == 0 && value.suspicious_count == 0 && value.info_count == 0 && value.ledger_current {
+        if value.invalid_count == 0
+            && value.suspicious_count == 0
+            && value.info_count == 0
+            && value.ledger_current
+        {
             format!("Audit clean for {}.", value.repo)
         } else {
             format!(

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -133,10 +133,9 @@ fn select_claimable_theses<'a>(
         .filter(|thesis| matches!(thesis.phase, ThesisPhase::Approved))
         .filter(|thesis| thesis.active_claims.is_empty())
         .filter(|thesis| {
-            !thesis
-                .releases
-                .iter()
-                .any(|release| release.node == node && release.reason == ReleaseReason::NoImprovement)
+            !thesis.releases.iter().any(|release| {
+                release.node == node && release.reason == ReleaseReason::NoImprovement
+            })
         })
         .collect::<Vec<_>>();
     theses.sort_by_key(|thesis| thesis.issue.number);

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -55,7 +55,10 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
 pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<(std::path::PathBuf, String)> {
     let upstream = RepoRef::from_user_input(&args.url)?;
     let clone_url = upstream.clone_url();
-    eprintln!("Bootstrapping polyresearch project from {}", upstream.slug());
+    eprintln!(
+        "Bootstrapping polyresearch project from {}",
+        upstream.slug()
+    );
 
     let repo_root = if ctx.repo_root.join(".git").exists() {
         ctx.repo_root.clone()
@@ -129,7 +132,9 @@ fn get_current_login() -> Result<String> {
     }
     let login = String::from_utf8(output.stdout)?.trim().to_string();
     if login.is_empty() {
-        return Err(eyre!("could not determine GitHub login; run `gh auth login` first"));
+        return Err(eyre!(
+            "could not determine GitHub login; run `gh auth login` first"
+        ));
     }
     Ok(login)
 }
@@ -242,8 +247,11 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>, login: &str) -> Res
 
     let results_path = repo_root.join("results.tsv");
     if !results_path.exists() {
-        fs::write(&results_path, "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n")
-            .wrap_err_with(|| format!("failed to write {}", results_path.display()))?;
+        fs::write(
+            &results_path,
+            "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+        )
+        .wrap_err_with(|| format!("failed to write {}", results_path.display()))?;
         eprintln!("Created {}", results_path.display());
     }
 
@@ -265,8 +273,8 @@ fn ensure_lead_login(repo_root: &Path, login: &str) -> Result<()> {
         return Ok(());
     }
 
-    let contents = fs::read_to_string(&path)
-        .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    let contents =
+        fs::read_to_string(&path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
 
     let keys = ["lead_github_login", "maintainer_github_login"];
     let mut changed = false;
@@ -275,13 +283,13 @@ fn ensure_lead_login(repo_root: &Path, login: &str) -> Result<()> {
         .map(|line| {
             let trimmed = line.trim();
             for key in &keys {
-                if let Some(rest) = trimmed.strip_prefix(*key) {
-                    if let Some(value) = rest.strip_prefix(':') {
-                        let value = value.trim();
-                        if !value.is_empty() && value != login {
-                            changed = true;
-                            return format!("{key}: {login}");
-                        }
+                if let Some(rest) = trimmed.strip_prefix(*key)
+                    && let Some(value) = rest.strip_prefix(':')
+                {
+                    let value = value.trim();
+                    if !value.is_empty() && value != login {
+                        changed = true;
+                        return format!("{key}: {login}");
                     }
                 }
             }
@@ -314,7 +322,12 @@ fn replace_goal_section(template: &str, goal: &str) -> String {
         .find("\n## ")
         .map(|i| body_start + i)
         .unwrap_or(template.len());
-    format!("{}\n{}\n{}", &template[..body_start], goal, &template[body_end..])
+    format!(
+        "{}\n{}\n{}",
+        &template[..body_start],
+        goal,
+        &template[body_end..]
+    )
 }
 
 fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
@@ -326,8 +339,13 @@ fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> R
     Ok(())
 }
 
-fn spawn_setup_agent(repo_root: &Path, overrides: &crate::cli::NodeOverrides, verbose: bool, login: &str) -> Result<()> {
-    let node_config = NodeConfig::load(&repo_root.to_path_buf())
+fn spawn_setup_agent(
+    repo_root: &Path,
+    overrides: &crate::cli::NodeOverrides,
+    verbose: bool,
+    login: &str,
+) -> Result<()> {
+    let node_config = NodeConfig::load(repo_root)
         .ok()
         .map(|c| c.with_overrides(overrides));
     let agent_command = node_config
@@ -397,7 +415,9 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
 
     match commands::run_git(&repo, &["push", "origin", "HEAD"]) {
         Ok(_) => eprintln!("Committed and pushed setup files."),
-        Err(err) => eprintln!("Committed setup files locally. Push failed (run `git push` manually): {err}"),
+        Err(err) => {
+            eprintln!("Committed setup files locally. Push failed (run `git push` manually): {err}")
+        }
     }
     Ok(())
 }
@@ -412,8 +432,8 @@ pub fn normalize_program_md(repo_root: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let contents = fs::read_to_string(&path)
-        .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    let contents =
+        fs::read_to_string(&path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
 
     let required_sections = [
         "## Goal",

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -84,8 +84,12 @@ pub(crate) fn claim_selected_thesis(
         (branch, worktree_path)
     } else {
         let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
-        let workspace =
-            create_thesis_worktree(&ctx.repo_root, thesis.issue.number, &thesis.issue.title, &default_branch)?;
+        let workspace = create_thesis_worktree(
+            &ctx.repo_root,
+            thesis.issue.number,
+            &thesis.issue.title,
+            &default_branch,
+        )?;
         (
             workspace.branch,
             workspace.worktree_path.display().to_string(),

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -7,7 +7,7 @@ use color_eyre::eyre::{Result, eyre};
 use crate::cli::ContributeArgs;
 use crate::commands::{self, AppContext};
 use crate::comments::{Observation, ProtocolComment, ReleaseReason};
-use crate::config::{NodeConfig, ProtocolConfig, ProgramSpec};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::github::{GitHubApi, GitHubClient, RepoRef};
 use crate::hardware;
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
@@ -92,6 +92,7 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_iteration(
     ctx: &AppContext,
     args: &ContributeArgs,
@@ -113,7 +114,10 @@ async fn run_iteration(
         if thesis.issue.state != "OPEN" {
             continue;
         }
-        let has_merged_pr = thesis.pull_requests.iter().any(|pr| pr.pr.state == "MERGED");
+        let has_merged_pr = thesis
+            .pull_requests
+            .iter()
+            .any(|pr| pr.pr.state == "MERGED");
         if has_merged_pr {
             continue;
         }
@@ -124,10 +128,7 @@ async fn run_iteration(
                     .iter()
                     .any(|c| c.node == node_id && a.created_at >= c.created_at)
         });
-        let has_open_pr = thesis
-            .pull_requests
-            .iter()
-            .any(|pr| pr.pr.state == "OPEN");
+        let has_open_pr = thesis.pull_requests.iter().any(|pr| pr.pr.state == "OPEN");
         if has_improved && !has_open_pr {
             eprintln!("Auto-submitting thesis #{}...", thesis.issue.number);
             let worktree_path = commands::thesis_worktree_path(
@@ -155,10 +156,18 @@ async fn run_iteration(
                             &format!("References #{}", thesis.issue.number),
                             default_branch,
                         ) {
-                            Ok(_) => { submitted_any = true; }
-                            Err(err) => eprintln!("Warning: PR creation failed for thesis #{}: {err}", thesis.issue.number),
+                            Ok(_) => {
+                                submitted_any = true;
+                            }
+                            Err(err) => eprintln!(
+                                "Warning: PR creation failed for thesis #{}: {err}",
+                                thesis.issue.number
+                            ),
                         },
-                        Err(err) => eprintln!("Warning: push failed for thesis #{}: {err}", thesis.issue.number),
+                        Err(err) => eprintln!(
+                            "Warning: push failed for thesis #{}: {err}",
+                            thesis.issue.number
+                        ),
                     }
                 }
             }
@@ -288,6 +297,7 @@ async fn run_iteration(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_worker_context(
     thesis: &ThesisState,
     repo_root: &Path,
@@ -355,10 +365,7 @@ fn cleanup_worktree(repo_root: &Path, worktree_path: &Path) {
     }
 }
 
-fn claimable_theses<'a>(
-    repo_state: &'a RepositoryState,
-    node_id: &str,
-) -> Vec<&'a ThesisState> {
+fn claimable_theses<'a>(repo_state: &'a RepositoryState, node_id: &str) -> Vec<&'a ThesisState> {
     repo_state
         .theses
         .iter()
@@ -375,10 +382,7 @@ fn claimable_theses<'a>(
         .collect()
 }
 
-fn resumable_theses<'a>(
-    repo_state: &'a RepositoryState,
-    node_id: &str,
-) -> Vec<&'a ThesisState> {
+fn resumable_theses<'a>(repo_state: &'a RepositoryState, node_id: &str) -> Vec<&'a ThesisState> {
     repo_state
         .theses
         .iter()
@@ -429,10 +433,10 @@ fn parse_prepare_key(repo_root: &Path, key: &str) -> Option<String> {
     let contents = std::fs::read_to_string(path).ok()?;
     for line in contents.lines() {
         let trimmed = line.trim();
-        if let Some((k, v)) = trimmed.split_once(':') {
-            if k.trim() == key {
-                return Some(v.trim().to_string());
-            }
+        if let Some((k, v)) = trimmed.split_once(':')
+            && k.trim() == key
+        {
+            return Some(v.trim().to_string());
         }
     }
     None

--- a/cli/src/commands/decide.rs
+++ b/cli/src/commands/decide.rs
@@ -73,7 +73,10 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
             ctx.config.required_confirmations,
         )?
     } else {
-        DecisionExecuted { outcome, confirmations }
+        DecisionExecuted {
+            outcome,
+            confirmations,
+        }
     };
 
     let output = DecideOutput {
@@ -128,7 +131,12 @@ pub(crate) fn decide_without_peer_review(
     let Some(baseline) = attempt.baseline_metric else {
         return Ok(Outcome::NonImprovement);
     };
-    if !metric_beats(attempt.metric, baseline, tolerance, ctx.config.metric_direction) {
+    if !metric_beats(
+        attempt.metric,
+        baseline,
+        tolerance,
+        ctx.config.metric_direction,
+    ) {
         return Ok(Outcome::NonImprovement);
     }
 
@@ -270,6 +278,7 @@ fn close_pr_and_cleanup(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_decision(
     github: &Arc<dyn GitHubApi>,
     repo_root: Option<&PathBuf>,
@@ -332,7 +341,10 @@ pub fn execute_decision(
                 };
                 github.post_issue_comment(pr_number, &comment.render())?;
                 github.close_issue(thesis_number)?;
-                DecisionExecuted { outcome, confirmations }
+                DecisionExecuted {
+                    outcome,
+                    confirmations,
+                }
             } else {
                 let comment = ProtocolComment::Decision {
                     thesis: thesis_number,
@@ -342,7 +354,10 @@ pub fn execute_decision(
                 };
                 github.post_issue_comment(pr_number, &comment.render())?;
                 close_pr_and_cleanup(github, pr_number, head_ref_name)?;
-                DecisionExecuted { outcome: Outcome::Stale, confirmations: 0 }
+                DecisionExecuted {
+                    outcome: Outcome::Stale,
+                    confirmations: 0,
+                }
             }
         }
         Outcome::InfraFailure | Outcome::Stale => {
@@ -354,7 +369,10 @@ pub fn execute_decision(
             };
             github.post_issue_comment(pr_number, &comment.render())?;
             close_pr_and_cleanup(github, pr_number, head_ref_name)?;
-            DecisionExecuted { outcome, confirmations }
+            DecisionExecuted {
+                outcome,
+                confirmations,
+            }
         }
         Outcome::NonImprovement | Outcome::Disagreement | Outcome::PolicyRejection => {
             let comment = ProtocolComment::Decision {
@@ -368,7 +386,10 @@ pub fn execute_decision(
             if required_confirmations > 0 || !matches!(outcome, Outcome::NonImprovement) {
                 github.close_issue(thesis_number)?;
             }
-            DecisionExecuted { outcome, confirmations }
+            DecisionExecuted {
+                outcome,
+                confirmations,
+            }
         }
     };
     Ok(result)

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -279,7 +279,9 @@ fn check_contributor_idle_state(
     if repo_state.queue_depth == 0 {
         advisory.push(DutyItem {
             category: "idle".to_string(),
-            message: "Queue is empty. Wait for the lead to generate theses. Do not assume lead duties.".to_string(),
+            message:
+                "Queue is empty. Wait for the lead to generate theses. Do not assume lead duties."
+                    .to_string(),
             command: "sleep 60 && polyresearch duties".to_string(),
         });
         return Ok(());
@@ -341,10 +343,9 @@ fn check_contributor_idle_state(
         .filter(|thesis| {
             thesis.issue.state == "OPEN"
                 && matches!(thesis.phase, ThesisPhase::Approved)
-                && !thesis
-                    .releases
-                    .iter()
-                    .any(|release| release.node == node_id && release.reason == ReleaseReason::NoImprovement)
+                && !thesis.releases.iter().any(|release| {
+                    release.node == node_id && release.reason == ReleaseReason::NoImprovement
+                })
         })
         .count();
 

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -39,14 +39,14 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         ));
     }
 
-    if let Some(max_queue_depth) = ctx.config.max_queue_depth {
-        if repo_state.queue_depth >= max_queue_depth {
-            return Err(eyre!(
-                "queue depth is already {} (max_queue_depth = {}), refusing to generate more theses",
-                repo_state.queue_depth,
-                max_queue_depth
-            ));
-        }
+    if let Some(max_queue_depth) = ctx.config.max_queue_depth
+        && repo_state.queue_depth >= max_queue_depth
+    {
+        return Err(eyre!(
+            "queue depth is already {} (max_queue_depth = {}), refusing to generate more theses",
+            repo_state.queue_depth,
+            max_queue_depth
+        ));
     }
 
     let warned_below_min_queue_depth = repo_state.queue_depth < ctx.config.min_queue_depth;

--- a/cli/src/commands/guards.rs
+++ b/cli/src/commands/guards.rs
@@ -16,19 +16,16 @@ pub fn ensure_lead(ctx: &AppContext) -> Result<String> {
     Ok(login)
 }
 
-pub fn find_thesis<'a>(
-    repo_state: &'a RepositoryState,
-    issue_number: u64,
-) -> Result<&'a ThesisState> {
+pub fn find_thesis(repo_state: &RepositoryState, issue_number: u64) -> Result<&ThesisState> {
     repo_state
         .get_thesis(issue_number)
         .ok_or_else(|| eyre!("thesis #{} not found", issue_number))
 }
 
-pub fn require_claimable_thesis<'a>(
-    repo_state: &'a RepositoryState,
+pub fn require_claimable_thesis(
+    repo_state: &RepositoryState,
     issue_number: u64,
-) -> Result<&'a ThesisState> {
+) -> Result<&ThesisState> {
     let thesis = find_thesis(repo_state, issue_number)?;
     if thesis.issue.state != "OPEN" {
         return Err(eyre!("thesis #{} is not open", issue_number));
@@ -65,10 +62,10 @@ pub fn require_claimed_thesis<'a>(
     Ok(thesis)
 }
 
-pub fn require_pull_request<'a>(
-    repo_state: &'a RepositoryState,
+pub fn require_pull_request(
+    repo_state: &RepositoryState,
     pr_number: u64,
-) -> Result<(&'a ThesisState, &'a PullRequestState)> {
+) -> Result<(&ThesisState, &PullRequestState)> {
     repo_state
         .get_pull_request(pr_number)
         .ok_or_else(|| eyre!("PR #{} not found", pr_number))
@@ -118,10 +115,10 @@ pub fn require_claimed_review_pr<'a>(
     Ok((thesis, pr_state))
 }
 
-pub fn require_decidable_pr<'a>(
-    repo_state: &'a RepositoryState,
+pub fn require_decidable_pr(
+    repo_state: &RepositoryState,
     pr_number: u64,
-) -> Result<(&'a ThesisState, &'a PullRequestState)> {
+) -> Result<(&ThesisState, &PullRequestState)> {
     let (thesis, pr_state) = require_pull_request(repo_state, pr_number)?;
     if pr_state.decision.is_some() {
         return Err(eyre!("PR #{} already has a decision", pr_number));
@@ -141,7 +138,8 @@ pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<
     if blocking_count > 0 {
         return Err(eyre!(
             "cannot {} while {} critical audit finding(s) are present; run `polyresearch audit` and resolve them through `polyresearch admin ...` first",
-            action, blocking_count
+            action,
+            blocking_count
         ));
     }
     Ok(())
@@ -149,10 +147,7 @@ pub fn ensure_clean_audit(repo_state: &RepositoryState, action: &str) -> Result<
 
 /// Checks that the audit is clean and results.tsv is current.
 /// Call after `ensure_lead` and `RepositoryState::derive`.
-pub fn ensure_current_ledger(
-    ctx: &AppContext,
-    repo_state: &RepositoryState,
-) -> Result<Ledger> {
+pub fn ensure_current_ledger(ctx: &AppContext, repo_state: &RepositoryState) -> Result<Ledger> {
     ensure_clean_audit(repo_state, "proceed")?;
     let ledger = Ledger::load(&ctx.repo_root)?;
     if !ledger.is_current(repo_state) {
@@ -165,19 +160,15 @@ pub fn ensure_current_ledger(
 
 /// After a release with `no_improvement`, re-derive state and close the issue
 /// if the thesis has become Exhausted (no remaining active claims).
-pub async fn close_if_exhausted(
-    ctx: &AppContext,
-    issue: u64,
-    reason: ReleaseReason,
-) -> Result<()> {
+pub async fn close_if_exhausted(ctx: &AppContext, issue: u64, reason: ReleaseReason) -> Result<()> {
     if reason != ReleaseReason::NoImprovement {
         return Ok(());
     }
     let updated = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    if let Some(t) = updated.theses.iter().find(|t| t.issue.number == issue) {
-        if matches!(t.phase, ThesisPhase::Exhausted) {
-            ctx.github.close_issue(issue)?;
-        }
+    if let Some(t) = updated.theses.iter().find(|t| t.issue.number == issue)
+        && matches!(t.phase, ThesisPhase::Exhausted)
+    {
+        ctx.github.close_issue(issue)?;
     }
     Ok(())
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -64,10 +64,10 @@ fn default_machine_id() -> String {
 }
 
 fn resolve_hostname() -> String {
-    if let Ok(hostname) = env::var("HOSTNAME") {
-        if !hostname.trim().is_empty() {
-            return hostname;
-        }
+    if let Ok(hostname) = env::var("HOSTNAME")
+        && !hostname.trim().is_empty()
+    {
+        return hostname;
     }
 
     let output = Command::new("hostname").output();

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -4,10 +4,10 @@ use color_eyre::eyre::{Result, eyre};
 
 use crate::agent;
 use crate::cli::LeadArgs;
-use crate::commands::{self, AppContext};
 use crate::commands::decide;
+use crate::commands::{self, AppContext};
 use crate::comments::{Outcome, ProtocolComment};
-use crate::config::{NodeConfig, ProtocolConfig, ProgramSpec};
+use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
 use crate::ledger::Ledger;
 use crate::state::RepositoryState;
 
@@ -47,7 +47,10 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
             return Ok(());
         }
 
-        eprintln!("Sleeping {}s before next lead iteration...", args.sleep_secs);
+        eprintln!(
+            "Sleeping {}s before next lead iteration...",
+            args.sleep_secs
+        );
         tokio::time::sleep(Duration::from_secs(args.sleep_secs)).await;
     }
 }
@@ -73,7 +76,11 @@ async fn run_iteration(
     Ok(())
 }
 
-pub fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_branch: &str) -> Result<()> {
+pub fn sync_if_stale(
+    ctx: &AppContext,
+    repo_state: &RepositoryState,
+    default_branch: &str,
+) -> Result<()> {
     let ledger = Ledger::load(&ctx.repo_root)?;
     if ledger.is_current(repo_state) {
         return Ok(());
@@ -96,7 +103,10 @@ pub fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_bra
         return Ok(());
     }
 
-    commands::run_git(&ctx.repo_root, &["pull", "origin", default_branch, "--ff-only"])?;
+    commands::run_git(
+        &ctx.repo_root,
+        &["pull", "origin", default_branch, "--ff-only"],
+    )?;
 
     let mut ledger = Ledger::load(&ctx.repo_root)?;
     let missing = ledger.missing_rows(repo_state);
@@ -105,7 +115,11 @@ pub fn sync_if_stale(ctx: &AppContext, repo_state: &RepositoryState, default_bra
     }
 
     ledger.append_rows(&missing)?;
-    commands::commit_file(&ctx.repo_root, "results.tsv", "Update results.tsv via polyresearch lead sync.")?;
+    commands::commit_file(
+        &ctx.repo_root,
+        "results.tsv",
+        "Update results.tsv via polyresearch lead sync.",
+    )?;
     commands::run_git(&ctx.repo_root, &["push"])?;
     eprintln!("Synced {} rows to results.tsv", missing.len());
     Ok(())
@@ -143,7 +157,10 @@ pub fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> 
                 if violations.is_empty() {
                     eprintln!("Would post policy-pass on PR #{}", pr_state.pr.number);
                 } else {
-                    eprintln!("Would reject PR #{} for policy violations: {:?}", pr_state.pr.number, violations);
+                    eprintln!(
+                        "Would reject PR #{} for policy violations: {:?}",
+                        pr_state.pr.number, violations
+                    );
                 }
                 continue;
             }
@@ -153,7 +170,8 @@ pub fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> 
                     thesis: thesis_num,
                     candidate_sha: pr_state.pr.head_ref_oid.clone().unwrap_or_default(),
                 };
-                ctx.github.post_issue_comment(pr_state.pr.number, &comment.render())?;
+                ctx.github
+                    .post_issue_comment(pr_state.pr.number, &comment.render())?;
                 eprintln!("Policy-pass posted on PR #{}", pr_state.pr.number);
             } else {
                 let comment = ProtocolComment::Decision {
@@ -162,7 +180,8 @@ pub fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> 
                     outcome: Outcome::PolicyRejection,
                     confirmations: 0,
                 };
-                ctx.github.post_issue_comment(pr_state.pr.number, &comment.render())?;
+                ctx.github
+                    .post_issue_comment(pr_state.pr.number, &comment.render())?;
                 ctx.github.close_pull_request(pr_state.pr.number)?;
                 ctx.github.close_issue(thesis_num)?;
                 eprintln!("PR #{} rejected for policy violations", pr_state.pr.number);
@@ -172,7 +191,11 @@ pub fn policy_check_open_prs(ctx: &AppContext, repo_state: &RepositoryState) -> 
     Ok(())
 }
 
-pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &RepositoryState) -> Result<()> {
+pub fn decide_ready_prs(
+    ctx: &AppContext,
+    config: &ProtocolConfig,
+    repo_state: &RepositoryState,
+) -> Result<()> {
     let required = config.required_confirmations as usize;
 
     let ledger = if config.required_confirmations == 0 {
@@ -193,7 +216,10 @@ pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &
             }
 
             if pr_state.pr.mergeable.as_deref() == Some("CONFLICTING") {
-                eprintln!("PR #{} has merge conflicts, closing as stale...", pr_state.pr.number);
+                eprintln!(
+                    "PR #{} has merge conflicts, closing as stale...",
+                    pr_state.pr.number
+                );
                 if !ctx.cli.dry_run {
                     let stale_comment = ProtocolComment::Decision {
                         thesis: thesis.issue.number,
@@ -201,7 +227,8 @@ pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &
                         outcome: Outcome::Stale,
                         confirmations: 0,
                     };
-                    ctx.github.post_issue_comment(pr_state.pr.number, &stale_comment.render())?;
+                    ctx.github
+                        .post_issue_comment(pr_state.pr.number, &stale_comment.render())?;
                     ctx.github.close_pull_request(pr_state.pr.number)?;
                 }
                 continue;
@@ -221,7 +248,11 @@ pub fn decide_ready_prs(ctx: &AppContext, config: &ProtocolConfig, repo_state: &
             };
 
             let candidate_sha = pr_state.pr.head_ref_oid.clone().unwrap_or_default();
-            let confirmations = if required == 0 { 0 } else { pr_state.reviews.len() as u64 };
+            let confirmations = if required == 0 {
+                0
+            } else {
+                pr_state.reviews.len() as u64
+            };
 
             let result = decide::execute_decision(
                 &ctx.github,
@@ -252,10 +283,10 @@ async fn generate_if_needed(
         return Ok(());
     }
 
-    if let Some(max) = config.max_queue_depth {
-        if repo_state.queue_depth >= max {
-            return Ok(());
-        }
+    if let Some(max) = config.max_queue_depth
+        && repo_state.queue_depth >= max
+    {
+        return Ok(());
     }
 
     let blocking_count = repo_state
@@ -269,11 +300,16 @@ async fn generate_if_needed(
     }
     let non_blocking = repo_state.audit_findings.len() - blocking_count;
     if non_blocking > 0 {
-        eprintln!("Note: {non_blocking} non-blocking audit finding(s) present (run `polyresearch audit`)");
+        eprintln!(
+            "Note: {non_blocking} non-blocking audit finding(s) present (run `polyresearch audit`)"
+        );
     }
 
-    let needed = config.min_queue_depth.saturating_sub(repo_state.queue_depth);
-    let capped = config.max_queue_depth
+    let needed = config
+        .min_queue_depth
+        .saturating_sub(repo_state.queue_depth);
+    let capped = config
+        .max_queue_depth
         .map(|max| needed.min(max.saturating_sub(repo_state.queue_depth)))
         .unwrap_or(needed);
 
@@ -281,7 +317,10 @@ async fn generate_if_needed(
         return Ok(());
     }
 
-    eprintln!("Queue depth {} < min {}, generating up to {capped} theses...", repo_state.queue_depth, config.min_queue_depth);
+    eprintln!(
+        "Queue depth {} < min {}, generating up to {capped} theses...",
+        repo_state.queue_depth, config.min_queue_depth
+    );
 
     if ctx.cli.dry_run {
         eprintln!("Would generate {capped} thesis proposals");
@@ -302,14 +341,19 @@ async fn generate_if_needed(
     eprintln!("Agent produced {} thesis proposals", proposals.len());
 
     for proposal in proposals {
-        let issue = ctx.github.create_issue(&proposal.title, &proposal.body, &["thesis"])?;
+        let issue = ctx
+            .github
+            .create_issue(&proposal.title, &proposal.body, &["thesis"])?;
         eprintln!("Created thesis #{}: {}", issue.number, proposal.title);
 
         if config.auto_approve {
             let approval = ProtocolComment::Approval {
                 thesis: issue.number,
             };
-            if let Err(err) = ctx.github.post_issue_comment(issue.number, &approval.render()) {
+            if let Err(err) = ctx
+                .github
+                .post_issue_comment(issue.number, &approval.render())
+            {
                 eprintln!("Failed to approve #{}, closing: {err}", issue.number);
                 let _ = ctx.github.close_issue(issue.number);
                 continue;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -107,25 +107,31 @@ pub fn exit_with(code: i32, message: impl Into<String>) -> Result<()> {
     .into())
 }
 
-pub fn read_node_config(repo_root: &PathBuf) -> Result<NodeConfig> {
+pub fn read_node_config(repo_root: &Path) -> Result<NodeConfig> {
     NodeConfig::load(repo_root)
 }
 
-pub fn read_node_id(repo_root: &PathBuf) -> Result<String> {
+pub fn read_node_id(repo_root: &Path) -> Result<String> {
     Ok(read_node_config(repo_root)?.node_id)
 }
 
-pub fn write_node_id(repo_root: &PathBuf, node: &str) -> Result<()> {
+pub fn write_node_id(repo_root: &Path, node: &str) -> Result<()> {
     write_node_config(repo_root, node, &crate::cli::NodeOverrides::default())
 }
 
 pub fn write_node_config(
-    repo_root: &PathBuf,
+    repo_root: &Path,
     node: &str,
     overrides: &crate::cli::NodeOverrides,
 ) -> Result<()> {
     let mut config = NodeConfig::load(repo_root).unwrap_or_else(|_| {
-        NodeConfig::new(node, crate::config::DEFAULT_CAPACITY, crate::config::DEFAULT_API_BUDGET, crate::config::DEFAULT_REQUEST_DELAY_MS, None)
+        NodeConfig::new(
+            node,
+            crate::config::DEFAULT_CAPACITY,
+            crate::config::DEFAULT_API_BUDGET,
+            crate::config::DEFAULT_REQUEST_DELAY_MS,
+            None,
+        )
     });
     config.node_id = node.to_string();
     config.with_overrides(overrides).save(repo_root)
@@ -151,7 +157,7 @@ pub fn ensure_node_config(repo_root: &Path) -> Result<()> {
             .collect()
     };
     let node_id = format!("{hostname}-{suffix}");
-    write_node_config(&repo_root.to_path_buf(), &node_id, &crate::cli::NodeOverrides::default())?;
+    write_node_config(repo_root, &node_id, &crate::cli::NodeOverrides::default())?;
     eprintln!("Initialized node as `{node_id}`");
     Ok(())
 }
@@ -206,7 +212,7 @@ pub struct ThesisWorkspace {
     pub worktree_path: PathBuf,
 }
 
-pub fn thesis_worktree_path(repo_root: &PathBuf, issue_number: u64, title: &str) -> PathBuf {
+pub fn thesis_worktree_path(repo_root: &Path, issue_number: u64, title: &str) -> PathBuf {
     let slug = slugify(title);
     repo_root
         .join(".worktrees")
@@ -245,7 +251,14 @@ pub fn create_thesis_worktree(
     let worktree_path_arg = worktree_path.to_string_lossy().into_owned();
     run_git(
         repo_root,
-        &["worktree", "add", "-b", &branch, &worktree_path_arg, default_branch],
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &branch,
+            &worktree_path_arg,
+            default_branch,
+        ],
     )?;
 
     Ok(ThesisWorkspace {

--- a/cli/src/commands/review.rs
+++ b/cli/src/commands/review.rs
@@ -34,7 +34,10 @@ pub async fn run(ctx: &AppContext, args: &ReviewArgs) -> Result<()> {
         .clone()
         .ok_or_else(|| eyre!("PR #{} does not expose a head SHA", args.pr))?;
     let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
-    let base_sha = run_git(&ctx.repo_root, &["merge-base", &default_branch, &candidate_sha])?;
+    let base_sha = run_git(
+        &ctx.repo_root,
+        &["merge-base", &default_branch, &candidate_sha],
+    )?;
     let env_sha = compute_env_sha(&ctx.repo_root.join(".polyresearch"))?;
 
     let comment = ProtocolComment::Review {

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -21,7 +21,9 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     if !ctx.cli.dry_run && !missing_rows.is_empty() {
         let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
         if current_branch(&ctx.repo_root)? != default_branch {
-            return Err(eyre!("`polyresearch sync` must run from the `{default_branch}` branch"));
+            return Err(eyre!(
+                "`polyresearch sync` must run from the `{default_branch}` branch"
+            ));
         }
         ledger.append_rows(&missing_rows)?;
         commit_file(

--- a/cli/src/comments.rs
+++ b/cli/src/comments.rs
@@ -174,10 +174,10 @@ impl ProtocolComment {
 
         let full_match = captures.get(0).unwrap();
         let before_match = &body[..full_match.start()];
-        if let Some(last_line) = before_match.rsplit('\n').next() {
-            if last_line.trim_start().starts_with('>') {
-                return Ok(None);
-            }
+        if let Some(last_line) = before_match.rsplit('\n').next()
+            && last_line.trim_start().starts_with('>')
+        {
+            return Ok(None);
         }
 
         let comment_type = captures

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -112,7 +112,13 @@ impl NodeConfig {
             .map(|config| config.request_delay_ms)
             .unwrap_or(DEFAULT_REQUEST_DELAY_MS);
 
-        Ok(Self::new(node_id, capacity, api_budget, request_delay_ms, file_config.as_ref().map(|c| c.agent.clone())))
+        Ok(Self::new(
+            node_id,
+            capacity,
+            api_budget,
+            request_delay_ms,
+            file_config.as_ref().map(|c| c.agent.clone()),
+        ))
     }
 
     pub fn load_api_budget(repo_root: &Path) -> u64 {
@@ -324,10 +330,11 @@ impl ProtocolConfig {
                     };
                 }
                 "metric_bound" => {
-                    config.metric_bound =
-                        Some(value.parse().wrap_err_with(|| {
-                            format!("invalid metric_bound value `{value}`")
-                        })?);
+                    config.metric_bound = Some(
+                        value
+                            .parse()
+                            .wrap_err_with(|| format!("invalid metric_bound value `{value}`"))?,
+                    );
                 }
                 "lead_github_login" => {
                     if value != "replace-me" && !value.is_empty() {
@@ -418,14 +425,14 @@ pub fn detect_default_branch_from_git(repo_root: &Path) -> String {
         .current_dir(repo_root)
         .output()
         .ok();
-    if let Some(output) = output {
-        if output.status.success() {
-            let raw = String::from_utf8_lossy(&output.stdout);
-            let branch = raw.trim();
-            let branch = branch.strip_prefix("origin/").unwrap_or(branch);
-            if !branch.is_empty() {
-                return branch.to_string();
-            }
+    if let Some(output) = output
+        && output.status.success()
+    {
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let branch = raw.trim();
+        let branch = branch.strip_prefix("origin/").unwrap_or(branch);
+        if !branch.is_empty() {
+            return branch.to_string();
         }
     }
     "main".to_string()
@@ -818,7 +825,13 @@ capacity = 50
 
     #[test]
     fn defaults_capacity_when_zero() {
-        let config = NodeConfig::new("node-7f83", 0, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "node-7f83",
+            0,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         assert_eq!(config.capacity, DEFAULT_CAPACITY);
     }
 
@@ -836,7 +849,13 @@ capacity = 50
 
     #[test]
     fn defaults_api_budget_when_missing() {
-        let config = NodeConfig::new("node-7f83", DEFAULT_CAPACITY, 0, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "node-7f83",
+            DEFAULT_CAPACITY,
+            0,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         assert_eq!(config.effective_api_budget(), DEFAULT_API_BUDGET);
     }
 
@@ -1072,7 +1091,13 @@ Do something.
 
     #[test]
     fn with_overrides_applies_capacity() {
-        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "n",
+            DEFAULT_CAPACITY,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         let overrides = crate::cli::NodeOverrides {
             capacity: Some(42),
             ..Default::default()
@@ -1086,7 +1111,13 @@ Do something.
 
     #[test]
     fn with_overrides_applies_api_budget() {
-        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "n",
+            DEFAULT_CAPACITY,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         let overrides = crate::cli::NodeOverrides {
             api_budget: Some(10_000),
             ..Default::default()
@@ -1098,7 +1129,13 @@ Do something.
 
     #[test]
     fn with_overrides_applies_request_delay() {
-        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "n",
+            DEFAULT_CAPACITY,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         let overrides = crate::cli::NodeOverrides {
             request_delay: Some(500),
             ..Default::default()
@@ -1109,7 +1146,13 @@ Do something.
 
     #[test]
     fn with_overrides_applies_agent_command() {
-        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "n",
+            DEFAULT_CAPACITY,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         let overrides = crate::cli::NodeOverrides {
             agent_command: Some("codex --full-auto".to_string()),
             ..Default::default()
@@ -1139,7 +1182,16 @@ Do something.
 
     #[test]
     fn with_overrides_empty_leaves_unchanged() {
-        let config = NodeConfig::new("n", 50, 3000, 200, Some(AgentConfig { command: "original".to_string(), ..Default::default() }));
+        let config = NodeConfig::new(
+            "n",
+            50,
+            3000,
+            200,
+            Some(AgentConfig {
+                command: "original".to_string(),
+                ..Default::default()
+            }),
+        );
         let overrides = crate::cli::NodeOverrides::default();
         let updated = config.clone().with_overrides(&overrides);
         assert_eq!(updated, config);
@@ -1164,7 +1216,13 @@ Do something.
 
     #[test]
     fn with_overrides_applies_agent_timeout() {
-        let config = NodeConfig::new("n", DEFAULT_CAPACITY, DEFAULT_API_BUDGET, DEFAULT_REQUEST_DELAY_MS, None);
+        let config = NodeConfig::new(
+            "n",
+            DEFAULT_CAPACITY,
+            DEFAULT_API_BUDGET,
+            DEFAULT_REQUEST_DELAY_MS,
+            None,
+        );
         let overrides = crate::cli::NodeOverrides {
             agent_timeout: Some(120),
             ..Default::default()

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -64,8 +64,8 @@ impl RepoRef {
     }
 
     fn parse_remote(remote: &str) -> Result<Self> {
-        let stripped = strip_github_prefix(remote)
-            .unwrap_or_else(|| remote.trim().trim_end_matches(".git"));
+        let stripped =
+            strip_github_prefix(remote).unwrap_or_else(|| remote.trim().trim_end_matches(".git"));
         Self::parse(stripped)
     }
 
@@ -173,10 +173,10 @@ impl GitHubClient {
     }
 
     pub fn auth_token(&self) -> Result<String> {
-        if let Ok(token) = env::var("GITHUB_TOKEN") {
-            if !token.trim().is_empty() {
-                return Ok(token);
-            }
+        if let Ok(token) = env::var("GITHUB_TOKEN")
+            && !token.trim().is_empty()
+        {
+            return Ok(token);
         }
 
         let output = Command::new("gh")
@@ -824,8 +824,8 @@ impl std::error::Error for GitHubCliError {}
 
 fn run_json_command(mut command: Command, idempotent: bool) -> Result<serde_json::Value> {
     let stdout = run_command_with_retries(&mut command, idempotent)?;
-    Ok(serde_json::from_str(&stdout)
-        .wrap_err_with(|| format!("failed to parse GitHub CLI JSON output: {stdout}"))?)
+    serde_json::from_str(&stdout)
+        .wrap_err_with(|| format!("failed to parse GitHub CLI JSON output: {stdout}"))
 }
 
 fn run_text_command(mut command: Command, idempotent: bool) -> Result<String> {
@@ -975,7 +975,9 @@ fn classify_error_hint(stderr: &str) -> Option<&'static str> {
     let lowered = stderr.to_ascii_lowercase();
 
     if lowered.contains("has disabled issues") {
-        return Some("Enable Issues in your repository settings: gh api repos/OWNER/REPO --method PATCH -f has_issues=true");
+        return Some(
+            "Enable Issues in your repository settings: gh api repos/OWNER/REPO --method PATCH -f has_issues=true",
+        );
     }
 
     if lowered.contains("could not authenticate")
@@ -987,7 +989,9 @@ fn classify_error_hint(stderr: &str) -> Option<&'static str> {
     }
 
     if lowered.contains("http 404") || lowered.contains("could not resolve") {
-        return Some("Check that the repository exists and you have access: gh repo view OWNER/REPO");
+        return Some(
+            "Check that the repository exists and you have access: gh repo view OWNER/REPO",
+        );
     }
 
     if lowered.contains("permission denied")
@@ -1157,7 +1161,8 @@ mod tests {
         );
         let last_attempt = SECONDARY_RETRY_DELAYS_SECS.len() - 1;
         for _ in 0..100 {
-            let d = resolve_rate_limit_delay(RateLimitKind::Secondary, last_attempt, stderr).unwrap();
+            let d =
+                resolve_rate_limit_delay(RateLimitKind::Secondary, last_attempt, stderr).unwrap();
             assert!(
                 d <= MAX_RETRY_DELAY,
                 "secondary fallback delay {d:?} exceeded MAX_RETRY_DELAY at max attempt"
@@ -1168,7 +1173,10 @@ mod tests {
     #[test]
     fn primary_rate_limit_cap_limits_large_values() {
         assert_eq!(capped_delay(Duration::from_secs(2861)), MAX_RETRY_DELAY);
-        assert_eq!(capped_delay(Duration::from_secs(120)), Duration::from_secs(120));
+        assert_eq!(
+            capped_delay(Duration::from_secs(120)),
+            Duration::from_secs(120)
+        );
     }
 
     #[test]
@@ -1178,7 +1186,10 @@ mod tests {
         for _ in 0..100 {
             seen.insert(jittered_delay(base).as_millis());
         }
-        assert!(seen.len() >= 2, "jittered_delay produced no variation across 100 calls");
+        assert!(
+            seen.len() >= 2,
+            "jittered_delay produced no variation across 100 calls"
+        );
     }
 
     #[test]
@@ -1206,7 +1217,10 @@ mod tests {
         for _ in 0..100 {
             seen.insert(server_jittered_delay(base).as_millis());
         }
-        assert!(seen.len() >= 2, "server_jittered_delay produced no variation across 100 calls");
+        assert!(
+            seen.len() >= 2,
+            "server_jittered_delay produced no variation across 100 calls"
+        );
     }
 
     #[test]

--- a/cli/src/hardware.rs
+++ b/cli/src/hardware.rs
@@ -369,12 +369,10 @@ mod tests {
         assert!(snapshot.physical_cores >= 1);
         assert!(snapshot.total_memory_gb > 0.0);
         assert!(snapshot.available_memory_gb >= 0.0);
-        assert!(
-            matches!(
-                snapshot.platform,
-                Platform::MacOS | Platform::Linux | Platform::Other
-            )
-        );
+        assert!(matches!(
+            snapshot.platform,
+            Platform::MacOS | Platform::Linux | Platform::Other
+        ));
     }
 
     #[test]

--- a/cli/src/ledger.rs
+++ b/cli/src/ledger.rs
@@ -67,7 +67,7 @@ impl Ledger {
         repo_state
             .theses
             .iter()
-            .flat_map(|thesis| rows_for_thesis(thesis))
+            .flat_map(rows_for_thesis)
             .filter(|row| !self.contains_attempt(&row.attempt))
             .collect()
     }
@@ -156,7 +156,10 @@ fn rows_for_thesis(thesis: &ThesisState) -> Vec<LedgerRow> {
             thesis: format!("#{}", thesis.issue.number),
             attempt: attempt.branch.clone(),
             metric,
-            baseline: attempt.baseline_metric.map(|b| format!("{b:.4}")).unwrap_or_else(|| "N/A".to_string()),
+            baseline: attempt
+                .baseline_metric
+                .map(|b| format!("{b:.4}"))
+                .unwrap_or_else(|| "N/A".to_string()),
             status,
             summary: attempt.summary.clone(),
         });

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 
@@ -36,8 +36,8 @@ async fn main() -> Result<()> {
 
     if needs_deferred_setup {
         let repo_root = discover_repo_root(&cwd).unwrap_or(cwd);
-        let request_delay_ms = request_delay_override
-            .unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
+        let request_delay_ms =
+            request_delay_override.unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
         throttle::init(request_delay_ms);
         let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)
             .ok()
@@ -46,8 +46,8 @@ async fn main() -> Result<()> {
                 name: String::new(),
             });
         let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-        let api_budget = api_budget_override
-            .unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
+        let api_budget =
+            api_budget_override.unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
         let config = ProtocolConfig::default();
         let program = ProgramSpec {
             can_modify: Vec::new(),
@@ -68,13 +68,12 @@ async fn main() -> Result<()> {
     }
 
     let repo_root = discover_repo_root(&cwd)?;
-    let request_delay_ms = request_delay_override
-        .unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
+    let request_delay_ms =
+        request_delay_override.unwrap_or_else(|| NodeConfig::load_request_delay_ms(&repo_root));
     throttle::init(request_delay_ms);
     let repo = RepoRef::discover(cli.repo.as_deref(), &repo_root)?;
     let github: Arc<dyn GitHubApi> = Arc::new(GitHubClient::new(repo.clone()));
-    let api_budget = api_budget_override
-        .unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
+    let api_budget = api_budget_override.unwrap_or_else(|| NodeConfig::load_api_budget(&repo_root));
     let config = ProtocolConfig::load(&repo_root)?;
     config.check_cli_version(env!("CARGO_PKG_VERSION"))?;
     let program = ProgramSpec::load(&repo_root, &config)?;
@@ -105,7 +104,7 @@ async fn run_and_handle_exit(ctx: AppContext) -> Result<()> {
     }
 }
 
-fn discover_repo_root(start: &PathBuf) -> Result<PathBuf> {
+fn discover_repo_root(start: &Path) -> Result<PathBuf> {
     for candidate in start.ancestors() {
         let path = candidate.to_path_buf();
         if path.join(".git").exists() || path.join("PROGRAM.md").exists() {

--- a/cli/src/throttle.rs
+++ b/cli/src/throttle.rs
@@ -56,6 +56,7 @@ fn acquire_request_slot_with_config(throttle: &RequestThrottle) -> Result<()> {
 
     let mut file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&throttle.state_path)
@@ -86,11 +87,11 @@ fn acquire_request_slot_with_config(throttle: &RequestThrottle) -> Result<()> {
 }
 
 fn pace_locked_file(file: &mut File, request_delay: Duration) -> Result<()> {
-    if let Some(last_request_at) = read_last_request(file)? {
-        if let Some(wait) = remaining_delay(last_request_at, request_delay) {
-            github_debug::log_throttle_wait(wait);
-            thread::sleep(wait);
-        }
+    if let Some(last_request_at) = read_last_request(file)?
+        && let Some(wait) = remaining_delay(last_request_at, request_delay)
+    {
+        github_debug::log_throttle_wait(wait);
+        thread::sleep(wait);
     }
 
     write_last_request(file, SystemTime::now())

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -44,16 +44,16 @@ fn run_event_loop(
     loop {
         terminal.draw(|frame| views::draw(frame, &app, ctx))?;
 
-        if event::poll(Duration::from_millis(250))? {
-            if let Event::Key(key) = event::read()? {
-                match key.code {
-                    KeyCode::Char('q') => break,
-                    KeyCode::Down => app.next(),
-                    KeyCode::Up => app.previous(),
-                    KeyCode::Enter => app.toggle_detail(),
-                    KeyCode::Char('r') => app.refresh(ctx)?,
-                    _ => {}
-                }
+        if event::poll(Duration::from_millis(250))?
+            && let Event::Key(key) = event::read()?
+        {
+            match key.code {
+                KeyCode::Char('q') => break,
+                KeyCode::Down => app.next(),
+                KeyCode::Up => app.previous(),
+                KeyCode::Enter => app.toggle_detail(),
+                KeyCode::Char('r') => app.refresh(ctx)?,
+                _ => {}
             }
         }
     }

--- a/cli/src/tui/views.rs
+++ b/cli/src/tui/views.rs
@@ -195,7 +195,7 @@ fn draw_thesis_table(
         .block(Block::default().borders(Borders::ALL).title("Theses"))
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
-    let mut state = app.table_state.clone();
+    let mut state = app.table_state;
     frame.render_stateful_widget(table, area, &mut state);
 }
 

--- a/cli/src/validation.rs
+++ b/cli/src/validation.rs
@@ -225,10 +225,10 @@ pub fn validate_pull_request(
                         &comment,
                         "admin repair note from non-lead actor",
                     ));
-                } else if action == "acknowledge_invalid" {
-                    if let Some(related_comment_id) = related_comment_id {
-                        acknowledged_comment_ids.insert(*related_comment_id);
-                    }
+                } else if action == "acknowledge_invalid"
+                    && let Some(related_comment_id) = related_comment_id
+                {
+                    acknowledged_comment_ids.insert(*related_comment_id);
                 }
             }
             Some(ProtocolComment::PolicyPass {
@@ -482,10 +482,10 @@ pub fn validate_issue(
                         &comment,
                         "admin repair note from non-lead actor",
                     ));
-                } else if action == "acknowledge_invalid" {
-                    if let Some(related_comment_id) = related_comment_id {
-                        acknowledged_comment_ids.insert(*related_comment_id);
-                    }
+                } else if action == "acknowledge_invalid"
+                    && let Some(related_comment_id) = related_comment_id
+                {
+                    acknowledged_comment_ids.insert(*related_comment_id);
                 }
             }
             Some(ProtocolComment::Approval { thesis }) => {
@@ -960,11 +960,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             protocol: None,
         };
-        let finding = invalid_issue_like(
-            AuditScope::Issue { number: 1 },
-            &envelope,
-            "test",
-        );
+        let finding = invalid_issue_like(AuditScope::Issue { number: 1 }, &envelope, "test");
         assert!(matches!(finding.severity, AuditSeverity::Invalid));
         assert!(finding.severity.is_blocking());
     }
@@ -977,11 +973,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             protocol: None,
         };
-        let finding = suspicious_issue_like(
-            AuditScope::Issue { number: 1 },
-            &envelope,
-            "test",
-        );
+        let finding = suspicious_issue_like(AuditScope::Issue { number: 1 }, &envelope, "test");
         assert!(matches!(finding.severity, AuditSeverity::Suspicious));
         assert!(!finding.severity.is_blocking());
     }

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use color_eyre::eyre::{Context, Result, eyre};
 
 use crate::agent::{self, AgentOutcome, ExperimentResult, RecoveredMetric};
-use crate::comments::{Observation, ProtocolComment, ReleaseReason};
 use crate::commands;
+use crate::comments::{Observation, ProtocolComment, ReleaseReason};
 use crate::config::MetricDirection;
 use crate::github::GitHubApi;
 use crate::state::ThesisState;
@@ -144,7 +144,10 @@ impl ThesisWorker {
 
         if let Some(recovered) = agent::recover_from_logs(&self.worktree_path) {
             eprintln!("Recovered metric {:.4} from run logs", recovered.metric);
-            return Ok(ExperimentOutcome::Result(classify_recovered(recovered, self.ctx.metric_direction)));
+            return Ok(ExperimentOutcome::Result(classify_recovered(
+                recovered,
+                self.ctx.metric_direction,
+            )));
         }
 
         eprintln!("Log recovery failed; attempting direct harness execution...");
@@ -156,8 +159,14 @@ impl ThesisWorker {
 
         match harness_result {
             Ok(Some(recovered)) => {
-                eprintln!("Recovered metric {:.4} from direct harness", recovered.metric);
-                Ok(ExperimentOutcome::Result(classify_recovered(recovered, self.ctx.metric_direction)))
+                eprintln!(
+                    "Recovered metric {:.4} from direct harness",
+                    recovered.metric
+                );
+                Ok(ExperimentOutcome::Result(classify_recovered(
+                    recovered,
+                    self.ctx.metric_direction,
+                )))
             }
             Ok(None) => Ok(ExperimentOutcome::NoResult),
             Err(err) => {
@@ -206,7 +215,10 @@ impl ThesisWorker {
             };
             github.create_pull_request(
                 &self.branch,
-                &format!("Thesis #{}: {}", self.ctx.issue_number, self.ctx.thesis_title),
+                &format!(
+                    "Thesis #{}: {}",
+                    self.ctx.issue_number, self.ctx.thesis_title
+                ),
                 &body,
                 default_branch,
             )?;
@@ -342,7 +354,14 @@ impl ThesisWorker {
         } else {
             commands::run_git(
                 &self.ctx.repo_root,
-                &["worktree", "add", "-b", &self.branch, &path_str, default_branch],
+                &[
+                    "worktree",
+                    "add",
+                    "-b",
+                    &self.branch,
+                    &path_str,
+                    default_branch,
+                ],
             )?;
         }
 
@@ -390,11 +409,8 @@ impl ThesisWorker {
             let _ = commands::run_git(&self.worktree_path, &["reset", "HEAD", "--", glob]);
         }
 
-        let has_staged = commands::run_git(
-            &self.worktree_path,
-            &["diff", "--cached", "--quiet"],
-        )
-        .is_err();
+        let has_staged =
+            commands::run_git(&self.worktree_path, &["diff", "--cached", "--quiet"]).is_err();
         if !has_staged {
             return Err(eyre!("no changes to commit within the editable surface"));
         }
@@ -450,7 +466,10 @@ impl ThesisWorker {
     }
 }
 
-pub fn classify_recovered(recovered: RecoveredMetric, direction: MetricDirection) -> ExperimentResult {
+pub fn classify_recovered(
+    recovered: RecoveredMetric,
+    direction: MetricDirection,
+) -> ExperimentResult {
     let Some(baseline) = recovered.baseline else {
         return ExperimentResult {
             metric: recovered.metric,
@@ -468,7 +487,12 @@ pub fn classify_recovered(recovered: RecoveredMetric, direction: MetricDirection
     ExperimentResult {
         metric: recovered.metric,
         baseline: Some(baseline),
-        observation: if improved { "improved" } else { "no_improvement" }.to_string(),
+        observation: if improved {
+            "improved"
+        } else {
+            "no_improvement"
+        }
+        .to_string(),
         summary: recovered.summary,
     }
 }
@@ -558,7 +582,10 @@ mod tests {
 
     #[test]
     fn parallelism_respects_max_parallel_flag() {
-        assert_eq!(calculate_parallelism(16, 64.0, 64.0, 1, 1.0, Some(3), 10), 3);
+        assert_eq!(
+            calculate_parallelism(16, 64.0, 64.0, 1, 1.0, Some(3), 10),
+            3
+        );
     }
 
     #[test]
@@ -606,10 +633,19 @@ mod tests {
 
     #[test]
     fn parse_observation_valid() {
-        assert_eq!(parse_observation("improved").unwrap(), Observation::Improved);
-        assert_eq!(parse_observation("no_improvement").unwrap(), Observation::NoImprovement);
+        assert_eq!(
+            parse_observation("improved").unwrap(),
+            Observation::Improved
+        );
+        assert_eq!(
+            parse_observation("no_improvement").unwrap(),
+            Observation::NoImprovement
+        );
         assert_eq!(parse_observation("crashed").unwrap(), Observation::Crashed);
-        assert_eq!(parse_observation("infra_failure").unwrap(), Observation::InfraFailure);
+        assert_eq!(
+            parse_observation("infra_failure").unwrap(),
+            Observation::InfraFailure
+        );
     }
 
     #[test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
+use polyresearch::agent;
 use polyresearch::cli::{
     AdminArgs, AdminCommands, AdminReleaseClaimArgs, AdminReopenThesisArgs, AttemptArgs,
     BatchClaimArgs, Cli, Commands, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
@@ -29,7 +30,6 @@ use polyresearch::state::{
 };
 use polyresearch::validation::{AuditFinding, AuditScope, AuditSeverity};
 use polyresearch::worker;
-use polyresearch::agent;
 use serde::Deserialize;
 
 #[allow(unused_imports)]
@@ -163,10 +163,17 @@ impl GitHubApi for MockGitHubClient {
             title: title.to_string(),
             body: Some(body.to_string()),
             state: "OPEN".to_string(),
-            labels: labels.iter().map(|l| polyresearch::github::Label { name: l.to_string() }).collect(),
+            labels: labels
+                .iter()
+                .map(|l| polyresearch::github::Label {
+                    name: l.to_string(),
+                })
+                .collect(),
             created_at: chrono::Utc::now(),
             closed_at: None,
-            author: Some(polyresearch::github::Author { login: self.current_login.clone() }),
+            author: Some(polyresearch::github::Author {
+                login: self.current_login.clone(),
+            }),
             url: Some(format!("https://github.com/test/repo/issues/{number}")),
         };
         self.created_issues.lock().unwrap().push(issue.clone());
@@ -395,7 +402,10 @@ async fn init_writes_node_identity() {
         false,
         Commands::Init(InitArgs {
             node: Some("test-node".to_string()),
-            overrides: NodeOverrides { capacity: Some(50), ..Default::default() },
+            overrides: NodeOverrides {
+                capacity: Some(50),
+                ..Default::default()
+            },
         }),
     );
 
@@ -403,7 +413,10 @@ async fn init_writes_node_identity() {
         &ctx,
         &InitArgs {
             node: Some("test-node".to_string()),
-            overrides: NodeOverrides { capacity: Some(50), ..Default::default() },
+            overrides: NodeOverrides {
+                capacity: Some(50),
+                ..Default::default()
+            },
         },
     )
     .await
@@ -428,7 +441,15 @@ async fn env_override_uses_session_node_id() {
         HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
-    commands::write_node_config(&repo.path, "lead/file-node", &NodeOverrides { capacity: Some(60), ..Default::default() }).unwrap();
+    commands::write_node_config(
+        &repo.path,
+        "lead/file-node",
+        &NodeOverrides {
+            capacity: Some(60),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     set_node_id_env("lead/env-node");
 
     let node_config = NodeConfig::load(&repo.path).unwrap();
@@ -687,7 +708,10 @@ async fn init_drops_legacy_fields_and_writes_capacity() {
         false,
         Commands::Init(InitArgs {
             node: Some("new-node".to_string()),
-            overrides: NodeOverrides { capacity: Some(40), ..Default::default() },
+            overrides: NodeOverrides {
+                capacity: Some(40),
+                ..Default::default()
+            },
         }),
     );
 
@@ -695,7 +719,10 @@ async fn init_drops_legacy_fields_and_writes_capacity() {
         &ctx,
         &InitArgs {
             node: Some("new-node".to_string()),
-            overrides: NodeOverrides { capacity: Some(40), ..Default::default() },
+            overrides: NodeOverrides {
+                capacity: Some(40),
+                ..Default::default()
+            },
         },
     )
     .await
@@ -2048,10 +2075,18 @@ async fn bootstrap_commits_setup_files() {
     let bare = TestRepo::new("bootstrap-commit-bare");
     let _ = fs::remove_dir_all(&bare.path);
     Command::new("git")
-        .args(["clone", "--bare", &repo.path.to_string_lossy(), &bare.path.to_string_lossy()])
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
         .output()
         .unwrap();
-    run_git(&repo.path, &["remote", "add", "origin", &bare.path.to_string_lossy()]);
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
 
     commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
@@ -2059,12 +2094,23 @@ async fn bootstrap_commits_setup_files() {
 
     // Verify git status is clean for setup files
     let status_output = Command::new("git")
-        .args(["status", "--porcelain", "--", "PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch"])
+        .args([
+            "status",
+            "--porcelain",
+            "--",
+            "PROGRAM.md",
+            "PREPARE.md",
+            "results.tsv",
+            ".polyresearch",
+        ])
         .current_dir(&repo.path)
         .output()
         .unwrap();
     let status = String::from_utf8(status_output.stdout).unwrap();
-    assert!(status.trim().is_empty(), "setup files should be clean after commit, got: {status}");
+    assert!(
+        status.trim().is_empty(),
+        "setup files should be clean after commit, got: {status}"
+    );
 
     // Verify commit exists with expected message
     let log_output = Command::new("git")
@@ -2073,7 +2119,10 @@ async fn bootstrap_commits_setup_files() {
         .output()
         .unwrap();
     let log = String::from_utf8(log_output.stdout).unwrap();
-    assert!(log.contains("Add polyresearch setup files"), "commit message not found in: {log}");
+    assert!(
+        log.contains("Add polyresearch setup files"),
+        "commit message not found in: {log}"
+    );
 
     // Verify committed files
     let show_output = Command::new("git")
@@ -2095,10 +2144,18 @@ async fn bootstrap_commit_is_idempotent() {
     let bare = TestRepo::new("bootstrap-commit-idempotent-bare");
     let _ = fs::remove_dir_all(&bare.path);
     Command::new("git")
-        .args(["clone", "--bare", &repo.path.to_string_lossy(), &bare.path.to_string_lossy()])
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
         .output()
         .unwrap();
-    run_git(&repo.path, &["remote", "add", "origin", &bare.path.to_string_lossy()]);
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
 
     commands::bootstrap::write_templates(&repo.path, None, "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
@@ -2114,8 +2171,15 @@ async fn bootstrap_commit_is_idempotent() {
         .output()
         .unwrap();
     let log = String::from_utf8(log_output.stdout).unwrap();
-    let setup_commits: Vec<&str> = log.lines().filter(|l| l.contains("Add polyresearch setup files")).collect();
-    assert_eq!(setup_commits.len(), 1, "expected exactly one setup commit, got: {log}");
+    let setup_commits: Vec<&str> = log
+        .lines()
+        .filter(|l| l.contains("Add polyresearch setup files"))
+        .collect();
+    assert_eq!(
+        setup_commits.len(),
+        1,
+        "expected exactly one setup commit, got: {log}"
+    );
 }
 
 // --- Contribute claimability tests ---
@@ -2150,10 +2214,14 @@ fn contribute_claimable_excludes_no_improvement_releases() {
         findings: vec![],
     };
 
-    let has_no_improvement = thesis.releases.iter().any(|r| {
-        r.node == "my-node" && r.reason == ReleaseReason::NoImprovement
-    });
-    assert!(has_no_improvement, "thesis should be blacklisted for this node");
+    let has_no_improvement = thesis
+        .releases
+        .iter()
+        .any(|r| r.node == "my-node" && r.reason == ReleaseReason::NoImprovement);
+    assert!(
+        has_no_improvement,
+        "thesis should be blacklisted for this node"
+    );
 }
 
 #[test]
@@ -2186,28 +2254,56 @@ fn contribute_claimable_allows_infra_failure_reclaim() {
         findings: vec![],
     };
 
-    let has_no_improvement = thesis.releases.iter().any(|r| {
-        r.node == "my-node" && r.reason == ReleaseReason::NoImprovement
-    });
-    assert!(!has_no_improvement, "infra_failure should NOT blacklist the node");
+    let has_no_improvement = thesis
+        .releases
+        .iter()
+        .any(|r| r.node == "my-node" && r.reason == ReleaseReason::NoImprovement);
+    assert!(
+        !has_no_improvement,
+        "infra_failure should NOT blacklist the node"
+    );
 }
 
 // --- Worker parallelism tests ---
 
 #[test]
 fn worker_parallelism_formula_basics() {
-    assert_eq!(worker::calculate_parallelism(8, 64.0, 64.0, 2, 4.0, None, 10), 4);
-    assert_eq!(worker::calculate_parallelism(16, 8.0, 8.0, 1, 4.0, None, 10), 2);
-    assert_eq!(worker::calculate_parallelism(16, 64.0, 4.0, 1, 4.0, None, 10), 1);
-    assert_eq!(worker::calculate_parallelism(16, 64.0, 64.0, 1, 1.0, Some(3), 10), 3);
-    assert_eq!(worker::calculate_parallelism(16, 64.0, 64.0, 1, 1.0, None, 2), 2);
-    assert_eq!(worker::calculate_parallelism(1, 0.5, 0.1, 4, 8.0, None, 1), 1);
+    assert_eq!(
+        worker::calculate_parallelism(8, 64.0, 64.0, 2, 4.0, None, 10),
+        4
+    );
+    assert_eq!(
+        worker::calculate_parallelism(16, 8.0, 8.0, 1, 4.0, None, 10),
+        2
+    );
+    assert_eq!(
+        worker::calculate_parallelism(16, 64.0, 4.0, 1, 4.0, None, 10),
+        1
+    );
+    assert_eq!(
+        worker::calculate_parallelism(16, 64.0, 64.0, 1, 1.0, Some(3), 10),
+        3
+    );
+    assert_eq!(
+        worker::calculate_parallelism(16, 64.0, 64.0, 1, 1.0, None, 2),
+        2
+    );
+    assert_eq!(
+        worker::calculate_parallelism(1, 0.5, 0.1, 4, 8.0, None, 1),
+        1
+    );
 }
 
 #[test]
 fn worker_parallelism_never_exceeds_available_work() {
-    assert_eq!(worker::calculate_parallelism(64, 256.0, 256.0, 1, 1.0, None, 0), 0);
-    assert_eq!(worker::calculate_parallelism(64, 256.0, 256.0, 1, 1.0, None, 3), 3);
+    assert_eq!(
+        worker::calculate_parallelism(64, 256.0, 256.0, 1, 1.0, None, 0),
+        0
+    );
+    assert_eq!(
+        worker::calculate_parallelism(64, 256.0, 256.0, 1, 1.0, None, 3),
+        3
+    );
 }
 
 // --- Contribute blocking duties ---
@@ -2245,13 +2341,17 @@ async fn contribute_blocks_on_non_submit_duties() {
         }),
     );
 
-    let result = commands::contribute::run(&ctx, &ContributeArgs {
-        url: None,
-        once: true,
-        max_parallel: Some(1),
-        sleep_secs: 0,
-        overrides: NodeOverrides::default(),
-    }).await;
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
 
     assert!(result.is_ok() || result.unwrap_err().to_string().contains("blocking"));
 }
@@ -2498,7 +2598,8 @@ fn write_node_config_persists_agent_timeout_with_command() {
 
 #[test]
 fn agent_experiment_result_deserialization() {
-    let json = r#"{"metric": 0.95, "baseline": 0.90, "observation": "improved", "summary": "test run"}"#;
+    let json =
+        r#"{"metric": 0.95, "baseline": 0.90, "observation": "improved", "summary": "test run"}"#;
     let result: agent::ExperimentResult = serde_json::from_str(json).unwrap();
     assert!(result.is_improved());
     assert!((result.metric - 0.95).abs() < f64::EPSILON);
@@ -2520,9 +2621,17 @@ fn agent_experiment_result_all_observations() {
             summary: "test".to_string(),
         };
         assert_eq!(result.is_improved(), improved, "is_improved for {obs}");
-        assert_eq!(result.is_no_improvement(), no_imp, "is_no_improvement for {obs}");
+        assert_eq!(
+            result.is_no_improvement(),
+            no_imp,
+            "is_no_improvement for {obs}"
+        );
         assert_eq!(result.is_crashed(), crashed, "is_crashed for {obs}");
-        assert_eq!(result.is_infra_failure(), infra, "is_infra_failure for {obs}");
+        assert_eq!(
+            result.is_infra_failure(),
+            infra,
+            "is_infra_failure for {obs}"
+        );
     }
 }
 
@@ -2543,7 +2652,11 @@ fn agent_recover_from_logs_finds_ops_per_sec() {
     let dir = std::env::temp_dir().join(format!("e2e-recover-ops-{}", std::process::id()));
     let poly_dir = dir.join(".polyresearch");
     fs::create_dir_all(&poly_dir).unwrap();
-    fs::write(poly_dir.join("run-001.log"), "starting...\nops_per_sec=42.5\ndone").unwrap();
+    fs::write(
+        poly_dir.join("run-001.log"),
+        "starting...\nops_per_sec=42.5\ndone",
+    )
+    .unwrap();
 
     let result = agent::recover_from_logs(&dir);
     assert!(result.is_some());
@@ -2581,7 +2694,13 @@ fn agent_write_thesis_context_creates_file() {
     let dir = std::env::temp_dir().join(format!("e2e-thesis-ctx-{}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
 
-    agent::write_thesis_context(&dir, "Optimize RMSNorm", "Replace LayerNorm", "Attempt 1: no improvement").unwrap();
+    agent::write_thesis_context(
+        &dir,
+        "Optimize RMSNorm",
+        "Replace LayerNorm",
+        "Attempt 1: no improvement",
+    )
+    .unwrap();
 
     let content = fs::read_to_string(dir.join(".polyresearch/thesis.md")).unwrap();
     assert!(content.contains("# Thesis: Optimize RMSNorm"));
@@ -2630,19 +2749,17 @@ fn worker_format_prior_attempts_with_data() {
         maintainer_rejected: false,
         active_claims: vec![],
         releases: vec![],
-        attempts: vec![
-            AttemptRecord {
-                thesis: 12,
-                node: "node-a".to_string(),
-                branch: "thesis/12-rmsnorm-attempt-1".to_string(),
-                metric: 0.95,
-                baseline_metric: Some(0.90),
-                observation: Observation::Improved,
-                summary: "RMSNorm swap".to_string(),
-                author: "alice".to_string(),
-                created_at: chrono::Utc::now(),
-            },
-        ],
+        attempts: vec![AttemptRecord {
+            thesis: 12,
+            node: "node-a".to_string(),
+            branch: "thesis/12-rmsnorm-attempt-1".to_string(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: Observation::Improved,
+            summary: "RMSNorm swap".to_string(),
+            author: "alice".to_string(),
+            created_at: chrono::Utc::now(),
+        }],
         pull_requests: vec![],
         best_attempt_metric: Some(0.95),
         findings: vec![],
@@ -2796,13 +2913,16 @@ Test.
         "loaded config should have the real min_queue_depth"
     );
 
-    let result = commands::contribute::run(&ctx, &ContributeArgs {
-        url: None,
-        once: true,
-        max_parallel: Some(1),
-        sleep_secs: 0,
-        overrides: NodeOverrides::default(),
-    })
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
     .await;
 
     assert!(
@@ -2882,11 +3002,7 @@ fn make_policy_ctx(
     ctx
 }
 
-fn make_pr_with_thesis(
-    number: u64,
-    thesis: u64,
-    author: &str,
-) -> PullRequest {
+fn make_pr_with_thesis(number: u64, thesis: u64, author: &str) -> PullRequest {
     PullRequest {
         number,
         title: format!("Thesis #{thesis}: test"),
@@ -2898,26 +3014,40 @@ fn make_pr_with_thesis(
         created_at: chrono::Utc::now(),
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: author.to_string() }),
+        author: Some(Author {
+            login: author.to_string(),
+        }),
         url: Some(format!("https://github.com/test/repo/pull/{number}")),
         mergeable: None,
     }
 }
 
-fn make_thesis_for_pr(thesis_number: u64, pr: &PullRequest, lead: &str) -> (Issue, Vec<IssueComment>) {
+fn make_thesis_for_pr(
+    thesis_number: u64,
+    pr: &PullRequest,
+    lead: &str,
+) -> (Issue, Vec<IssueComment>) {
     let now = chrono::Utc::now();
     let issue = Issue {
         number: thesis_number,
         title: format!("Thesis {thesis_number}"),
         body: Some("Test thesis.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(2),
         closed_at: None,
-        author: Some(Author { login: lead.to_string() }),
-        url: Some(format!("https://github.com/test/repo/issues/{thesis_number}")),
+        author: Some(Author {
+            login: lead.to_string(),
+        }),
+        url: Some(format!(
+            "https://github.com/test/repo/issues/{thesis_number}"
+        )),
     };
-    let approval = ProtocolComment::Approval { thesis: thesis_number };
+    let approval = ProtocolComment::Approval {
+        thesis: thesis_number,
+    };
     let claim = ProtocolComment::Claim {
         thesis: thesis_number,
         node: "worker-a".to_string(),
@@ -2935,21 +3065,27 @@ fn make_thesis_for_pr(thesis_number: u64, pr: &PullRequest, lead: &str) -> (Issu
         IssueComment {
             id: thesis_number * 100,
             body: approval.render(),
-            user: CommentUser { login: lead.to_string() },
+            user: CommentUser {
+                login: lead.to_string(),
+            },
             created_at: now - chrono::Duration::hours(1),
             updated_at: None,
         },
         IssueComment {
             id: thesis_number * 100 + 1,
             body: claim.render(),
-            user: CommentUser { login: "contributor".to_string() },
+            user: CommentUser {
+                login: "contributor".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(50),
             updated_at: None,
         },
         IssueComment {
             id: thesis_number * 100 + 2,
             body: attempt.render(),
-            user: CommentUser { login: "contributor".to_string() },
+            user: CommentUser {
+                login: "contributor".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(40),
             updated_at: None,
         },
@@ -2963,30 +3099,48 @@ async fn policy_check_passes_when_all_files_editable() {
     let repo = TestRepo::new("policy-pass");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let pr = make_pr_with_thesis(50, 10, "contributor");
     let (issue, comments) = make_thesis_for_pr(10, &pr, "lead");
 
-    let mock = Arc::new(MockGitHubClient::new(
-        "lead",
-        vec![issue],
-        HashMap::from([(10, comments)]),
-        vec![pr],
-        HashMap::new(),
-    ).with_pr_files(50, vec![
-        PullRequestFile { filename: "src/main.js".to_string() },
-        PullRequestFile { filename: "src/utils.js".to_string() },
-    ]));
+    let mock = Arc::new(
+        MockGitHubClient::new(
+            "lead",
+            vec![issue],
+            HashMap::from([(10, comments)]),
+            vec![pr],
+            HashMap::new(),
+        )
+        .with_pr_files(
+            50,
+            vec![
+                PullRequestFile {
+                    filename: "src/main.js".to_string(),
+                },
+                PullRequestFile {
+                    filename: "src/utils.js".to_string(),
+                },
+            ],
+        ),
+    );
 
     let ctx = make_policy_ctx(repo.path.clone(), mock.clone(), "lead", false, 50);
-    commands::policy_check::run(&ctx, &PrArgs { pr: 50 }).await.unwrap();
+    commands::policy_check::run(&ctx, &PrArgs { pr: 50 })
+        .await
+        .unwrap();
 
     let posted = mock.posted_issue_comments.lock().unwrap();
     assert!(
-        posted.iter().any(|(num, body)| *num == 50 && body.contains("polyresearch:policy-pass")),
+        posted
+            .iter()
+            .any(|(num, body)| *num == 50 && body.contains("polyresearch:policy-pass")),
         "should post PolicyPass comment on PR"
     );
 }
@@ -2997,34 +3151,58 @@ async fn policy_check_rejects_protected_file() {
     let repo = TestRepo::new("policy-reject-protected");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let pr = make_pr_with_thesis(51, 11, "contributor");
     let (issue, comments) = make_thesis_for_pr(11, &pr, "lead");
 
-    let mock = Arc::new(MockGitHubClient::new(
-        "lead",
-        vec![issue],
-        HashMap::from([(11, comments)]),
-        vec![pr],
-        HashMap::new(),
-    ).with_pr_files(51, vec![
-        PullRequestFile { filename: "src/main.js".to_string() },
-        PullRequestFile { filename: "PREPARE.md".to_string() },
-    ]));
+    let mock = Arc::new(
+        MockGitHubClient::new(
+            "lead",
+            vec![issue],
+            HashMap::from([(11, comments)]),
+            vec![pr],
+            HashMap::new(),
+        )
+        .with_pr_files(
+            51,
+            vec![
+                PullRequestFile {
+                    filename: "src/main.js".to_string(),
+                },
+                PullRequestFile {
+                    filename: "PREPARE.md".to_string(),
+                },
+            ],
+        ),
+    );
 
     let ctx = make_policy_ctx(repo.path.clone(), mock.clone(), "lead", false, 51);
-    commands::policy_check::run(&ctx, &PrArgs { pr: 51 }).await.unwrap();
+    commands::policy_check::run(&ctx, &PrArgs { pr: 51 })
+        .await
+        .unwrap();
 
     let posted = mock.posted_issue_comments.lock().unwrap();
     assert!(
-        posted.iter().any(|(num, body)| *num == 51 && body.contains("polyresearch:decision") && body.contains("policy_rejection")),
+        posted.iter().any(|(num, body)| *num == 51
+            && body.contains("polyresearch:decision")
+            && body.contains("policy_rejection")),
         "should post policy_rejection decision on PR"
     );
-    assert!(mock.closed_prs.lock().unwrap().contains(&51), "PR should be closed");
-    assert!(mock.closed_issues.lock().unwrap().contains(&11), "thesis should be closed");
+    assert!(
+        mock.closed_prs.lock().unwrap().contains(&51),
+        "PR should be closed"
+    );
+    assert!(
+        mock.closed_issues.lock().unwrap().contains(&11),
+        "thesis should be closed"
+    );
 }
 
 #[tokio::test]
@@ -3033,29 +3211,43 @@ async fn policy_check_rejects_outside_editable_surface() {
     let repo = TestRepo::new("policy-reject-outside");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let pr = make_pr_with_thesis(52, 12, "contributor");
     let (issue, comments) = make_thesis_for_pr(12, &pr, "lead");
 
-    let mock = Arc::new(MockGitHubClient::new(
-        "lead",
-        vec![issue],
-        HashMap::from([(12, comments)]),
-        vec![pr],
-        HashMap::new(),
-    ).with_pr_files(52, vec![
-        PullRequestFile { filename: "docs/readme.md".to_string() },
-    ]));
+    let mock = Arc::new(
+        MockGitHubClient::new(
+            "lead",
+            vec![issue],
+            HashMap::from([(12, comments)]),
+            vec![pr],
+            HashMap::new(),
+        )
+        .with_pr_files(
+            52,
+            vec![PullRequestFile {
+                filename: "docs/readme.md".to_string(),
+            }],
+        ),
+    );
 
     let ctx = make_policy_ctx(repo.path.clone(), mock.clone(), "lead", false, 52);
-    commands::policy_check::run(&ctx, &PrArgs { pr: 52 }).await.unwrap();
+    commands::policy_check::run(&ctx, &PrArgs { pr: 52 })
+        .await
+        .unwrap();
 
     let posted = mock.posted_issue_comments.lock().unwrap();
     assert!(
-        posted.iter().any(|(_, body)| body.contains("policy_rejection")),
+        posted
+            .iter()
+            .any(|(_, body)| body.contains("policy_rejection")),
         "should reject PR with files outside editable surface"
     );
 }
@@ -3066,7 +3258,11 @@ async fn policy_check_idempotent_after_pass() {
     let repo = TestRepo::new("policy-idempotent");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -3081,7 +3277,9 @@ async fn policy_check_idempotent_after_pass() {
     let pr_comments = vec![IssueComment {
         id: 5301,
         body: policy_pass.render(),
-        user: CommentUser { login: "lead".to_string() },
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(5),
         updated_at: None,
     }];
@@ -3095,7 +3293,9 @@ async fn policy_check_idempotent_after_pass() {
     ));
 
     let ctx = make_policy_ctx(repo.path.clone(), mock.clone(), "lead", false, 53);
-    let err = commands::policy_check::run(&ctx, &PrArgs { pr: 53 }).await.unwrap_err();
+    let err = commands::policy_check::run(&ctx, &PrArgs { pr: 53 })
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("already has a policy-pass"));
 }
 
@@ -3109,7 +3309,12 @@ fn make_decidable_state(
     metric: f64,
     baseline: f64,
     lead: &str,
-) -> (Vec<Issue>, HashMap<u64, Vec<IssueComment>>, Vec<PullRequest>, HashMap<u64, Vec<IssueComment>>) {
+) -> (
+    Vec<Issue>,
+    HashMap<u64, Vec<IssueComment>>,
+    Vec<PullRequest>,
+    HashMap<u64, Vec<IssueComment>>,
+) {
     let now = chrono::Utc::now();
     let branch = format!("thesis/{thesis_number}-test");
     let issue = Issue {
@@ -3117,14 +3322,22 @@ fn make_decidable_state(
         title: format!("Thesis {thesis_number}"),
         body: Some("Test thesis.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(2),
         closed_at: None,
-        author: Some(Author { login: lead.to_string() }),
-        url: Some(format!("https://github.com/test/repo/issues/{thesis_number}")),
+        author: Some(Author {
+            login: lead.to_string(),
+        }),
+        url: Some(format!(
+            "https://github.com/test/repo/issues/{thesis_number}"
+        )),
     };
 
-    let approval = ProtocolComment::Approval { thesis: thesis_number };
+    let approval = ProtocolComment::Approval {
+        thesis: thesis_number,
+    };
     let claim = ProtocolComment::Claim {
         thesis: thesis_number,
         node: "worker-a".to_string(),
@@ -3143,21 +3356,27 @@ fn make_decidable_state(
         IssueComment {
             id: thesis_number * 100,
             body: approval.render(),
-            user: CommentUser { login: lead.to_string() },
+            user: CommentUser {
+                login: lead.to_string(),
+            },
             created_at: now - chrono::Duration::hours(1),
             updated_at: None,
         },
         IssueComment {
             id: thesis_number * 100 + 1,
             body: claim.render(),
-            user: CommentUser { login: "contributor".to_string() },
+            user: CommentUser {
+                login: "contributor".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(50),
             updated_at: None,
         },
         IssueComment {
             id: thesis_number * 100 + 2,
             body: attempt.render(),
-            user: CommentUser { login: "contributor".to_string() },
+            user: CommentUser {
+                login: "contributor".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(40),
             updated_at: None,
         },
@@ -3174,7 +3393,9 @@ fn make_decidable_state(
         created_at: now - chrono::Duration::minutes(35),
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "contributor".to_string() }),
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
         url: Some(format!("https://github.com/test/repo/pull/{pr_number}")),
         mergeable: None,
     };
@@ -3186,7 +3407,9 @@ fn make_decidable_state(
     let pr_comments = vec![IssueComment {
         id: pr_number * 100,
         body: policy_pass.render(),
-        user: CommentUser { login: lead.to_string() },
+        user: CommentUser {
+            login: lead.to_string(),
+        },
         created_at: now - chrono::Duration::minutes(5),
         updated_at: None,
     }];
@@ -3205,18 +3428,33 @@ async fn decide_lower_is_better_accepted() {
     let repo = TestRepo::new("decide-lib-accepted");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state(10, 50, 50.0, 100.0, "lead");
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 50 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 50 }),
+    );
     ctx.config.metric_direction = MetricDirection::LowerIsBetter;
     ctx.config.metric_tolerance = Some(1.0);
 
-    commands::decide::run(&ctx, &PrArgs { pr: 50 }).await.unwrap();
-    assert!(mock.merged_prs.lock().unwrap().contains(&50), "PR should be merged for accepted");
+    commands::decide::run(&ctx, &PrArgs { pr: 50 })
+        .await
+        .unwrap();
+    assert!(
+        mock.merged_prs.lock().unwrap().contains(&50),
+        "PR should be merged for accepted"
+    );
 }
 
 #[tokio::test]
@@ -3225,19 +3463,37 @@ async fn decide_lower_is_better_non_improvement() {
     let repo = TestRepo::new("decide-lib-non-improv");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state(11, 51, 110.0, 100.0, "lead");
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 51 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 51 }),
+    );
     ctx.config.metric_direction = MetricDirection::LowerIsBetter;
     ctx.config.metric_tolerance = Some(1.0);
 
-    commands::decide::run(&ctx, &PrArgs { pr: 51 }).await.unwrap();
-    assert!(mock.closed_prs.lock().unwrap().contains(&51), "PR should be closed for non_improvement");
-    assert!(mock.merged_prs.lock().unwrap().is_empty(), "PR should NOT be merged");
+    commands::decide::run(&ctx, &PrArgs { pr: 51 })
+        .await
+        .unwrap();
+    assert!(
+        mock.closed_prs.lock().unwrap().contains(&51),
+        "PR should be closed for non_improvement"
+    );
+    assert!(
+        mock.merged_prs.lock().unwrap().is_empty(),
+        "PR should NOT be merged"
+    );
 }
 
 #[tokio::test]
@@ -3246,18 +3502,36 @@ async fn decide_metric_within_tolerance_is_non_improvement() {
     let repo = TestRepo::new("decide-tolerance");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state(12, 52, 0.905, 0.90, "lead");
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 52 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 52 }),
+    );
     ctx.config.metric_tolerance = Some(0.01);
 
-    commands::decide::run(&ctx, &PrArgs { pr: 52 }).await.unwrap();
-    assert!(mock.closed_prs.lock().unwrap().contains(&52), "PR should be closed");
-    assert!(mock.merged_prs.lock().unwrap().is_empty(), "improvement within tolerance should be non_improvement");
+    commands::decide::run(&ctx, &PrArgs { pr: 52 })
+        .await
+        .unwrap();
+    assert!(
+        mock.closed_prs.lock().unwrap().contains(&52),
+        "PR should be closed"
+    );
+    assert!(
+        mock.merged_prs.lock().unwrap().is_empty(),
+        "improvement within tolerance should be non_improvement"
+    );
 }
 
 #[tokio::test]
@@ -3275,11 +3549,25 @@ async fn decide_below_ledger_best_is_non_improvement() {
 
     let (issues, ic, prs, pc) = make_decidable_state(13, 53, 0.95, 0.90, "lead");
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 53 }));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 53 }),
+    );
 
-    commands::decide::run(&ctx, &PrArgs { pr: 53 }).await.unwrap();
-    assert!(mock.closed_prs.lock().unwrap().contains(&53), "PR should be closed");
-    assert!(mock.merged_prs.lock().unwrap().is_empty(), "metric below ledger best should be non_improvement");
+    commands::decide::run(&ctx, &PrArgs { pr: 53 })
+        .await
+        .unwrap();
+    assert!(
+        mock.closed_prs.lock().unwrap().contains(&53),
+        "PR should be closed"
+    );
+    assert!(
+        mock.merged_prs.lock().unwrap().is_empty(),
+        "metric below ledger best should be non_improvement"
+    );
 }
 
 // ===========================================================================
@@ -3292,16 +3580,28 @@ async fn decide_requires_maintainer_approval_when_auto_approve_off() {
     let repo = TestRepo::new("decide-no-maintainer");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state(14, 54, 0.95, 0.90, "lead");
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 54 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 54 }),
+    );
     ctx.config.auto_approve = false;
 
-    let err = commands::decide::run(&ctx, &PrArgs { pr: 54 }).await.unwrap_err();
+    let err = commands::decide::run(&ctx, &PrArgs { pr: 54 })
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("requires maintainer `/approve`"));
 }
 
@@ -3311,7 +3611,11 @@ async fn decide_succeeds_after_maintainer_approve() {
     let repo = TestRepo::new("decide-maintainer-ok");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -3321,18 +3625,31 @@ async fn decide_succeeds_after_maintainer_approve() {
     let approve_comment = IssueComment {
         id: 5501,
         body: "/approve".to_string(),
-        user: CommentUser { login: "maintainer".to_string() },
+        user: CommentUser {
+            login: "maintainer".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(3),
         updated_at: None,
     };
     pc.entry(55).or_default().push(approve_comment);
 
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 55 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 55 }),
+    );
     ctx.config.auto_approve = false;
 
-    commands::decide::run(&ctx, &PrArgs { pr: 55 }).await.unwrap();
-    assert!(mock.merged_prs.lock().unwrap().contains(&55), "PR should be merged after maintainer /approve");
+    commands::decide::run(&ctx, &PrArgs { pr: 55 })
+        .await
+        .unwrap();
+    assert!(
+        mock.merged_prs.lock().unwrap().contains(&55),
+        "PR should be merged after maintainer /approve"
+    );
 }
 
 #[tokio::test]
@@ -3341,7 +3658,11 @@ async fn decide_rejects_after_maintainer_reject() {
     let repo = TestRepo::new("decide-maintainer-reject");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -3351,17 +3672,27 @@ async fn decide_rejects_after_maintainer_reject() {
     let reject_comment = IssueComment {
         id: 5601,
         body: "/reject too risky".to_string(),
-        user: CommentUser { login: "maintainer".to_string() },
+        user: CommentUser {
+            login: "maintainer".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(3),
         updated_at: None,
     };
     pc.entry(56).or_default().push(reject_comment);
 
     let mock = Arc::new(MockGitHubClient::new("lead", issues, ic, prs, pc));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Decide(PrArgs { pr: 56 }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Decide(PrArgs { pr: 56 }),
+    );
     ctx.config.auto_approve = false;
 
-    let err = commands::decide::run(&ctx, &PrArgs { pr: 56 }).await.unwrap_err();
+    let err = commands::decide::run(&ctx, &PrArgs { pr: 56 })
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("rejected by the maintainer"));
 }
 
@@ -3414,14 +3745,33 @@ async fn admin_release_claim_posts_note_and_release() {
         mock.clone(),
         &fixture.lead_github_login,
         false,
-        Commands::Admin(AdminArgs { command: AdminCommands::ReleaseClaim(args.clone()) }),
+        Commands::Admin(AdminArgs {
+            command: AdminCommands::ReleaseClaim(args.clone()),
+        }),
     );
 
-    commands::admin::run(&ctx, &AdminArgs { command: AdminCommands::ReleaseClaim(args) }).await.unwrap();
+    commands::admin::run(
+        &ctx,
+        &AdminArgs {
+            command: AdminCommands::ReleaseClaim(args),
+        },
+    )
+    .await
+    .unwrap();
 
     let posted = mock.posted_issue_comments.lock().unwrap();
-    assert!(posted.iter().any(|(_, body)| body.contains("polyresearch:admin-note")), "should post AdminNote");
-    assert!(posted.iter().any(|(_, body)| body.contains("polyresearch:release")), "should post Release");
+    assert!(
+        posted
+            .iter()
+            .any(|(_, body)| body.contains("polyresearch:admin-note")),
+        "should post AdminNote"
+    );
+    assert!(
+        posted
+            .iter()
+            .any(|(_, body)| body.contains("polyresearch:release")),
+        "should post Release"
+    );
 }
 
 #[tokio::test]
@@ -3447,11 +3797,23 @@ async fn admin_release_claim_errors_when_no_active_claim() {
         mock.clone(),
         &fixture.lead_github_login,
         false,
-        Commands::Admin(AdminArgs { command: AdminCommands::ReleaseClaim(args.clone()) }),
+        Commands::Admin(AdminArgs {
+            command: AdminCommands::ReleaseClaim(args.clone()),
+        }),
     );
 
-    let err = commands::admin::run(&ctx, &AdminArgs { command: AdminCommands::ReleaseClaim(args) }).await.unwrap_err();
-    assert!(err.to_string().contains("does not currently have an active claim"));
+    let err = commands::admin::run(
+        &ctx,
+        &AdminArgs {
+            command: AdminCommands::ReleaseClaim(args),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("does not currently have an active claim")
+    );
 }
 
 #[tokio::test]
@@ -3476,14 +3838,31 @@ async fn admin_reopen_thesis_reopens_closed_issue() {
         mock.clone(),
         &fixture.lead_github_login,
         false,
-        Commands::Admin(AdminArgs { command: AdminCommands::ReopenThesis(args.clone()) }),
+        Commands::Admin(AdminArgs {
+            command: AdminCommands::ReopenThesis(args.clone()),
+        }),
     );
 
-    commands::admin::run(&ctx, &AdminArgs { command: AdminCommands::ReopenThesis(args) }).await.unwrap();
+    commands::admin::run(
+        &ctx,
+        &AdminArgs {
+            command: AdminCommands::ReopenThesis(args),
+        },
+    )
+    .await
+    .unwrap();
 
-    assert!(mock.reopened_issues.lock().unwrap().contains(&fixture.issue.number), "issue should be reopened");
+    assert!(
+        mock.reopened_issues
+            .lock()
+            .unwrap()
+            .contains(&fixture.issue.number),
+        "issue should be reopened"
+    );
     let posted = mock.posted_issue_comments.lock().unwrap();
-    assert!(posted.iter().any(|(_, body)| body.contains("polyresearch:admin-note") && body.contains("reopen_thesis")));
+    assert!(posted.iter().any(
+        |(_, body)| body.contains("polyresearch:admin-note") && body.contains("reopen_thesis")
+    ));
 }
 
 // ===========================================================================
@@ -3501,15 +3880,27 @@ async fn generate_refuses_at_max_queue_depth() {
         vec![],
         HashMap::new(),
     ));
-    let mut ctx = make_ctx(repo.path.clone(), mock, "lead", true, Commands::Generate(GenerateArgs {
-        title: "Test".to_string(),
-        body: "Body".to_string(),
-    }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
     ctx.config.max_queue_depth = Some(0);
 
-    let err = commands::generate::run(&ctx, &GenerateArgs { title: "Test".to_string(), body: "Body".to_string() })
-        .await
-        .unwrap_err();
+    let err = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
     assert!(err.to_string().contains("queue depth is already"));
 }
 
@@ -3524,15 +3915,27 @@ async fn generate_succeeds_below_max_queue_depth() {
         vec![],
         HashMap::new(),
     ));
-    let mut ctx = make_ctx(repo.path.clone(), mock, "lead", true, Commands::Generate(GenerateArgs {
-        title: "Test".to_string(),
-        body: "Body".to_string(),
-    }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "Test".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
     ctx.config.max_queue_depth = Some(10);
 
-    commands::generate::run(&ctx, &GenerateArgs { title: "New thesis".to_string(), body: "Body text".to_string() })
-        .await
-        .unwrap();
+    commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "New thesis".to_string(),
+            body: "Body text".to_string(),
+        },
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -3546,25 +3949,44 @@ async fn generate_with_auto_approve_false_assigns_maintainer() {
         vec![],
         HashMap::new(),
     ));
-    let mut ctx = make_ctx(repo.path.clone(), mock.clone(), "lead", false, Commands::Generate(GenerateArgs {
-        title: "Test thesis".to_string(),
-        body: "Body".to_string(),
-    }));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Generate(GenerateArgs {
+            title: "Test thesis".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
     ctx.config.auto_approve = false;
     ctx.config.max_queue_depth = Some(10);
 
-    commands::generate::run(&ctx, &GenerateArgs { title: "Test thesis".to_string(), body: "Body".to_string() })
-        .await
-        .unwrap();
+    commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Test thesis".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap();
 
     let created = mock.created_issues.lock().unwrap();
     assert_eq!(created.len(), 1, "should create one issue");
     let posted = mock.posted_issue_comments.lock().unwrap();
-    assert!(!posted.iter().any(|(_, body)| body.contains("polyresearch:approval")),
-        "should NOT auto-approve when auto_approve is false");
+    assert!(
+        !posted
+            .iter()
+            .any(|(_, body)| body.contains("polyresearch:approval")),
+        "should NOT auto-approve when auto_approve is false"
+    );
     let assigned = mock.assigned_issues.lock().unwrap();
     assert!(!assigned.is_empty(), "should assign maintainer");
-    assert!(assigned[0].1.contains(&"maintainer".to_string()), "should assign the maintainer login");
+    assert!(
+        assigned[0].1.contains(&"maintainer".to_string()),
+        "should assign the maintainer login"
+    );
 }
 
 // ===========================================================================
@@ -3577,7 +3999,11 @@ async fn review_claim_rejects_self_review() {
     let repo = TestRepo::new("review-self");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -3585,11 +4011,16 @@ async fn review_claim_rejects_self_review() {
     let pr = make_pr_with_thesis(60, 20, "alice");
     let (issue, issue_comments) = make_thesis_for_pr(20, &pr, "lead");
 
-    let policy_pass = ProtocolComment::PolicyPass { thesis: 20, candidate_sha: "abc123".to_string() };
+    let policy_pass = ProtocolComment::PolicyPass {
+        thesis: 20,
+        candidate_sha: "abc123".to_string(),
+    };
     let pr_comments = vec![IssueComment {
         id: 6001,
         body: policy_pass.render(),
-        user: CommentUser { login: "lead".to_string() },
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(5),
         updated_at: None,
     }];
@@ -3603,8 +4034,16 @@ async fn review_claim_rejects_self_review() {
     ));
     commands::write_node_id(&repo.path, "alice-node").unwrap();
 
-    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::ReviewClaim(PrArgs { pr: 60 }));
-    let err = commands::review_claim::run(&ctx, &PrArgs { pr: 60 }).await.unwrap_err();
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::ReviewClaim(PrArgs { pr: 60 }),
+    );
+    let err = commands::review_claim::run(&ctx, &PrArgs { pr: 60 })
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("cannot review your own PR"));
 }
 
@@ -3614,7 +4053,11 @@ async fn review_claim_rejects_without_policy_pass() {
     let repo = TestRepo::new("review-no-policy");
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -3630,8 +4073,16 @@ async fn review_claim_rejects_without_policy_pass() {
     ));
     commands::write_node_id(&repo.path, "reviewer-node").unwrap();
 
-    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::ReviewClaim(PrArgs { pr: 61 }));
-    let err = commands::review_claim::run(&ctx, &PrArgs { pr: 61 }).await.unwrap_err();
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::ReviewClaim(PrArgs { pr: 61 }),
+    );
+    let err = commands::review_claim::run(&ctx, &PrArgs { pr: 61 })
+        .await
+        .unwrap_err();
     assert!(err.to_string().contains("not passed policy check"));
 }
 
@@ -3647,10 +4098,14 @@ async fn claim_rejects_unapproved_thesis() {
         title: "Unapproved thesis".to_string(),
         body: Some("No approval yet.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now,
         closed_at: None,
-        author: Some(Author { login: "lead".to_string() }),
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
         url: None,
     };
 
@@ -3663,8 +4118,16 @@ async fn claim_rejects_unapproved_thesis() {
     ));
     commands::write_node_id(&repo.path, "node-a").unwrap();
 
-    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Claim(IssueArgs { issue: 99 }));
-    let err = commands::claim::run(&ctx, &IssueArgs { issue: 99 }).await.unwrap_err();
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Claim(IssueArgs { issue: 99 }),
+    );
+    let err = commands::claim::run(&ctx, &IssueArgs { issue: 99 })
+        .await
+        .unwrap_err();
     assert!(
         err.to_string().contains("not approved") || err.to_string().contains("not claimable"),
         "should reject unapproved thesis, got: {err}"
@@ -3701,12 +4164,21 @@ async fn prune_preserves_active_worktrees() {
     let stale = repo.path.join(".worktrees").join("stale-empty");
     fs::create_dir_all(&stale).unwrap();
 
-    let mock = Arc::new(MockGitHubClient::new("alice", vec![], HashMap::new(), vec![], HashMap::new()));
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Prune);
     commands::prune::run(&ctx).await.unwrap();
 
     assert!(!stale.exists(), "stale empty worktree should be removed");
-    assert!(active.exists(), "active worktree with files should be preserved");
+    assert!(
+        active.exists(),
+        "active worktree with files should be preserved"
+    );
 }
 
 // ===========================================================================
@@ -3733,10 +4205,19 @@ async fn claim_fails_when_another_node_holds_claim() {
         mock,
         &fixture.lead_github_login,
         false,
-        Commands::Claim(IssueArgs { issue: fixture.issue.number }),
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+        }),
     );
 
-    let err = commands::claim::run(&ctx, &IssueArgs { issue: fixture.issue.number }).await.unwrap_err();
+    let err = commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
     assert!(
         err.to_string().contains("not claimable"),
         "should reject claim when another node holds it, got: {err}"
@@ -3751,7 +4232,11 @@ async fn claim_fails_when_another_node_holds_claim() {
 fn ledger_is_current_when_no_missing_rows() {
     let dir = std::env::temp_dir().join(format!("ledger-current-{}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        dir.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
 
     let ledger = Ledger::load(&dir).unwrap();
     let repo_state = make_repo_state(vec![], 0, 0, None);
@@ -3763,13 +4248,19 @@ fn ledger_is_current_when_no_missing_rows() {
 fn ledger_detects_missing_decided_row() {
     let dir = std::env::temp_dir().join(format!("ledger-missing-{}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        dir.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
 
     let ledger = Ledger::load(&dir).unwrap();
     let now = chrono::Utc::now();
     let thesis = ThesisState {
         issue: make_open_issue(1, "Test"),
-        phase: ThesisPhase::Resolved { outcome: Outcome::Accepted },
+        phase: ThesisPhase::Resolved {
+            outcome: Outcome::Accepted,
+        },
         approved: true,
         maintainer_approved: false,
         maintainer_rejected: false,
@@ -3821,7 +4312,10 @@ fn ledger_detects_missing_decided_row() {
     };
 
     let repo_state = make_repo_state(vec![thesis], 1, 0, Some(0.95));
-    assert!(!ledger.is_current(&repo_state), "ledger should be stale with missing decided row");
+    assert!(
+        !ledger.is_current(&repo_state),
+        "ledger should be stale with missing decided row"
+    );
     let missing = ledger.missing_rows(&repo_state);
     assert_eq!(missing.len(), 1);
     assert_eq!(missing[0].status, "accepted");
@@ -3833,7 +4327,11 @@ fn ledger_detects_missing_decided_row() {
 fn ledger_skips_open_attempts_with_no_decision() {
     let dir = std::env::temp_dir().join(format!("ledger-open-{}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        dir.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
 
     let ledger = Ledger::load(&dir).unwrap();
     let now = chrono::Utc::now();
@@ -3890,7 +4388,10 @@ fn ledger_skips_open_attempts_with_no_decision() {
     };
 
     let repo_state = make_repo_state(vec![thesis], 1, 1, None);
-    assert!(ledger.is_current(&repo_state), "open attempt with no decision should not make ledger stale");
+    assert!(
+        ledger.is_current(&repo_state),
+        "open attempt with no decision should not make ledger stale"
+    );
 
     fs::remove_dir_all(dir).unwrap();
 }
@@ -3899,7 +4400,11 @@ fn ledger_skips_open_attempts_with_no_decision() {
 fn ledger_detects_discarded_after_release() {
     let dir = std::env::temp_dir().join(format!("ledger-discarded-{}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
-    fs::write(dir.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        dir.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
 
     let ledger = Ledger::load(&dir).unwrap();
     let now = chrono::Utc::now();
@@ -3967,14 +4472,21 @@ async fn batch_claim_allows_reclaim_after_infra_failure_release() {
         title: "Infra retry thesis".to_string(),
         body: Some("Test.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(3),
         closed_at: None,
-        author: Some(Author { login: lead.to_string() }),
+        author: Some(Author {
+            login: lead.to_string(),
+        }),
         url: None,
     };
     let approval = ProtocolComment::Approval { thesis: 50 };
-    let claim = ProtocolComment::Claim { thesis: 50, node: "node-a".to_string() };
+    let claim = ProtocolComment::Claim {
+        thesis: 50,
+        node: "node-a".to_string(),
+    };
     let release = ProtocolComment::Release {
         thesis: 50,
         node: "node-a".to_string(),
@@ -3984,21 +4496,27 @@ async fn batch_claim_allows_reclaim_after_infra_failure_release() {
         IssueComment {
             id: 5001,
             body: approval.render(),
-            user: CommentUser { login: lead.to_string() },
+            user: CommentUser {
+                login: lead.to_string(),
+            },
             created_at: now - chrono::Duration::hours(2),
             updated_at: None,
         },
         IssueComment {
             id: 5002,
             body: claim.render(),
-            user: CommentUser { login: "alice".to_string() },
+            user: CommentUser {
+                login: "alice".to_string(),
+            },
             created_at: now - chrono::Duration::hours(1),
             updated_at: None,
         },
         IssueComment {
             id: 5003,
             body: release.render(),
-            user: CommentUser { login: "alice".to_string() },
+            user: CommentUser {
+                login: "alice".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(30),
             updated_at: None,
         },
@@ -4012,15 +4530,22 @@ async fn batch_claim_allows_reclaim_after_infra_failure_release() {
         HashMap::new(),
     ));
     let ctx = make_ctx(
-        repo.path.clone(), mock.clone(), lead, false,
+        repo.path.clone(),
+        mock.clone(),
+        lead,
+        false,
         Commands::BatchClaim(BatchClaimArgs { count: Some(1) }),
     );
     commands::write_node_id(&repo.path, "node-a").unwrap();
 
     let result = commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(1) }).await;
-    assert!(result.is_ok(), "batch-claim should allow reclaim after infra_failure: {result:?}");
+    assert!(
+        result.is_ok(),
+        "batch-claim should allow reclaim after infra_failure: {result:?}"
+    );
     assert_eq!(
-        mock.posted_issue_comments.lock().unwrap().len(), 1,
+        mock.posted_issue_comments.lock().unwrap().len(),
+        1,
         "should post exactly one claim comment for the reclaimed thesis"
     );
 }
@@ -4033,7 +4558,11 @@ async fn batch_claim_allows_reclaim_after_infra_failure_release() {
 async fn duties_counts_infra_failure_released_thesis_as_claimable() {
     let repo = TestRepo::new("duties-infra-claimable");
     let mock = Arc::new(MockGitHubClient::new(
-        "alice", vec![], HashMap::new(), vec![], HashMap::new(),
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
     ));
     let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
     commands::write_node_id(&repo.path, "node-a").unwrap();
@@ -4049,7 +4578,10 @@ async fn duties_counts_infra_failure_released_thesis_as_claimable() {
     let report = duties::check(&ctx, &repo_state).unwrap();
 
     assert!(
-        !report.advisory.iter().any(|d| d.category == "no-claimable-work"),
+        !report
+            .advisory
+            .iter()
+            .any(|d| d.category == "no-claimable-work"),
         "infra_failure release should NOT make thesis unclaimable for the same node; \
          spec says only no_improvement permanently blocks"
     );
@@ -4087,9 +4619,10 @@ fn claimability_filter_is_per_node_for_no_improvement() {
     let is_claimable_by_node_b = thesis.issue.state == "OPEN"
         && thesis.approved
         && thesis.active_claims.is_empty()
-        && !thesis.releases.iter().any(|r| {
-            r.node == "node-b" && r.reason == ReleaseReason::NoImprovement
-        });
+        && !thesis
+            .releases
+            .iter()
+            .any(|r| r.node == "node-b" && r.reason == ReleaseReason::NoImprovement);
 
     assert!(
         is_claimable_by_node_b,
@@ -4099,9 +4632,10 @@ fn claimability_filter_is_per_node_for_no_improvement() {
     let is_claimable_by_node_a = thesis.issue.state == "OPEN"
         && thesis.approved
         && thesis.active_claims.is_empty()
-        && !thesis.releases.iter().any(|r| {
-            r.node == "node-a" && r.reason == ReleaseReason::NoImprovement
-        });
+        && !thesis
+            .releases
+            .iter()
+            .any(|r| r.node == "node-a" && r.reason == ReleaseReason::NoImprovement);
 
     assert!(
         !is_claimable_by_node_a,
@@ -4122,7 +4656,11 @@ async fn contribute_auto_submit_recreates_missing_worktree() {
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
     write_node_config(&repo.path, "test-node");
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -4132,24 +4670,36 @@ async fn contribute_auto_submit_recreates_missing_worktree() {
         title: "Auto submit test".to_string(),
         body: Some("Test.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(3),
         closed_at: None,
-        author: Some(Author { login: "lead".to_string() }),
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
         url: None,
     };
     let comments = vec![
         IssueComment {
             id: 6001,
             body: ProtocolComment::Approval { thesis: 60 }.render(),
-            user: CommentUser { login: "lead".to_string() },
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
             created_at: now - chrono::Duration::hours(2),
             updated_at: None,
         },
         IssueComment {
             id: 6002,
-            body: ProtocolComment::Claim { thesis: 60, node: "test-node".to_string() }.render(),
-            user: CommentUser { login: "lead".to_string() },
+            body: ProtocolComment::Claim {
+                thesis: 60,
+                node: "test-node".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
             created_at: now - chrono::Duration::hours(1),
             updated_at: None,
         },
@@ -4163,8 +4713,11 @@ async fn contribute_auto_submit_recreates_missing_worktree() {
                 observation: Observation::Improved,
                 summary: "improved".to_string(),
                 annotations: None,
-            }.render(),
-            user: CommentUser { login: "lead".to_string() },
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
             created_at: now - chrono::Duration::minutes(30),
             updated_at: None,
         },
@@ -4180,20 +4733,36 @@ async fn contribute_auto_submit_recreates_missing_worktree() {
     set_node_id_env("test-node");
 
     let worktree_path = repo.path.join(".worktrees/60-auto-submit-test");
-    assert!(!worktree_path.exists(), "precondition: worktree should not exist");
+    assert!(
+        !worktree_path.exists(),
+        "precondition: worktree should not exist"
+    );
 
     let ctx = make_ctx(
-        repo.path.clone(), mock.clone(), "lead", false,
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
         Commands::Contribute(ContributeArgs {
-            url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
             overrides: NodeOverrides::default(),
         }),
     );
 
-    let result = commands::contribute::run(&ctx, &ContributeArgs {
-        url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
-        overrides: NodeOverrides::default(),
-    }).await;
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
 
     assert!(
         result.is_err(),
@@ -4224,7 +4793,11 @@ async fn contribute_once_errors_on_unresolvable_submit_duty() {
     init_git_repo(&repo.path);
     write_program_md(&repo.path);
     write_node_config(&repo.path, "test-node");
-    fs::write(repo.path.join("results.tsv"), "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n").unwrap();
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
@@ -4240,17 +4813,30 @@ async fn contribute_once_errors_on_unresolvable_submit_duty() {
     ));
 
     let ctx = make_ctx(
-        repo.path.clone(), mock, &fixture.lead_github_login, false,
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
         Commands::Contribute(ContributeArgs {
-            url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
             overrides: NodeOverrides::default(),
         }),
     );
 
-    let result = commands::contribute::run(&ctx, &ContributeArgs {
-        url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
-        overrides: NodeOverrides::default(),
-    }).await;
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
 
     assert!(
         result.is_err(),
@@ -4286,8 +4872,11 @@ fn worker_setup_failure_returns_issue_number_for_release() {
     };
 
     let tw = worker::ThesisWorker::new(wctx, String::new());
-    assert_eq!(tw.issue_number(), 99,
-        "ThesisWorker must expose issue_number for cleanup even before execute()");
+    assert_eq!(
+        tw.issue_number(),
+        99,
+        "ThesisWorker must expose issue_number for cleanup even before execute()"
+    );
 }
 
 /// Spec (Duties, advisory): "metric-floor / stale-queue: best metric is
@@ -4302,7 +4891,11 @@ fn worker_setup_failure_returns_issue_number_for_release() {
 async fn duties_reports_metric_floor_for_higher_is_better() {
     let repo = TestRepo::new("duties-metric-floor-hib");
     let mock = Arc::new(MockGitHubClient::new(
-        "lead", vec![], HashMap::new(), vec![], HashMap::new(),
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
     ));
     let mut ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
     ctx.config.metric_direction = MetricDirection::HigherIsBetter;
@@ -4310,8 +4903,13 @@ async fn duties_reports_metric_floor_for_higher_is_better() {
     ctx.config.min_queue_depth = 3;
 
     let repo_state = make_repo_state(
-        vec![make_approved_thesis(1), make_approved_thesis(2), make_approved_thesis(3)],
-        0, 3,
+        vec![
+            make_approved_thesis(1),
+            make_approved_thesis(2),
+            make_approved_thesis(3),
+        ],
+        0,
+        3,
         Some(0.999),
     );
     let report = duties::check(&ctx, &repo_state).unwrap();
@@ -4340,24 +4938,36 @@ async fn expired_claim_makes_thesis_claimable() {
         title: "Expired claim thesis".to_string(),
         body: Some("Test.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(72),
         closed_at: None,
-        author: Some(Author { login: lead.to_string() }),
+        author: Some(Author {
+            login: lead.to_string(),
+        }),
         url: None,
     };
     let comments = vec![
         IssueComment {
             id: 8001,
             body: ProtocolComment::Approval { thesis: 80 }.render(),
-            user: CommentUser { login: lead.to_string() },
+            user: CommentUser {
+                login: lead.to_string(),
+            },
             created_at: now - chrono::Duration::hours(48),
             updated_at: None,
         },
         IssueComment {
             id: 8002,
-            body: ProtocolComment::Claim { thesis: 80, node: "stale-node".to_string() }.render(),
-            user: CommentUser { login: "alice".to_string() },
+            body: ProtocolComment::Claim {
+                thesis: 80,
+                node: "stale-node".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "alice".to_string(),
+            },
             created_at: now - chrono::Duration::hours(36),
             updated_at: None,
         },
@@ -4373,7 +4983,10 @@ async fn expired_claim_makes_thesis_claimable() {
     commands::write_node_id(&repo.path, "fresh-node").unwrap();
 
     let mut ctx = make_ctx(
-        repo.path.clone(), mock.clone(), lead, false,
+        repo.path.clone(),
+        mock.clone(),
+        lead,
+        false,
         Commands::Claim(IssueArgs { issue: 80 }),
     );
     ctx.config.assignment_timeout = Duration::from_secs(24 * 60 * 60);
@@ -4405,24 +5018,36 @@ async fn contribute_counts_resumable_theses_as_available_work() {
         title: "Resumable thesis".to_string(),
         body: Some("Test.".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(3),
         closed_at: None,
-        author: Some(Author { login: "lead".to_string() }),
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
         url: None,
     };
     let comments = vec![
         IssueComment {
             id: 9001,
             body: ProtocolComment::Approval { thesis: 90 }.render(),
-            user: CommentUser { login: "lead".to_string() },
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
             created_at: now - chrono::Duration::hours(2),
             updated_at: None,
         },
         IssueComment {
             id: 9002,
-            body: ProtocolComment::Claim { thesis: 90, node: "test-node-resume".to_string() }.render(),
-            user: CommentUser { login: "contributor".to_string() },
+            body: ProtocolComment::Claim {
+                thesis: 90,
+                node: "test-node-resume".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "contributor".to_string(),
+            },
             created_at: now - chrono::Duration::hours(1),
             updated_at: None,
         },
@@ -4438,17 +5063,30 @@ async fn contribute_counts_resumable_theses_as_available_work() {
     set_node_id_env("test-node-resume");
 
     let ctx = make_ctx(
-        repo.path.clone(), mock.clone(), "lead", true,
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        true,
         Commands::Contribute(ContributeArgs {
-            url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
             overrides: NodeOverrides::default(),
         }),
     );
 
-    let result = commands::contribute::run(&ctx, &ContributeArgs {
-        url: None, once: true, max_parallel: Some(1), sleep_secs: 0,
-        overrides: NodeOverrides::default(),
-    }).await;
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
 
     assert!(
         result.is_ok(),
@@ -4468,7 +5106,10 @@ fn ensure_clean_audit_passes_with_only_suspicious_findings() {
         created_at: Some(chrono::Utc::now()),
     });
     let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
-    assert!(result.is_ok(), "suspicious findings should not block: {result:?}");
+    assert!(
+        result.is_ok(),
+        "suspicious findings should not block: {result:?}"
+    );
 }
 
 #[test]
@@ -4531,7 +5172,10 @@ fn ensure_clean_audit_blocks_on_invalid_even_with_non_blocking_present() {
         created_at: Some(chrono::Utc::now()),
     });
     let result = commands::guards::ensure_clean_audit(&repo_state, "proceed");
-    assert!(result.is_err(), "must block when invalid findings are present");
+    assert!(
+        result.is_err(),
+        "must block when invalid findings are present"
+    );
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("1 critical audit finding"));
 }
@@ -4568,7 +5212,10 @@ fn computed_findings_without_comment_id_do_not_block_when_info() {
         .count();
     assert_eq!(blocking_count, 0);
     let result = commands::guards::ensure_clean_audit(&repo_state, "generate theses");
-    assert!(result.is_ok(), "info findings with null comment_id should not block: {result:?}");
+    assert!(
+        result.is_ok(),
+        "info findings with null comment_id should not block: {result:?}"
+    );
 }
 
 fn load_issue_fixture(name: &str) -> IssueFixture {

--- a/cli/tests/scenario_mock.rs
+++ b/cli/tests/scenario_mock.rs
@@ -79,10 +79,7 @@ impl ScenarioGitHub {
 
     pub fn seed_pr_comments(&self, pr_number: u64, comments: Vec<IssueComment>) {
         let mut s = self.state.lock().unwrap();
-        s.pr_comments
-            .entry(pr_number)
-            .or_default()
-            .extend(comments);
+        s.pr_comments.entry(pr_number).or_default().extend(comments);
     }
 
     pub fn seed_pr_files(&self, pr_number: u64, files: Vec<PullRequestFile>) {
@@ -129,7 +126,11 @@ impl ScenarioGitHub {
     #[allow(dead_code)]
     pub fn created_issues(&self) -> Vec<Issue> {
         let s = self.state.lock().unwrap();
-        s.issues.iter().filter(|i| i.number >= 100).cloned().collect()
+        s.issues
+            .iter()
+            .filter(|i| i.number >= 100)
+            .cloned()
+            .collect()
     }
 
     #[allow(dead_code)]
@@ -326,18 +327,12 @@ impl GitHubApi for ScenarioGitHub {
 
     fn list_pull_request_comments(&self, pr_number: u64) -> Result<Vec<IssueComment>> {
         let s = self.state.lock().unwrap();
-        Ok(s.pr_comments
-            .get(&pr_number)
-            .cloned()
-            .unwrap_or_default())
+        Ok(s.pr_comments.get(&pr_number).cloned().unwrap_or_default())
     }
 
     fn list_pull_request_files(&self, pr_number: u64) -> Result<Vec<PullRequestFile>> {
         let s = self.state.lock().unwrap();
-        Ok(s.pr_files
-            .get(&pr_number)
-            .cloned()
-            .unwrap_or_default())
+        Ok(s.pr_files.get(&pr_number).cloned().unwrap_or_default())
     }
 
     fn create_pull_request(
@@ -389,7 +384,9 @@ impl GitHubApi for ScenarioGitHub {
 
         if let Some(pr) = s.pull_requests.iter().find(|pr| pr.number == pr_number) {
             if pr.mergeable.as_deref() == Some("CONFLICTING") && current_attempt <= 1 {
-                return Err(eyre!("405 Method Not Allowed: pull request is not mergeable"));
+                return Err(eyre!(
+                    "405 Method Not Allowed: pull request is not mergeable"
+                ));
             }
         }
         s.merged_prs.push(pr_number);

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -7,18 +7,14 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use polyresearch::cli::{
-    BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides,
-};
+use polyresearch::cli::{BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides};
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
-use polyresearch::config::{
-    DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig,
-};
-use polyresearch::state::RepositoryState;
+use polyresearch::config::{DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig};
 use polyresearch::github::{
     Author, CommentUser, GitHubApi, Issue, IssueComment, Label, PullRequest, RepoRef,
 };
+use polyresearch::state::RepositoryState;
 
 use scenario_mock::ScenarioGitHub;
 
@@ -323,7 +319,10 @@ async fn scenario_bootstrap_fresh() {
 
     assert!(repo.path.join("PROGRAM.md").exists(), "PROGRAM.md created");
     assert!(repo.path.join("PREPARE.md").exists(), "PREPARE.md created");
-    assert!(repo.path.join("results.tsv").exists(), "results.tsv created");
+    assert!(
+        repo.path.join("results.tsv").exists(),
+        "results.tsv created"
+    );
     assert!(
         repo.path.join(".polyresearch-node.toml").exists(),
         "node config created"
@@ -558,7 +557,9 @@ async fn scenario_contribute_improved() {
     github.seed_issue(issue);
     github.seed_issue_comments(10, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -606,7 +607,9 @@ async fn scenario_contribute_no_improvement() {
     github.seed_issue(issue);
     github.seed_issue_comments(20, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ni"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ni");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -654,7 +657,9 @@ async fn scenario_contribute_agent_failure() {
     github.seed_issue(issue);
     github.seed_issue_comments(30, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fail"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fail");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -682,7 +687,10 @@ async fn scenario_contribute_agent_failure() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should succeed even on agent failure: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should succeed even on agent failure: {result:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -771,9 +779,12 @@ async fn scenario_lead_accept_pr() {
     github.seed_issue_comments(40, issue_comments);
     github.seed_pull_request(pr);
     github.seed_pr_comments(50, pr_comments);
-    github.seed_pr_files(50, vec![polyresearch::github::PullRequestFile {
-        filename: "src/inference.js".to_string(),
-    }]);
+    github.seed_pr_files(
+        50,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/inference.js".to_string(),
+        }],
+    );
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -808,7 +819,10 @@ async fn scenario_lead_accept_pr() {
     let has_decision = pr_bodies
         .iter()
         .any(|b| b.contains("polyresearch:decision") && b.contains("accepted"));
-    assert!(has_decision, "should have posted accepted decision on PR #50");
+    assert!(
+        has_decision,
+        "should have posted accepted decision on PR #50"
+    );
 }
 
 #[tokio::test]
@@ -893,9 +907,12 @@ async fn scenario_lead_reject_non_improvement() {
     github.seed_issue_comments(41, issue_comments);
     github.seed_pull_request(pr);
     github.seed_pr_comments(51, pr_comments);
-    github.seed_pr_files(51, vec![polyresearch::github::PullRequestFile {
-        filename: "src/quantize.js".to_string(),
-    }]);
+    github.seed_pr_files(
+        51,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/quantize.js".to_string(),
+        }],
+    );
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -972,7 +989,10 @@ fn execute_decision_non_improvement_zero_conf_keeps_thesis_open() {
     )
     .unwrap();
 
-    assert_eq!(result.outcome, polyresearch::comments::Outcome::NonImprovement);
+    assert_eq!(
+        result.outcome,
+        polyresearch::comments::Outcome::NonImprovement
+    );
     assert_eq!(result.confirmations, 0);
     assert!(
         github.is_pr_closed(70),
@@ -1020,7 +1040,10 @@ fn execute_decision_disagreement_zero_conf_closes_thesis() {
     )
     .unwrap();
 
-    assert_eq!(result.outcome, polyresearch::comments::Outcome::Disagreement);
+    assert_eq!(
+        result.outcome,
+        polyresearch::comments::Outcome::Disagreement
+    );
     assert_eq!(result.confirmations, 0);
     assert!(
         github.is_pr_closed(71),
@@ -1162,9 +1185,12 @@ async fn scenario_lead_closes_conflicting_pr_as_stale() {
     github.seed_issue_comments(45, issue_comments);
     github.seed_pull_request(pr);
     github.seed_pr_comments(55, pr_comments);
-    github.seed_pr_files(55, vec![polyresearch::github::PullRequestFile {
-        filename: "src/hot_path.js".to_string(),
-    }]);
+    github.seed_pr_files(
+        55,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/hot_path.js".to_string(),
+        }],
+    );
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -1243,7 +1269,10 @@ fn execute_decision_falls_back_on_merge_failure() {
         0,
     );
 
-    assert!(result.is_ok(), "should not propagate merge error: {result:?}");
+    assert!(
+        result.is_ok(),
+        "should not propagate merge error: {result:?}"
+    );
     let result = result.unwrap();
     assert_eq!(
         result.outcome,
@@ -1296,10 +1325,7 @@ fn execute_decision_falls_back_on_merge_failure() {
 /// diverges from an advanced main. Returns (clone_path, bare_path) both
 /// inside the given `parent` directory. The caller owns the `parent`
 /// `ScenarioRepo` whose Drop cleans everything up.
-fn setup_diverged_repo(
-    parent: &ScenarioRepo,
-    conflict: bool,
-) -> (PathBuf, PathBuf) {
+fn setup_diverged_repo(parent: &ScenarioRepo, conflict: bool) -> (PathBuf, PathBuf) {
     let bare_path = parent.path.join("remote.git");
     let clone_path = parent.path.join("work");
 
@@ -1498,7 +1524,10 @@ fn execute_decision_branch_cleanup_on_non_improvement() {
     )
     .unwrap();
 
-    assert_eq!(result.outcome, polyresearch::comments::Outcome::NonImprovement);
+    assert_eq!(
+        result.outcome,
+        polyresearch::comments::Outcome::NonImprovement
+    );
     assert!(
         github.is_pr_closed(82),
         "PR should be closed on non_improvement"
@@ -1548,10 +1577,7 @@ fn execute_decision_branch_cleanup_on_stale() {
     .unwrap();
 
     assert_eq!(result.outcome, polyresearch::comments::Outcome::Stale);
-    assert!(
-        github.is_pr_closed(83),
-        "PR should be closed on stale"
-    );
+    assert!(github.is_pr_closed(83), "PR should be closed on stale");
     assert!(
         github.is_branch_deleted("thesis/83-stale"),
         "remote branch should be deleted on stale so thesis can be retried"
@@ -1841,26 +1867,61 @@ async fn scenario_decide_peer_review_accepted() {
     let reviews = vec![
         make_review_claim_comment(8001, 80, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8002, 80, "reviewer-b", "reviewer-b", 24),
-        make_review_comment(8003, 80, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env1"), 20),
-        make_review_comment(8004, 80, "reviewer-b", "reviewer-b", 0.955, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env1"), 19),
+        make_review_comment(
+            8003,
+            80,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env1"),
+            20,
+        ),
+        make_review_comment(
+            8004,
+            80,
+            "reviewer-b",
+            "reviewer-b",
+            0.955,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env1"),
+            19,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(80, 180, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(80, 180, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
     github.seed_issue_comments(80, issue_comments);
     github.seed_pull_request(pr);
     github.seed_pr_comments(180, pr_comments);
-    github.seed_pr_files(180, vec![polyresearch::github::PullRequestFile {
-        filename: "src/test.js".to_string(),
-    }]);
+    github.seed_pr_files(
+        180,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/test.js".to_string(),
+        }],
+    );
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 180, 2);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 180 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        180,
+        2,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 180 })
+        .await
+        .unwrap();
 
-    assert!(github.is_pr_merged(180), "PR should be merged for accepted peer review");
+    assert!(
+        github.is_pr_merged(180),
+        "PR should be merged for accepted peer review"
+    );
     assert!(github.is_issue_closed(80), "thesis should be closed");
 }
 
@@ -1884,12 +1945,33 @@ async fn scenario_decide_peer_review_non_improvement() {
     let reviews = vec![
         make_review_claim_comment(8101, 81, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8102, 81, "reviewer-b", "reviewer-b", 24),
-        make_review_comment(8103, 81, "reviewer-a", "reviewer-a", 0.89, 0.90, polyresearch::comments::Observation::NoImprovement, &main_sha, Some("env1"), 20),
-        make_review_comment(8104, 81, "reviewer-b", "reviewer-b", 0.885, 0.90, polyresearch::comments::Observation::NoImprovement, &main_sha, Some("env1"), 19),
+        make_review_comment(
+            8103,
+            81,
+            "reviewer-a",
+            "reviewer-a",
+            0.89,
+            0.90,
+            polyresearch::comments::Observation::NoImprovement,
+            &main_sha,
+            Some("env1"),
+            20,
+        ),
+        make_review_comment(
+            8104,
+            81,
+            "reviewer-b",
+            "reviewer-b",
+            0.885,
+            0.90,
+            polyresearch::comments::Observation::NoImprovement,
+            &main_sha,
+            Some("env1"),
+            19,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(81, 181, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(81, 181, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -1897,11 +1979,22 @@ async fn scenario_decide_peer_review_non_improvement() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(181, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 181, 2);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 181 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        181,
+        2,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 181 })
+        .await
+        .unwrap();
 
     assert!(github.is_pr_closed(181), "PR should be closed");
-    assert!(github.is_issue_closed(81), "thesis should be closed with peer review non_improvement");
+    assert!(
+        github.is_issue_closed(81),
+        "thesis should be closed with peer review non_improvement"
+    );
 }
 
 #[tokio::test]
@@ -1924,12 +2017,33 @@ async fn scenario_decide_peer_review_disagreement_mixed_obs() {
     let reviews = vec![
         make_review_claim_comment(8201, 82, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8202, 82, "reviewer-b", "reviewer-b", 24),
-        make_review_comment(8203, 82, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env1"), 20),
-        make_review_comment(8204, 82, "reviewer-b", "reviewer-b", 0.89, 0.90, polyresearch::comments::Observation::NoImprovement, &main_sha, Some("env1"), 19),
+        make_review_comment(
+            8203,
+            82,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env1"),
+            20,
+        ),
+        make_review_comment(
+            8204,
+            82,
+            "reviewer-b",
+            "reviewer-b",
+            0.89,
+            0.90,
+            polyresearch::comments::Observation::NoImprovement,
+            &main_sha,
+            Some("env1"),
+            19,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(82, 182, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(82, 182, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -1937,14 +2051,31 @@ async fn scenario_decide_peer_review_disagreement_mixed_obs() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(182, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 182, 2);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 182 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        182,
+        2,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 182 })
+        .await
+        .unwrap();
 
-    assert!(github.is_pr_closed(182), "PR should be closed on disagreement");
-    assert!(github.is_issue_closed(82), "thesis should be closed on disagreement with peer review");
+    assert!(
+        github.is_pr_closed(182),
+        "PR should be closed on disagreement"
+    );
+    assert!(
+        github.is_issue_closed(82),
+        "thesis should be closed on disagreement with peer review"
+    );
 
     let bodies = github.comment_bodies_on(182);
-    assert!(bodies.iter().any(|b| b.contains("disagreement")), "should post disagreement decision");
+    assert!(
+        bodies.iter().any(|b| b.contains("disagreement")),
+        "should post disagreement decision"
+    );
 }
 
 #[tokio::test]
@@ -1958,12 +2089,33 @@ async fn scenario_decide_peer_review_stale_base() {
     let reviews = vec![
         make_review_claim_comment(8301, 83, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8302, 83, "reviewer-b", "reviewer-b", 24),
-        make_review_comment(8303, 83, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, "stale-old-sha", Some("env1"), 20),
-        make_review_comment(8304, 83, "reviewer-b", "reviewer-b", 0.95, 0.90, polyresearch::comments::Observation::Improved, "stale-old-sha", Some("env1"), 19),
+        make_review_comment(
+            8303,
+            83,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            "stale-old-sha",
+            Some("env1"),
+            20,
+        ),
+        make_review_comment(
+            8304,
+            83,
+            "reviewer-b",
+            "reviewer-b",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            "stale-old-sha",
+            Some("env1"),
+            19,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(83, 183, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(83, 183, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -1971,14 +2123,28 @@ async fn scenario_decide_peer_review_stale_base() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(183, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 183, 2);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 183 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        183,
+        2,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 183 })
+        .await
+        .unwrap();
 
     assert!(github.is_pr_closed(183), "PR should be closed on stale");
-    assert!(!github.is_issue_closed(83), "thesis should stay open on stale decision");
+    assert!(
+        !github.is_issue_closed(83),
+        "thesis should stay open on stale decision"
+    );
 
     let bodies = github.comment_bodies_on(183);
-    assert!(bodies.iter().any(|b| b.contains("stale")), "should post stale decision");
+    assert!(
+        bodies.iter().any(|b| b.contains("stale")),
+        "should post stale decision"
+    );
 }
 
 #[tokio::test]
@@ -2001,12 +2167,33 @@ async fn scenario_decide_peer_review_env_disagreement() {
     let reviews = vec![
         make_review_claim_comment(8401, 84, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8402, 84, "reviewer-b", "reviewer-b", 24),
-        make_review_comment(8403, 84, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env-aaa"), 20),
-        make_review_comment(8404, 84, "reviewer-b", "reviewer-b", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env-bbb"), 19),
+        make_review_comment(
+            8403,
+            84,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env-aaa"),
+            20,
+        ),
+        make_review_comment(
+            8404,
+            84,
+            "reviewer-b",
+            "reviewer-b",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env-bbb"),
+            19,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(84, 184, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(84, 184, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -2014,12 +2201,26 @@ async fn scenario_decide_peer_review_env_disagreement() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(184, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 184, 2);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 184 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        184,
+        2,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 184 })
+        .await
+        .unwrap();
 
-    assert!(github.is_pr_closed(184), "PR should be closed on env disagreement");
+    assert!(
+        github.is_pr_closed(184),
+        "PR should be closed on env disagreement"
+    );
     let bodies = github.comment_bodies_on(184);
-    assert!(bodies.iter().any(|b| b.contains("disagreement")), "should post disagreement decision");
+    assert!(
+        bodies.iter().any(|b| b.contains("disagreement")),
+        "should post disagreement decision"
+    );
 }
 
 #[tokio::test]
@@ -2043,13 +2244,45 @@ async fn scenario_decide_peer_review_infra_majority() {
         make_review_claim_comment(8501, 85, "reviewer-a", "reviewer-a", 25),
         make_review_claim_comment(8502, 85, "reviewer-b", "reviewer-b", 24),
         make_review_claim_comment(8503, 85, "reviewer-c", "reviewer-c", 23),
-        make_review_comment(8504, 85, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env1"), 20),
-        make_review_comment(8505, 85, "reviewer-b", "reviewer-b", 0.0, 0.90, polyresearch::comments::Observation::Crashed, &main_sha, Some("env1"), 19),
-        make_review_comment(8506, 85, "reviewer-c", "reviewer-c", 0.0, 0.90, polyresearch::comments::Observation::InfraFailure, &main_sha, Some("env1"), 18),
+        make_review_comment(
+            8504,
+            85,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env1"),
+            20,
+        ),
+        make_review_comment(
+            8505,
+            85,
+            "reviewer-b",
+            "reviewer-b",
+            0.0,
+            0.90,
+            polyresearch::comments::Observation::Crashed,
+            &main_sha,
+            Some("env1"),
+            19,
+        ),
+        make_review_comment(
+            8506,
+            85,
+            "reviewer-c",
+            "reviewer-c",
+            0.0,
+            0.90,
+            polyresearch::comments::Observation::InfraFailure,
+            &main_sha,
+            Some("env1"),
+            18,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(85, 185, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(85, 185, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -2057,14 +2290,31 @@ async fn scenario_decide_peer_review_infra_majority() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(185, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 185, 3);
-    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 185 }).await.unwrap();
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        185,
+        3,
+    );
+    commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 185 })
+        .await
+        .unwrap();
 
-    assert!(github.is_pr_closed(185), "PR should be closed on infra_failure");
-    assert!(!github.is_issue_closed(85), "thesis should stay open on infra_failure");
+    assert!(
+        github.is_pr_closed(185),
+        "PR should be closed on infra_failure"
+    );
+    assert!(
+        !github.is_issue_closed(85),
+        "thesis should stay open on infra_failure"
+    );
 
     let bodies = github.comment_bodies_on(185);
-    assert!(bodies.iter().any(|b| b.contains("infra_failure")), "should post infra_failure decision");
+    assert!(
+        bodies.iter().any(|b| b.contains("infra_failure")),
+        "should post infra_failure decision"
+    );
 }
 
 #[tokio::test]
@@ -2086,11 +2336,21 @@ async fn scenario_decide_peer_review_insufficient_reviews() {
 
     let reviews = vec![
         make_review_claim_comment(8601, 86, "reviewer-a", "reviewer-a", 25),
-        make_review_comment(8602, 86, "reviewer-a", "reviewer-a", 0.95, 0.90, polyresearch::comments::Observation::Improved, &main_sha, Some("env1"), 20),
+        make_review_comment(
+            8602,
+            86,
+            "reviewer-a",
+            "reviewer-a",
+            0.95,
+            0.90,
+            polyresearch::comments::Observation::Improved,
+            &main_sha,
+            Some("env1"),
+            20,
+        ),
     ];
 
-    let (issue, issue_comments, pr, pr_comments) =
-        make_peer_review_setup(86, 186, "lead", reviews);
+    let (issue, issue_comments, pr, pr_comments) = make_peer_review_setup(86, 186, "lead", reviews);
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
     github.seed_issue(issue);
@@ -2098,9 +2358,20 @@ async fn scenario_decide_peer_review_insufficient_reviews() {
     github.seed_pull_request(pr);
     github.seed_pr_comments(186, pr_comments);
 
-    let ctx = make_peer_review_ctx(&repo, Arc::clone(&github) as Arc<dyn GitHubApi>, "lead", 186, 2);
-    let err = commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 186 }).await.unwrap_err();
-    assert!(err.to_string().contains("only has 1 review"), "should error on insufficient reviews, got: {err}");
+    let ctx = make_peer_review_ctx(
+        &repo,
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        186,
+        2,
+    );
+    let err = commands::decide::run(&ctx, &polyresearch::cli::PrArgs { pr: 186 })
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("only has 1 review"),
+        "should error on insufficient reviews, got: {err}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -2124,7 +2395,9 @@ async fn scenario_contribute_agent_crash_releases_claim() {
     github.seed_issue(issue);
     github.seed_issue_comments(90, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-crash"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-crash");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2152,7 +2425,10 @@ async fn scenario_contribute_agent_crash_releases_claim() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should handle agent crash gracefully: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should handle agent crash gracefully: {result:?}"
+    );
 }
 
 #[tokio::test]
@@ -2172,7 +2448,9 @@ async fn scenario_contribute_no_improvement_releases() {
     github.seed_issue(issue);
     github.seed_issue_comments(91, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ni2"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ni2");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2200,7 +2478,10 @@ async fn scenario_contribute_no_improvement_releases() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should succeed with no_improvement: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should succeed with no_improvement: {result:?}"
+    );
 }
 
 #[tokio::test]
@@ -2220,7 +2501,9 @@ async fn scenario_contribute_agent_failure_recovers() {
     github.seed_issue(issue);
     github.seed_issue_comments(92, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fr"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fr");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2248,7 +2531,10 @@ async fn scenario_contribute_agent_failure_recovers() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should handle agent failure gracefully: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should handle agent failure gracefully: {result:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -2272,7 +2558,9 @@ async fn scenario_contribute_lower_is_better() {
     github.seed_issue(issue);
     github.seed_issue_comments(93, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-lib"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-lib");
+    }
 
     let mut ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2301,19 +2589,17 @@ async fn scenario_contribute_lower_is_better() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should succeed with lower_is_better: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should succeed with lower_is_better: {result:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
 // Lead/contribute separation (issue #94)
 // ---------------------------------------------------------------------------
 
-fn seed_decidable_pr(
-    github: &ScenarioGitHub,
-    thesis_num: u64,
-    pr_num: u64,
-    lead: &str,
-) {
+fn seed_decidable_pr(github: &ScenarioGitHub, thesis_num: u64, pr_num: u64, lead: &str) {
     let now = chrono::Utc::now();
     let (issue, mut issue_comments) = make_approved_thesis(thesis_num, "Decidable thesis", lead);
 
@@ -2386,9 +2672,12 @@ fn seed_decidable_pr(
     github.seed_issue_comments(thesis_num, issue_comments);
     github.seed_pull_request(pr);
     github.seed_pr_comments(pr_num, pr_comments);
-    github.seed_pr_files(pr_num, vec![polyresearch::github::PullRequestFile {
-        filename: "src/decidable.js".to_string(),
-    }]);
+    github.seed_pr_files(
+        pr_num,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/decidable.js".to_string(),
+        }],
+    );
 }
 
 #[tokio::test]
@@ -2406,7 +2695,9 @@ async fn scenario_contribute_does_not_decide() {
     let github = Arc::new(ScenarioGitHub::new("lead"));
     seed_decidable_pr(&github, 60, 160, "lead");
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-nd"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-nd");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2444,26 +2735,26 @@ async fn scenario_contribute_does_not_decide() {
         !has_decision,
         "contribute must NOT post decision comments, but found: {pr_bodies:?}"
     );
-    assert!(
-        !github.is_pr_merged(160),
-        "contribute must NOT merge PRs"
-    );
+    assert!(!github.is_pr_merged(160), "contribute must NOT merge PRs");
 
     let config = ProtocolConfig::load(&repo.path).unwrap();
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
     commands::lead::decide_ready_prs(&ctx, &config, &repo_state).unwrap();
 
     let pr_bodies = github.comment_bodies_on(160);
     let has_decision = pr_bodies
         .iter()
         .any(|b| b.contains("polyresearch:decision") && b.contains("accepted"));
-    assert!(has_decision, "lead::decide_ready_prs should post accepted decision");
-    assert!(github.is_pr_merged(160), "lead::decide_ready_prs should merge the PR");
+    assert!(
+        has_decision,
+        "lead::decide_ready_prs should post accepted decision"
+    );
+    assert!(
+        github.is_pr_merged(160),
+        "lead::decide_ready_prs should merge the PR"
+    );
 }
 
 #[tokio::test]
@@ -2481,7 +2772,9 @@ async fn scenario_contribute_does_not_sync() {
     let github = Arc::new(ScenarioGitHub::new("lead"));
     seed_decidable_pr(&github, 61, 161, "lead");
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ns"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-ns");
+    }
 
     let header = fs::read_to_string(repo.path.join("results.tsv")).unwrap();
 
@@ -2513,10 +2806,7 @@ async fn scenario_contribute_does_not_sync() {
     .await;
 
     let after = fs::read_to_string(repo.path.join("results.tsv")).unwrap();
-    assert_eq!(
-        header, after,
-        "contribute must NOT modify results.tsv"
-    );
+    assert_eq!(header, after, "contribute must NOT modify results.tsv");
 }
 
 #[tokio::test]
@@ -2534,7 +2824,9 @@ async fn scenario_contribute_does_not_merge() {
     let github = Arc::new(ScenarioGitHub::new("lead"));
     seed_decidable_pr(&github, 62, 162, "lead");
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-nm"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-nm");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2563,18 +2855,12 @@ async fn scenario_contribute_does_not_merge() {
     )
     .await;
 
-    assert!(
-        !github.is_pr_merged(162),
-        "contribute must NOT merge PRs"
-    );
+    assert!(!github.is_pr_merged(162), "contribute must NOT merge PRs");
 
     let config = ProtocolConfig::load(&repo.path).unwrap();
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
     commands::lead::decide_ready_prs(&ctx, &config, &repo_state).unwrap();
 
     assert!(
@@ -2607,22 +2893,19 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
         }),
     );
 
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
     commands::lead::decide_ready_prs(&ctx, &config, &repo_state).unwrap();
 
-    assert!(github.is_pr_merged(163), "PR should be merged after first decide");
+    assert!(
+        github.is_pr_merged(163),
+        "PR should be merged after first decide"
+    );
 
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
     // Second call should not post another decision.
     commands::lead::decide_ready_prs(&ctx, &config, &repo_state).unwrap();
 
@@ -2635,9 +2918,11 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
         .map(|b| b.as_str())
         .collect();
     assert_eq!(
-        unique_decisions.len(), 1,
+        unique_decisions.len(),
+        1,
         "should have exactly one unique decision comment on PR #163, found {}: {:?}",
-        unique_decisions.len(), unique_decisions
+        unique_decisions.len(),
+        unique_decisions
     );
 }
 
@@ -2667,7 +2952,10 @@ async fn scenario_sync_accepts_master_default_branch() {
     );
 
     let result = commands::sync::run(&ctx).await;
-    assert!(result.is_ok(), "sync should succeed on master with default_branch: master: {result:?}");
+    assert!(
+        result.is_ok(),
+        "sync should succeed on master with default_branch: master: {result:?}"
+    );
 }
 
 #[tokio::test]
@@ -2689,23 +2977,35 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
         title: "Test thesis".to_string(),
         body: Some("Test".to_string()),
         state: "OPEN".to_string(),
-        labels: vec![Label { name: "thesis".to_string() }],
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
         created_at: now - chrono::Duration::hours(2),
         closed_at: None,
-        author: Some(Author { login: "lead".to_string() }),
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
         url: None,
     };
     let approval_comment = IssueComment {
         id: 100,
         body: ProtocolComment::Approval { thesis: 1 }.render(),
-        user: CommentUser { login: "lead".to_string() },
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
         created_at: now - chrono::Duration::hours(1),
         updated_at: None,
     };
     let claim_comment = IssueComment {
         id: 101,
-        body: ProtocolComment::Claim { thesis: 1, node: "worker".to_string() }.render(),
-        user: CommentUser { login: "contrib".to_string() },
+        body: ProtocolComment::Claim {
+            thesis: 1,
+            node: "worker".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(50),
         updated_at: None,
     };
@@ -2719,8 +3019,11 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
             observation: polyresearch::comments::Observation::Improved,
             summary: "Test".to_string(),
             annotations: None,
-        }.render(),
-        user: CommentUser { login: "contrib".to_string() },
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(40),
         updated_at: None,
     };
@@ -2736,7 +3039,9 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
         created_at: now - chrono::Duration::minutes(30),
         closed_at: None,
         merged_at: Some(now - chrono::Duration::minutes(20)),
-        author: Some(Author { login: "contrib".to_string() }),
+        author: Some(Author {
+            login: "contrib".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -2745,8 +3050,11 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
         body: ProtocolComment::PolicyPass {
             thesis: 1,
             candidate_sha: "abc".to_string(),
-        }.render(),
-        user: CommentUser { login: "lead".to_string() },
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(18),
         updated_at: None,
     };
@@ -2757,8 +3065,11 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
             candidate_sha: "abc".to_string(),
             outcome: polyresearch::comments::Outcome::Accepted,
             confirmations: 0,
-        }.render(),
-        user: CommentUser { login: "lead".to_string() },
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
         created_at: now - chrono::Duration::minutes(15),
         updated_at: None,
     };
@@ -2778,9 +3089,15 @@ async fn scenario_sync_rejects_wrong_branch_with_config() {
     );
 
     let result = commands::sync::run(&ctx).await;
-    assert!(result.is_err(), "sync should reject when not on default branch");
+    assert!(
+        result.is_err(),
+        "sync should reject when not on default branch"
+    );
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("master"), "error should mention 'master' branch, got: {err_msg}");
+    assert!(
+        err_msg.contains("master"),
+        "error should mention 'master' branch, got: {err_msg}"
+    );
 }
 
 #[test]
@@ -2792,24 +3109,31 @@ fn create_thesis_worktree_uses_config_default_branch() {
     run_git(&repo.path, &["add", "-A"]);
     run_git(&repo.path, &["commit", "-m", "add src"]);
 
-    let workspace = commands::create_thesis_worktree(
-        &repo.path,
-        99,
-        "Test worktree on master",
-        "master",
-    )
-    .unwrap();
+    let workspace =
+        commands::create_thesis_worktree(&repo.path, 99, "Test worktree on master", "master")
+            .unwrap();
 
     assert!(workspace.worktree_path.exists(), "worktree should exist");
-    assert!(workspace.branch.starts_with("thesis/99-"), "branch should have thesis prefix");
+    assert!(
+        workspace.branch.starts_with("thesis/99-"),
+        "branch should have thesis prefix"
+    );
 
     let worktree_branch = commands::current_branch(&workspace.worktree_path).unwrap();
-    assert_eq!(worktree_branch, workspace.branch, "worktree should be on thesis branch");
+    assert_eq!(
+        worktree_branch, workspace.branch,
+        "worktree should be on thesis branch"
+    );
 
-    let _ = commands::run_git(&repo.path, &[
-        "worktree", "remove", "--force",
-        &workspace.worktree_path.to_string_lossy(),
-    ]);
+    let _ = commands::run_git(
+        &repo.path,
+        &[
+            "worktree",
+            "remove",
+            "--force",
+            &workspace.worktree_path.to_string_lossy(),
+        ],
+    );
 }
 
 #[tokio::test]
@@ -2872,7 +3196,10 @@ fn resolve_default_branch_falls_back_to_main() {
 
     let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
     let branch = config.resolve_default_branch(&repo.path).unwrap();
-    assert_eq!(branch, "main", "should fall back to 'main' when not set and git detection unavailable");
+    assert_eq!(
+        branch, "main",
+        "should fall back to 'main' when not set and git detection unavailable"
+    );
 }
 
 #[tokio::test]
@@ -2892,7 +3219,9 @@ async fn scenario_contribute_timeout_kills_agent() {
     github.seed_issue(issue);
     github.seed_issue_comments(95, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-timeout"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-timeout");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2920,12 +3249,15 @@ async fn scenario_contribute_timeout_kills_agent() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should handle agent timeout gracefully: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should handle agent timeout gracefully: {result:?}"
+    );
 
     let posted = github.posted_comments();
-    let has_release_timeout = posted.iter().any(|(_, body)| {
-        body.contains("polyresearch:release") && body.contains("timeout")
-    });
+    let has_release_timeout = posted
+        .iter()
+        .any(|(_, body)| body.contains("polyresearch:release") && body.contains("timeout"));
     assert!(
         has_release_timeout,
         "expected a release comment with reason=timeout, got: {posted:?}"
@@ -2949,7 +3281,9 @@ async fn scenario_contribute_fast_agent_unaffected_by_timeout() {
     github.seed_issue(issue);
     github.seed_issue_comments(96, comments);
 
-    unsafe { env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fast"); }
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-fast");
+    }
 
     let ctx = make_scenario_ctx(
         repo.path.clone(),
@@ -2977,5 +3311,8 @@ async fn scenario_contribute_fast_agent_unaffected_by_timeout() {
     )
     .await;
 
-    assert!(result.is_ok(), "contribute should succeed with short-lived agent: {result:?}");
+    assert!(
+        result.is_ok(),
+        "contribute should succeed with short-lived agent: {result:?}"
+    );
 }


### PR DESCRIPTION
## Summary

- Ran `cargo fmt` to fix all formatting issues across 29 files
- Fixed all 34 `cargo clippy -D warnings` errors:
  - Collapsed ~18 nested `if` statements using let-chains (`collapsible_if`)
  - Elided unnecessary explicit lifetimes in `guards.rs` (4 functions)
  - Changed `&PathBuf` params to `&Path` where Clippy flagged `ptr_arg` (5 functions in `mod.rs` + `main.rs`)
  - Removed unnecessary `.to_path_buf()` calls (`bootstrap.rs`, `mod.rs`)
  - Added `#[allow(clippy::too_many_arguments)]` to 3 internal functions
  - Removed `Ok(…?)` wrapping in `github.rs` (`needless_question_mark`)
  - Replaced redundant closure with function reference in `ledger.rs`
  - Added explicit `.truncate(false)` to throttle file open (`suspicious_open_options`)
  - Removed `.clone()` on `Copy` type in `tui/views.rs`

All tests pass: 152 unit, 112 e2e, 43 scenario (4 known-ignored).

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 307 tests pass (4 ignored)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly formatting and clippy-suggested refactors with minimal logic change; the main functional impact is small signature tightening (`PathBuf` -> `Path`) and a safer throttle file open option.
> 
> **Overview**
> Primarily a **maintenance-only** PR: runs rustfmt across the CLI crate and applies clippy-driven refactors (let-chains to collapse nested `if`s, small idiom cleanups like function pointers, removing unnecessary clones, and adding targeted `#[allow(clippy::too_many_arguments)]`).
> 
> Makes a few API/behavioral nits clippy flagged: switches several `&PathBuf` parameters to `&Path` (e.g., `commands::read_node_config`, `commands::thesis_worktree_path`, `main::discover_repo_root`), removes redundant `Ok(...?)` wrapping in `github.rs`, and explicitly sets `OpenOptions::truncate(false)` for the throttle state file to avoid accidental truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e988e56fb681492a4a728caab2d52834e6482244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->