### PR TITLE
Add pre-flight validation before lead and contribute loops

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -400,7 +400,7 @@ fn run_harness_in(harness: &HarnessSpec, work_dir: &Path, verbose: bool) -> Resu
     Ok(None)
 }
 
-fn shell_words(command: &str) -> Vec<String> {
+pub(crate) fn shell_words(command: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut current = String::new();
     let mut in_single_quote = false;

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -61,6 +61,8 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
 
     eprintln!("Contributing as node `{node_id}`");
 
+    crate::preflight::run_all(&agent_command, &ctx.repo_root)?;
+
     loop {
         match run_iteration(
             &local_ctx,

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -32,6 +32,8 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
 
     eprintln!("Running lead loop as `{login}`");
 
+    crate::preflight::run_all(&agent_command, &ctx.repo_root)?;
+
     loop {
         match run_iteration(ctx, &config, &program, &default_branch, &agent_command).await {
             Ok(()) => {}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod github;
 pub mod github_debug;
 pub mod hardware;
 pub mod ledger;
+pub mod preflight;
 pub mod state;
 pub mod throttle;
 pub mod tui;

--- a/cli/src/preflight.rs
+++ b/cli/src/preflight.rs
@@ -1,0 +1,310 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{Result, eyre};
+
+const SMOKE_TEST_PROMPT: &str = "Respond with exactly: PREFLIGHT_OK";
+const DEFAULT_SMOKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run all pre-flight checks before entering the main loop.
+///
+/// Call this once before the loop in both `lead::run` and `contribute::run`.
+/// All checks combined finish in seconds and prevent expensive failures.
+pub fn run_all(agent_command: &str, repo_root: &Path) -> Result<()> {
+    eprintln!("Running pre-flight checks...");
+
+    check_root_dangerous_flag(agent_command)?;
+    check_clean_working_tree(repo_root)?;
+    smoke_test_agent(agent_command, repo_root, DEFAULT_SMOKE_TIMEOUT)?;
+
+    eprintln!("Pre-flight checks passed.");
+    Ok(())
+}
+
+/// Verify the agent command can be spawned.
+///
+/// Catches missing binaries, broken PATH, and other launch-time failures.
+/// The check confirms the binary resolves and the OS can start the process.
+/// A non-zero exit from the smoke prompt is not treated as a failure -- agents
+/// may legitimately reject a trivial prompt while being fully functional for
+/// real experiment prompts.
+pub fn smoke_test_agent(
+    agent_command: &str,
+    work_dir: &Path,
+    timeout: Duration,
+) -> Result<()> {
+    let parts = crate::agent::shell_words(agent_command);
+    if parts.is_empty() {
+        return Err(eyre!("pre-flight: agent command is empty"));
+    }
+
+    let mut cmd = Command::new(&parts[0]);
+    cmd.args(&parts[1..]);
+    cmd.current_dir(work_dir);
+    cmd.arg(SMOKE_TEST_PROMPT);
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return Err(eyre!(
+                "pre-flight: agent command `{}` failed to start: {e}\n\
+                 Hint: verify the binary is installed and on your PATH",
+                parts[0]
+            ));
+        }
+    };
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return Ok(()),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok(());
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => {
+                return Err(eyre!("pre-flight: failed to poll agent process: {e}"));
+            }
+        }
+    }
+}
+
+/// Error if running as root with `--dangerously-skip-permissions` in the agent command.
+///
+/// Claude Code refuses this combination on servers where the user is root.
+pub fn check_root_dangerous_flag(agent_command: &str) -> Result<()> {
+    if !agent_command.contains("--dangerously-skip-permissions") {
+        return Ok(());
+    }
+
+    if is_running_as_root() {
+        return Err(eyre!(
+            "pre-flight: running as root with --dangerously-skip-permissions is not supported\n\
+             Hint: add allowed tools to ~/.claude/settings.json instead, or run as a non-root user"
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_running_as_root() -> bool {
+    #[cfg(unix)]
+    {
+        let output = Command::new("id")
+            .arg("-u")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output();
+        match output {
+            Ok(o) if o.status.success() => {
+                String::from_utf8_lossy(&o.stdout).trim() == "0"
+            }
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+/// Verify the working tree has no uncommitted changes to tracked files.
+///
+/// Dirty trees cause `git pull --rebase` failures and experiment leakage.
+/// Only checks tracked files (modified or staged). Untracked files are
+/// ignored since they don't block git operations.
+pub fn check_clean_working_tree(repo_root: &Path) -> Result<()> {
+    // Check for unstaged modifications to tracked files.
+    let unstaged = Command::new("git")
+        .args(["diff", "--quiet"])
+        .current_dir(repo_root)
+        .status()
+        .map_err(|e| eyre!("pre-flight: failed to run git diff: {e}"))?;
+
+    // Check for staged changes.
+    let staged = Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .current_dir(repo_root)
+        .status()
+        .map_err(|e| eyre!("pre-flight: failed to run git diff --cached: {e}"))?;
+
+    if unstaged.success() && staged.success() {
+        return Ok(());
+    }
+
+    let output = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| eyre!("pre-flight: failed to run git status: {e}"))?;
+
+    let dirty = String::from_utf8_lossy(&output.stdout);
+    let dirty = dirty.trim();
+    let file_count = dirty.lines().count().max(1);
+    let preview: String = dirty
+        .lines()
+        .take(10)
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    let suffix = if file_count > 10 {
+        format!("\n  ... and {} more", file_count - 10)
+    } else {
+        String::new()
+    };
+    Err(eyre!(
+        "pre-flight: working tree has {file_count} uncommitted change(s) to tracked files:\n  {preview}{suffix}\n\
+         Hint: commit or stash your changes before running the loop"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_git_repo(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("preflight-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&path)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+
+        run(&["init"]);
+        run(&["config", "user.name", "Test"]);
+        run(&["config", "user.email", "test@test.com"]);
+        fs::write(path.join("README.md"), "test\n").unwrap();
+        run(&["add", "README.md"]);
+        run(&["commit", "-m", "init"]);
+        path
+    }
+
+    #[test]
+    fn smoke_test_working_command() {
+        let dir = temp_git_repo("smoke-ok");
+        let result = smoke_test_agent("echo ok", &dir, Duration::from_secs(5));
+        assert!(result.is_ok(), "should pass with echo: {result:?}");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn smoke_test_nonzero_exit_is_not_fatal() {
+        let dir = temp_git_repo("smoke-nonfatal");
+        let result = smoke_test_agent("false", &dir, Duration::from_secs(5));
+        assert!(
+            result.is_ok(),
+            "non-zero exit should pass (binary exists, just rejected the prompt): {result:?}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn smoke_test_nonexistent_binary() {
+        let dir = temp_git_repo("smoke-nobin");
+        let result = smoke_test_agent("/nonexistent/binary", &dir, Duration::from_secs(5));
+        assert!(result.is_err(), "should fail with nonexistent binary");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("failed to start"), "error should mention start failure: {msg}");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn smoke_test_hanging_command_returns_ok() {
+        let dir = temp_git_repo("smoke-hang");
+        // Use bash -c so the extra prompt argument doesn't confuse sleep.
+        let result = smoke_test_agent("bash -c 'sleep 999'", &dir, Duration::from_secs(1));
+        assert!(
+            result.is_ok(),
+            "should return Ok for a process that started but timed out: {result:?}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn clean_tree_passes() {
+        let dir = temp_git_repo("clean");
+        let result = check_clean_working_tree(&dir);
+        assert!(result.is_ok(), "clean tree should pass: {result:?}");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn dirty_tree_fails() {
+        let dir = temp_git_repo("dirty");
+        fs::write(dir.join("README.md"), "modified content\n").unwrap();
+        let result = check_clean_working_tree(&dir);
+        assert!(result.is_err(), "dirty tree should fail");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("uncommitted"), "error should mention uncommitted: {msg}");
+        assert!(msg.contains("README.md"), "error should list the file: {msg}");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn untracked_files_are_ignored() {
+        let dir = temp_git_repo("untracked");
+        fs::write(dir.join("new-file.txt"), "untracked\n").unwrap();
+        let result = check_clean_working_tree(&dir);
+        assert!(
+            result.is_ok(),
+            "untracked files should not trigger dirty tree check: {result:?}"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn dirty_tree_with_staged_changes_fails() {
+        let dir = temp_git_repo("dirty-staged");
+        fs::write(dir.join("README.md"), "modified\n").unwrap();
+        let _ = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&dir)
+            .output();
+        let result = check_clean_working_tree(&dir);
+        assert!(result.is_err(), "staged changes should fail");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn root_flag_check_safe_for_non_root() {
+        let result = check_root_dangerous_flag("claude -p --dangerously-skip-permissions");
+        // On CI/dev machines we're not root, so this should pass.
+        // On root machines, we'd need --dangerously-skip-permissions to be absent.
+        // This test documents the expected behavior on non-root.
+        if !test_is_root() {
+            assert!(result.is_ok(), "non-root should pass: {result:?}");
+        }
+    }
+
+    #[test]
+    fn root_flag_check_passes_without_flag() {
+        let result = check_root_dangerous_flag("claude -p");
+        assert!(result.is_ok(), "command without the flag should always pass: {result:?}");
+    }
+
+    fn test_is_root() -> bool {
+        super::is_running_as_root()
+    }
+}

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -3316,3 +3316,222 @@ async fn scenario_contribute_fast_agent_unaffected_by_timeout() {
         "contribute should succeed with short-lived agent: {result:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Pre-flight validation scenarios (issue #101)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_preflight_broken_agent_aborts_contribute() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("preflight-contrib-bad-agent");
+    repo.init_git();
+
+    repo.write_full_setup("lead", "test-node-pf", "/nonexistent/agent");
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(200, "Preflight test thesis", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(200, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-pf");
+    }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "contribute should fail on broken agent command");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("pre-flight"),
+        "error should mention pre-flight: {err_msg}"
+    );
+
+    let posted = github.posted_comments();
+    assert!(
+        posted.is_empty(),
+        "no comments should have been posted (no claims): {posted:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_preflight_broken_agent_aborts_lead() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("preflight-lead-bad-agent");
+    repo.init_git();
+
+    repo.write_full_setup("lead", "lead-node-pf", "/nonexistent/agent");
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "lead should fail on broken agent command");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("pre-flight"),
+        "error should mention pre-flight: {err_msg}"
+    );
+
+    let created = github.created_issues();
+    assert!(
+        created.is_empty(),
+        "no thesis issues should have been created: {created:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_preflight_dirty_tree_aborts_contribute() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("preflight-dirty-tree");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("improved");
+    repo.write_full_setup("lead", "test-node-dirty", &agent_cmd);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    // Modify a tracked file to simulate experiment leakage.
+    fs::write(repo.path.join("src/main.js"), "// leaked experiment change\n").unwrap();
+
+    let (issue, comments) = make_approved_thesis(201, "Dirty tree thesis", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(201, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-dirty");
+    }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "contribute should fail with dirty working tree");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("uncommitted"),
+        "error should mention uncommitted changes: {err_msg}"
+    );
+
+    let posted = github.posted_comments();
+    assert!(
+        posted.is_empty(),
+        "no comments should have been posted (no claims): {posted:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_preflight_dirty_tree_aborts_lead() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("preflight-lead-dirty");
+    repo.init_git();
+
+    repo.write_full_setup("lead", "lead-node-dirty", "echo noop");
+    repo.commit_all("setup");
+
+    // Modify a tracked file to simulate experiment leakage.
+    fs::write(repo.path.join("README.md"), "leaked experiment data\n").unwrap();
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "lead should fail with dirty working tree");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("uncommitted"),
+        "error should mention uncommitted changes: {err_msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a `preflight.rs` module with three checks run once before the main loop in both `lead::run` and `contribute::run`: agent binary spawnability, root + `--dangerously-skip-permissions` detection, and tracked-file cleanliness.
- Prevents the waste pattern from #101: theses claimed then immediately failed as `infra_failure` because the agent command was broken, costing 6 API calls per cycle (3 claims + 3 releases) that a sub-second preflight check would have prevented.
- Only checks tracked file modifications (not untracked files), since the root cause was experiment changes leaking into the main worktree and blocking `git pull --rebase`.

## Test plan

- [x] 10 unit tests in `preflight.rs`: smoke test with working/failing/nonexistent/hanging command, root flag detection, clean/dirty/staged/untracked tree checks
- [x] 4 scenario tests: broken agent aborts contribute before claiming, broken agent aborts lead before generating, dirty tree blocks contribute, dirty tree blocks lead
- [x] All 43 pre-existing scenario tests pass (no regressions)
- [x] All 112 e2e tests pass (no regressions)
- [x] Clean clippy (no new warnings)

Closes #101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control flow to fail fast before any loop iterations, which can alter runtime behavior and block execution on dirty repos or misconfigured agents. Uses OS process spawning and `git` commands, so environment differences (PATH, non-git dirs, root/unix behavior) are the main risk.
> 
> **Overview**
> Adds a new `preflight` module and runs `preflight::run_all` once before entering both the `lead` and `contribute` loops.
> 
> The preflight step **fails fast** on three conditions: running as root with `--dangerously-skip-permissions`, a dirty working tree (tracked file changes or staged changes), and an agent command that can’t be spawned (via a short smoke-run with timeout).
> 
> Exports `agent::shell_words` for reuse, and adds unit + scenario tests to ensure lead/contribute abort *before* posting comments/creating issues when preflight fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3debdffbeed358db52e9532c461de6e53d80f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->