### PR TITLE
Add crash cooldown to prevent tight claim-crash-release loops

### DIFF
--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -205,7 +205,7 @@ async fn run_iteration(
 
     let claimable_ignoring_cooldown = claimable_theses(&repo_state, node_id, 0);
     let claimable = claimable_theses(&repo_state, node_id, args.sleep_secs);
-    let cooldown_skipped = claimable_ignoring_cooldown.len() - claimable.len();
+    let cooldown_skipped = claimable_ignoring_cooldown.len().saturating_sub(claimable.len());
     if cooldown_skipped > 0 {
         eprintln!("{cooldown_skipped} thesis(es) skipped due to crash cooldown");
     }

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Result, eyre};
 
 use crate::cli::ContributeArgs;
@@ -12,6 +13,8 @@ use crate::github::{GitHubApi, GitHubClient, RepoRef};
 use crate::hardware;
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
 use crate::worker::{self, ThesisWorker, WorkerContext, WorkerOutcome};
+
+pub const MAX_CRASH_COOLDOWN_SECS: u64 = 3600;
 
 pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
     let ctx = if let Some(url) = &args.url {
@@ -200,7 +203,26 @@ async fn run_iteration(
     let eval_cores = parse_eval_footprint_cores(&ctx.repo_root);
     let eval_memory_gb = parse_eval_footprint_memory(&ctx.repo_root);
 
-    let claimable = claimable_theses(&repo_state, node_id);
+    let claimable = claimable_theses(&repo_state, node_id, args.sleep_secs);
+    let now = Utc::now();
+    let cooldown_skipped = repo_state
+        .theses
+        .iter()
+        .filter(|t| {
+            t.issue.state == "OPEN"
+                && t.approved
+                && matches!(t.phase, ThesisPhase::Approved)
+                && t.active_claims.is_empty()
+                && !t
+                    .releases
+                    .iter()
+                    .any(|r| r.node == node_id && r.reason == ReleaseReason::NoImprovement)
+                && is_crash_cooldown(t, node_id, args.sleep_secs, now)
+        })
+        .count();
+    if cooldown_skipped > 0 {
+        eprintln!("{cooldown_skipped} thesis(es) skipped due to crash cooldown");
+    }
     let resumable = resumable_theses(&repo_state, node_id);
     let available_work = claimable.len() + resumable.len();
 
@@ -367,7 +389,46 @@ fn cleanup_worktree(repo_root: &Path, worktree_path: &Path) {
     }
 }
 
-fn claimable_theses<'a>(repo_state: &'a RepositoryState, node_id: &str) -> Vec<&'a ThesisState> {
+pub fn is_crash_cooldown(
+    thesis: &ThesisState,
+    node_id: &str,
+    base_cooldown_secs: u64,
+    now: DateTime<Utc>,
+) -> bool {
+    let mut count = 0u32;
+    let mut last_crash: Option<DateTime<Utc>> = None;
+
+    for r in &thesis.releases {
+        if r.node == node_id
+            && matches!(r.reason, ReleaseReason::InfraFailure | ReleaseReason::Timeout)
+        {
+            count += 1;
+            last_crash = Some(match last_crash {
+                Some(prev) => prev.max(r.created_at),
+                None => r.created_at,
+            });
+        }
+    }
+
+    let Some(last) = last_crash else {
+        return false;
+    };
+
+    let multiplier = 2u64.saturating_pow(count.saturating_sub(1));
+    let cooldown_secs = base_cooldown_secs
+        .saturating_mul(multiplier)
+        .min(MAX_CRASH_COOLDOWN_SECS);
+    let cooldown = chrono::Duration::seconds(cooldown_secs as i64);
+
+    now.signed_duration_since(last) < cooldown
+}
+
+pub fn claimable_theses<'a>(
+    repo_state: &'a RepositoryState,
+    node_id: &str,
+    base_cooldown_secs: u64,
+) -> Vec<&'a ThesisState> {
+    let now = Utc::now();
     repo_state
         .theses
         .iter()
@@ -380,6 +441,7 @@ fn claimable_theses<'a>(repo_state: &'a RepositoryState, node_id: &str) -> Vec<&
                     .releases
                     .iter()
                     .any(|r| r.node == node_id && r.reason == ReleaseReason::NoImprovement)
+                && !is_crash_cooldown(thesis, node_id, base_cooldown_secs, now)
         })
         .collect()
 }
