### PR TITLE
Fix: claim command writes .polyresearch/thesis.md in worktree

### DIFF
--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
+use crate::agent;
 use crate::cli::IssueArgs;
 use crate::commands::duties;
 use crate::commands::guards::require_claimable_thesis;
@@ -9,6 +10,7 @@ use crate::commands::{
 };
 use crate::comments::ProtocolComment;
 use crate::state::{RepositoryState, ThesisState};
+use crate::worker;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct ClaimOutput {
@@ -89,6 +91,13 @@ pub(crate) fn claim_selected_thesis(
             thesis.issue.number,
             &thesis.issue.title,
             &default_branch,
+        )?;
+        let prior_attempts = worker::format_prior_attempts(thesis);
+        agent::write_thesis_context(
+            &workspace.worktree_path,
+            &thesis.issue.title,
+            thesis.issue.body.as_deref().unwrap_or(""),
+            &prior_attempts,
         )?;
         (
             workspace.branch,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1043,6 +1043,18 @@ async fn claim_creates_worktree_by_default() {
         expected_branch
     );
     assert_eq!(mock.posted_issue_comments.lock().unwrap().len(), 1);
+
+    let thesis_md = worktree_path.join(".polyresearch/thesis.md");
+    assert!(
+        thesis_md.exists(),
+        "expected .polyresearch/thesis.md at {}",
+        thesis_md.display()
+    );
+    let thesis_content = std::fs::read_to_string(&thesis_md).unwrap();
+    assert!(
+        thesis_content.contains(&format!("# Thesis: {}", fixture.issue.title)),
+        "thesis.md should contain the thesis title"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Calls `agent::write_thesis_context()` from `claim_selected_thesis()` after the worktree is created, so `.polyresearch/thesis.md` is present when agents start work.
- The `experiment.md` prompt instructs agents to read this file for thesis context and prior attempt history; without it, agents lose structured knowledge of what was already tried.
- `batch_claim` also goes through `claim_selected_thesis()`, so it gets the fix automatically.

Fixes #121

## Test plan

- [x] Extended `claim_creates_worktree_by_default` e2e test to assert `.polyresearch/thesis.md` exists and contains the thesis title.
- [x] All 23 claim-related tests pass, including batch_claim variants.
- [x] `cargo check` clean, no new warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI change that writes an additional context file during worktree creation and adds an e2e assertion; minimal behavioral risk outside the claim flow.
> 
> **Overview**
> Ensures `claim` (and thus `batch_claim`) writes `.polyresearch/thesis.md` into the newly created thesis worktree by calling `agent::write_thesis_context()` after `create_thesis_worktree`, including formatted prior-attempt history via `worker::format_prior_attempts()`.
> 
> Extends the `claim_creates_worktree_by_default` e2e test to assert the context file exists and includes the thesis title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44aa062d0825a72b341bdeae3faabb8eb27dffa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->