@@ -442,4 +504,216 @@ fn parse_prepare_key(repo_root: &Path, key: &str) -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::github::Issue;
+    use crate::state::{ReleaseRecord, ThesisPhase, ThesisState};
+
+    fn make_thesis_with_releases(releases: Vec<ReleaseRecord>) -> ThesisState {
+        ThesisState {
+            issue: Issue {
+                number: 5,
+                title: "Test thesis".to_string(),
+                body: None,
+                state: "OPEN".to_string(),
+                labels: vec![],
+                created_at: Utc::now(),
+                closed_at: None,
+                author: None,
+                url: None,
+            },
+            phase: ThesisPhase::Approved,
+            approved: true,
+            maintainer_approved: false,
+            maintainer_rejected: false,
+            active_claims: vec![],
+            releases,
+            attempts: vec![],
+            pull_requests: vec![],
+            best_attempt_metric: None,
+            findings: vec![],
+        }
+    }
+
+    fn infra_release(node: &str, at: DateTime<Utc>) -> ReleaseRecord {
+        ReleaseRecord {
+            node: node.to_string(),
+            reason: ReleaseReason::InfraFailure,
+            created_at: at,
+        }
+    }
+
+    fn timeout_release(node: &str, at: DateTime<Utc>) -> ReleaseRecord {
+        ReleaseRecord {
+            node: node.to_string(),
+            reason: ReleaseReason::Timeout,
+            created_at: at,
+        }
+    }
+
+    #[test]
+    fn crash_cooldown_excludes_after_crashes() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![
+            infra_release("node-a", now - chrono::Duration::seconds(10)),
+            infra_release("node-a", now - chrono::Duration::seconds(5)),
+            infra_release("node-a", now - chrono::Duration::seconds(1)),
+        ]);
+
+        assert!(
+            is_crash_cooldown(&thesis, "node-a", 60, now),
+            "thesis should be in cooldown with 3 recent crashes"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_does_not_affect_other_nodes() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![
+            infra_release("node-a", now - chrono::Duration::seconds(10)),
+            infra_release("node-a", now - chrono::Duration::seconds(5)),
+            infra_release("node-a", now - chrono::Duration::seconds(1)),
+        ]);
+
+        assert!(
+            !is_crash_cooldown(&thesis, "node-b", 60, now),
+            "node-b should not be affected by node-a's crashes"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_increases_exponentially() {
+        let base = 60u64;
+        let last_crash = Utc::now() - chrono::Duration::seconds(200);
+
+        // 1 crash: cooldown = 60s. 200s after crash -> expired.
+        let thesis_1 = make_thesis_with_releases(vec![infra_release("n", last_crash)]);
+        let now = last_crash + chrono::Duration::seconds(200);
+        assert!(
+            !is_crash_cooldown(&thesis_1, "n", base, now),
+            "1 crash, 200s later: cooldown (60s) should have expired"
+        );
+
+        // 2 crashes: cooldown = 120s. 100s after last crash -> still active.
+        let thesis_2 = make_thesis_with_releases(vec![
+            infra_release("n", last_crash - chrono::Duration::seconds(300)),
+            infra_release("n", last_crash),
+        ]);
+        let now = last_crash + chrono::Duration::seconds(100);
+        assert!(
+            is_crash_cooldown(&thesis_2, "n", base, now),
+            "2 crashes, 100s later: cooldown (120s) should still be active"
+        );
+
+        // 3 crashes: cooldown = 240s. 200s after last crash -> still active.
+        let thesis_3 = make_thesis_with_releases(vec![
+            infra_release("n", last_crash - chrono::Duration::seconds(600)),
+            infra_release("n", last_crash - chrono::Duration::seconds(300)),
+            infra_release("n", last_crash),
+        ]);
+        let now = last_crash + chrono::Duration::seconds(200);
+        assert!(
+            is_crash_cooldown(&thesis_3, "n", base, now),
+            "3 crashes, 200s later: cooldown (240s) should still be active"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_expires() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![infra_release(
+            "node-a",
+            now - chrono::Duration::seconds(120),
+        )]);
+
+        assert!(
+            !is_crash_cooldown(&thesis, "node-a", 60, now),
+            "cooldown (60s) should have expired after 120s"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_capped_at_max() {
+        let now = Utc::now();
+        let mut releases = Vec::new();
+        for i in 0..20 {
+            releases.push(infra_release(
+                "node-a",
+                now - chrono::Duration::seconds(i),
+            ));
+        }
+        let thesis = make_thesis_with_releases(releases);
+
+        // 20 crashes with base=60: uncapped would be 60 * 2^19 = huge.
+        // Capped at MAX_CRASH_COOLDOWN_SECS (3600).
+        let after_max = now + chrono::Duration::seconds(MAX_CRASH_COOLDOWN_SECS as i64 + 1);
+        assert!(
+            !is_crash_cooldown(&thesis, "node-a", 60, after_max),
+            "cooldown should expire after MAX_CRASH_COOLDOWN_SECS even with 20 crashes"
+        );
+
+        // Should still be in cooldown just before the cap expires.
+        let before_max = now + chrono::Duration::seconds(MAX_CRASH_COOLDOWN_SECS as i64 - 60);
+        assert!(
+            is_crash_cooldown(&thesis, "node-a", 60, before_max),
+            "cooldown should be active before MAX_CRASH_COOLDOWN_SECS with 20 crashes"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_ignores_no_improvement_releases() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![ReleaseRecord {
+            node: "node-a".to_string(),
+            reason: ReleaseReason::NoImprovement,
+            created_at: now - chrono::Duration::seconds(1),
+        }]);
+
+        assert!(
+            !is_crash_cooldown(&thesis, "node-a", 60, now),
+            "NoImprovement releases should not trigger crash cooldown"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_counts_timeout_releases() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![timeout_release(
+            "node-a",
+            now - chrono::Duration::seconds(10),
+        )]);
+
+        assert!(
+            is_crash_cooldown(&thesis, "node-a", 60, now),
+            "timeout releases should trigger crash cooldown"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_no_releases() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![]);
+
+        assert!(
+            !is_crash_cooldown(&thesis, "node-a", 60, now),
+            "no releases should mean no cooldown"
+        );
+    }
+
+    #[test]
+    fn crash_cooldown_zero_base_always_expired() {
+        let now = Utc::now();
+        let thesis = make_thesis_with_releases(vec![infra_release(
+            "node-a",
+            now - chrono::Duration::milliseconds(1),
+        )]);
+
+        assert!(
+            !is_crash_cooldown(&thesis, "node-a", 0, now),
+            "zero base cooldown should never block"
+        );
+    }
 }

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -203,23 +203,9 @@ async fn run_iteration(
     let eval_cores = parse_eval_footprint_cores(&ctx.repo_root);
     let eval_memory_gb = parse_eval_footprint_memory(&ctx.repo_root);
 
+    let claimable_ignoring_cooldown = claimable_theses(&repo_state, node_id, 0);
     let claimable = claimable_theses(&repo_state, node_id, args.sleep_secs);
-    let now = Utc::now();
-    let cooldown_skipped = repo_state
-        .theses
-        .iter()
-        .filter(|t| {
-            t.issue.state == "OPEN"
-                && t.approved
-                && matches!(t.phase, ThesisPhase::Approved)
-                && t.active_claims.is_empty()
-                && !t
-                    .releases
-                    .iter()
-                    .any(|r| r.node == node_id && r.reason == ReleaseReason::NoImprovement)
-                && is_crash_cooldown(t, node_id, args.sleep_secs, now)
-        })
-        .count();
+    let cooldown_skipped = claimable_ignoring_cooldown.len() - claimable.len();
     if cooldown_skipped > 0 {
         eprintln!("{cooldown_skipped} thesis(es) skipped due to crash cooldown");
     }

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -3535,3 +3535,205 @@ async fn scenario_preflight_dirty_tree_aborts_lead() {
         "error should mention uncommitted changes: {err_msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Crash cooldown scenarios (issue #104)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_crash_cooldown_filters_claimable_theses() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("crash-cooldown");
+    repo.init_git();
+    repo.write_full_setup("lead", "test-node", "echo noop");
+    repo.commit_all("setup");
+
+    let now = chrono::Utc::now();
+
+    // Thesis #1: approved, with two claim+crash cycles from "test-node".
+    let (issue1, mut comments1) = make_approved_thesis(70, "Crashy thesis", "lead");
+
+    // First claim+release cycle.
+    comments1.push(IssueComment {
+        id: 7001,
+        body: ProtocolComment::Claim {
+            thesis: 70,
+            node: "test-node".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(60),
+        updated_at: None,
+    });
+    comments1.push(IssueComment {
+        id: 7002,
+        body: ProtocolComment::Release {
+            thesis: 70,
+            node: "test-node".to_string(),
+            reason: polyresearch::comments::ReleaseReason::InfraFailure,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(50),
+        updated_at: None,
+    });
+
+    // Second claim+release cycle.
+    comments1.push(IssueComment {
+        id: 7003,
+        body: ProtocolComment::Claim {
+            thesis: 70,
+            node: "test-node".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(40),
+        updated_at: None,
+    });
+    comments1.push(IssueComment {
+        id: 7004,
+        body: ProtocolComment::Release {
+            thesis: 70,
+            node: "test-node".to_string(),
+            reason: polyresearch::comments::ReleaseReason::InfraFailure,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(10),
+        updated_at: None,
+    });
+
+    // Thesis #2: approved, no crash history.
+    let (issue2, comments2) = make_approved_thesis(71, "Healthy thesis", "lead");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue1);
+    github.seed_issue_comments(70, comments1);
+    github.seed_issue(issue2);
+    github.seed_issue_comments(71, comments2);
+
+    let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    // With a 60s base cooldown, thesis #70 (2 crashes, last 10s ago, cooldown = 120s)
+    // should be excluded.
+    let claimable = polyresearch::commands::contribute::claimable_theses(
+        &repo_state,
+        "test-node",
+        60,
+    );
+    let claimable_numbers: Vec<u64> = claimable.iter().map(|t| t.issue.number).collect();
+    assert!(
+        !claimable_numbers.contains(&70),
+        "thesis #70 should be excluded due to crash cooldown, got: {claimable_numbers:?}"
+    );
+    assert!(
+        claimable_numbers.contains(&71),
+        "thesis #71 should be claimable (no crashes), got: {claimable_numbers:?}"
+    );
+
+    // With base_cooldown_secs = 0, cooldown is disabled; both should be claimable.
+    let claimable_no_cooldown = polyresearch::commands::contribute::claimable_theses(
+        &repo_state,
+        "test-node",
+        0,
+    );
+    let numbers_no_cooldown: Vec<u64> =
+        claimable_no_cooldown.iter().map(|t| t.issue.number).collect();
+    assert!(
+        numbers_no_cooldown.contains(&70),
+        "thesis #70 should be claimable with zero cooldown, got: {numbers_no_cooldown:?}"
+    );
+    assert!(
+        numbers_no_cooldown.contains(&71),
+        "thesis #71 should be claimable with zero cooldown, got: {numbers_no_cooldown:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_crash_cooldown_per_node() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("crash-cooldown-per-node");
+    repo.init_git();
+    repo.write_full_setup("lead", "node-a", "echo noop");
+    repo.commit_all("setup");
+
+    let now = chrono::Utc::now();
+
+    // Thesis with claim+InfraFailure release cycle from "node-a" only.
+    let (issue, mut comments) = make_approved_thesis(75, "Per-node thesis", "lead");
+    comments.push(IssueComment {
+        id: 7501,
+        body: ProtocolComment::Claim {
+            thesis: 75,
+            node: "node-a".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(15),
+        updated_at: None,
+    });
+    comments.push(IssueComment {
+        id: 7502,
+        body: ProtocolComment::Release {
+            thesis: 75,
+            node: "node-a".to_string(),
+            reason: polyresearch::comments::ReleaseReason::InfraFailure,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::seconds(5),
+        updated_at: None,
+    });
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(75, comments);
+
+    let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    // node-a should be blocked by cooldown.
+    let claimable_a = polyresearch::commands::contribute::claimable_theses(
+        &repo_state,
+        "node-a",
+        60,
+    );
+    assert!(
+        !claimable_a.iter().any(|t| t.issue.number == 75),
+        "node-a should be blocked by crash cooldown on thesis #75"
+    );
+
+    // node-b should NOT be blocked -- the crash is local to node-a.
+    let claimable_b = polyresearch::commands::contribute::claimable_theses(
+        &repo_state,
+        "node-b",
+        60,
+    );
+    assert!(
+        claimable_b.iter().any(|t| t.issue.number == 75),
+        "node-b should be able to claim thesis #75 (crash was node-a's)"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds exponential backoff cooldown for thesis reclaim after crashes, derived from existing `InfraFailure`/`Timeout` release comments already on GitHub
- Cooldown formula: `sleep_secs * 2^(count - 1)`, capped at 1 hour (3600s). One crash = one skipped cycle, two = two cycles, three = four, etc.
- No new state storage — filters `thesis.releases` that are already loaded during `RepositoryState::derive`
- Cooldown is per-node: node B can still claim a thesis that node A keeps crashing on
- Logs when theses are skipped due to cooldown

Fixes #104.

## Test plan

- [x] 9 unit tests for `is_crash_cooldown`: exclusion after crashes, per-node isolation, exponential increase, expiry, max cap, timeout releases, NoImprovement ignored, zero-base bypass, no-releases baseline
- [x] 2 scenario tests via `ScenarioGitHub` mock: full claim+release cycle filtering, per-node isolation through `RepositoryState::derive`
- [x] Full test suite passes (318 tests, 0 failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thesis selection logic in `contribute`, which could affect work scheduling/throughput if the cooldown is miscomputed, though behavior is bounded (1h cap) and well-tested.
> 
> **Overview**
> Adds a per-node **crash cooldown** to `contribute` so theses that were recently released due to `InfraFailure`/`Timeout` are temporarily unclaimable, using exponential backoff from `sleep_secs` and capped at `MAX_CRASH_COOLDOWN_SECS` (1h).
> 
> `claimable_theses` now takes a cooldown parameter and filters via new `is_crash_cooldown`, and the CLI logs how many theses were skipped; coverage is expanded with unit tests for cooldown math/edge cases and scenario tests verifying end-to-end filtering and per-node isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e0df9764a5511bf2a74f77fb7c25b45070be9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->