### PR TITLE
Guard submit against commits outside the editable surface

### DIFF
--- a/cli/src/commands/submit.rs
+++ b/cli/src/commands/submit.rs
@@ -1,10 +1,15 @@
+use std::path::PathBuf;
+
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::IssueArgs;
 use crate::commands::guards::require_claimed_thesis;
-use crate::commands::{AppContext, current_branch, print_value, push_current_branch, read_node_id};
+use crate::commands::{
+    AppContext, current_branch, print_value, push_current_branch, read_node_id, run_git,
+};
 use crate::comments::Observation;
+use crate::config::ProgramSpec;
 use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
@@ -40,11 +45,24 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         return Err(eyre!("branch `{branch}` already has an open PR"));
     }
 
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+
+    let violations = check_editable_surface(&ctx.repo_root, &ctx.program, &default_branch)?;
+    if !violations.is_empty() {
+        if ctx.cli.dry_run {
+            eprintln!(
+                "Would strip {} file(s) outside the editable surface: {}",
+                violations.len(),
+                violations.join(", ")
+            );
+        } else {
+            strip_violating_files(&ctx.repo_root, &violations, &default_branch)?;
+        }
+    }
+
     if !ctx.cli.dry_run {
         push_current_branch(&ctx.repo_root)?;
     }
-
-    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
     let pr = if ctx.cli.dry_run {
         None
     } else {
@@ -85,4 +103,67 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
             )
         }
     })
+}
+
+pub fn check_editable_surface(
+    repo_root: &PathBuf,
+    program: &ProgramSpec,
+    default_branch: &str,
+) -> Result<Vec<String>> {
+    let merge_base = format!("origin/{default_branch}");
+    let diff_ref = format!("{merge_base}...HEAD");
+    let diff_output = run_git(repo_root, &["diff", "--name-only", &diff_ref])?;
+
+    if diff_output.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let violations: Vec<String> = diff_output
+        .lines()
+        .filter(|file| {
+            let editable = program.is_editable(file).unwrap_or(false);
+            let protected = program.is_protected(file);
+            !editable || protected
+        })
+        .map(|file| file.to_string())
+        .collect();
+
+    Ok(violations)
+}
+
+pub fn strip_violating_files(
+    repo_root: &PathBuf,
+    violations: &[String],
+    default_branch: &str,
+) -> Result<()> {
+    let base_ref = format!("origin/{default_branch}");
+    for file in violations {
+        let exists_on_base =
+            run_git(repo_root, &["cat-file", "-e", &format!("{base_ref}:{file}")]).is_ok();
+
+        if exists_on_base {
+            run_git(repo_root, &["checkout", &base_ref, "--", file])?;
+        } else {
+            run_git(repo_root, &["rm", "-f", file])?;
+        }
+    }
+
+    let has_staged = run_git(repo_root, &["diff", "--cached", "--quiet"]).is_err();
+    if has_staged {
+        run_git(
+            repo_root,
+            &[
+                "commit",
+                "-m",
+                "polyresearch: strip files outside editable surface",
+            ],
+        )?;
+    }
+
+    eprintln!(
+        "Stripped {} file(s) outside the editable surface: {}",
+        violations.len(),
+        violations.join(", ")
+    );
+    Ok(())
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -6231,6 +6231,255 @@ fn load_pr_fixture(name: &str) -> PullRequestFixture {
     serde_json::from_str(include_fixture(name)).unwrap()
 }
 
+// ===========================================================================
+// Submit: editable-surface guard (#119)
+// ===========================================================================
+
+#[test]
+fn check_editable_surface_detects_violations() {
+    let repo = TestRepo::new("surface-violations");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/index.js"), "// editable\n").unwrap();
+    run_git(&repo.path, &["add", "src/index.js"]);
+    run_git(&repo.path, &["commit", "-m", "add src"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/42-test"]);
+    fs::write(repo.path.join("src/index.js"), "// edited\n").unwrap();
+    fs::write(repo.path.join("results.tsv"), "data\n").unwrap();
+    run_git(&repo.path, &["add", "src/index.js", "results.tsv"]);
+    run_git(&repo.path, &["commit", "-m", "agent commit"]);
+
+    let program = ProgramSpec {
+        can_modify: vec!["src/".to_string()],
+        cannot_modify: vec!["results.tsv".to_string()],
+    };
+
+    let violations =
+        commands::submit::check_editable_surface(&repo.path, &program, "main").unwrap();
+
+    assert!(
+        violations.contains(&"results.tsv".to_string()),
+        "results.tsv should be a violation, got: {violations:?}"
+    );
+    assert!(
+        !violations.iter().any(|f| f.starts_with("src/")),
+        "src/ files should NOT be violations, got: {violations:?}"
+    );
+}
+
+#[test]
+fn check_editable_surface_passes_clean_branch() {
+    let repo = TestRepo::new("surface-clean");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/index.js"), "// editable\n").unwrap();
+    run_git(&repo.path, &["add", "src/index.js"]);
+    run_git(&repo.path, &["commit", "-m", "add src"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/43-clean"]);
+    fs::write(repo.path.join("src/index.js"), "// improved\n").unwrap();
+    run_git(&repo.path, &["add", "src/index.js"]);
+    run_git(&repo.path, &["commit", "-m", "improve src"]);
+
+    let program = ProgramSpec {
+        can_modify: vec!["src/".to_string()],
+        cannot_modify: vec!["results.tsv".to_string()],
+    };
+
+    let violations =
+        commands::submit::check_editable_surface(&repo.path, &program, "main").unwrap();
+
+    assert!(
+        violations.is_empty(),
+        "branch with only editable files should have no violations, got: {violations:?}"
+    );
+}
+
+#[test]
+fn check_editable_surface_catches_files_outside_editable_surface() {
+    let repo = TestRepo::new("surface-outside");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// start\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "initial"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/44-outside"]);
+    fs::write(repo.path.join("src/main.js"), "// changed\n").unwrap();
+    fs::write(repo.path.join("PREPARE.md"), "# do not touch\n").unwrap();
+    fs::write(repo.path.join("random.txt"), "stray file\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "mixed commit"]);
+
+    let program = ProgramSpec {
+        can_modify: vec!["src/".to_string()],
+        cannot_modify: vec!["PREPARE.md".to_string()],
+    };
+
+    let violations =
+        commands::submit::check_editable_surface(&repo.path, &program, "main").unwrap();
+
+    assert!(
+        violations.contains(&"PREPARE.md".to_string()),
+        "PREPARE.md (explicitly protected) should be a violation, got: {violations:?}"
+    );
+    assert!(
+        violations.contains(&"random.txt".to_string()),
+        "random.txt (outside editable surface) should be a violation, got: {violations:?}"
+    );
+    assert_eq!(violations.len(), 2, "should have exactly 2 violations, got: {violations:?}");
+}
+
+#[test]
+fn strip_violating_files_restores_base_version() {
+    let repo = TestRepo::new("strip-restore");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/index.js"), "// editable\n").unwrap();
+    fs::write(repo.path.join("results.tsv"), "original\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "initial"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/50-strip"]);
+    fs::write(repo.path.join("src/index.js"), "// improved\n").unwrap();
+    fs::write(repo.path.join("results.tsv"), "modified by agent\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "agent commit"]);
+
+    commands::submit::strip_violating_files(
+        &repo.path,
+        &["results.tsv".to_string()],
+        "main",
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(repo.path.join("results.tsv")).unwrap();
+    assert_eq!(
+        content, "original\n",
+        "results.tsv should be restored to base version"
+    );
+
+    let src_content = fs::read_to_string(repo.path.join("src/index.js")).unwrap();
+    assert_eq!(
+        src_content, "// improved\n",
+        "editable file should be untouched"
+    );
+
+    let diff = commands::run_git(&repo.path, &["diff", "--name-only", "origin/main...HEAD"]).unwrap();
+    assert!(
+        !diff.contains("results.tsv"),
+        "results.tsv should no longer appear in the branch diff"
+    );
+    assert!(
+        diff.contains("src/index.js"),
+        "src/index.js should still appear in the branch diff"
+    );
+}
+
+#[test]
+fn strip_violating_files_removes_new_file() {
+    let repo = TestRepo::new("strip-new-file");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/index.js"), "// start\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "initial"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/51-newfile"]);
+    fs::write(repo.path.join("src/index.js"), "// improved\n").unwrap();
+    fs::write(repo.path.join("stray.txt"), "should not be here\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "agent commit with stray"]);
+
+    commands::submit::strip_violating_files(
+        &repo.path,
+        &["stray.txt".to_string()],
+        "main",
+    )
+    .unwrap();
+
+    assert!(
+        !repo.path.join("stray.txt").exists(),
+        "stray.txt should be removed from working tree"
+    );
+
+    let diff = commands::run_git(&repo.path, &["diff", "--name-only", "origin/main...HEAD"]).unwrap();
+    assert!(
+        !diff.contains("stray.txt"),
+        "stray.txt should no longer appear in the branch diff"
+    );
+    assert!(
+        diff.contains("src/index.js"),
+        "src/index.js should still appear in the branch diff"
+    );
+}
+
+#[test]
+fn submit_strips_violations_and_preserves_editable_changes() {
+    let repo = TestRepo::new("strip-e2e");
+    init_git_repo(&repo.path);
+
+    run_git(&repo.path, &["remote", "add", "origin", repo.path.to_str().unwrap()]);
+
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/app.js"), "// original\n").unwrap();
+    fs::write(repo.path.join("results.tsv"), "baseline\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "initial"]);
+    run_git(&repo.path, &["fetch", "origin"]);
+
+    run_git(&repo.path, &["checkout", "-b", "thesis/52-e2e"]);
+    fs::write(repo.path.join("src/app.js"), "// optimized\n").unwrap();
+    fs::write(repo.path.join("results.tsv"), "modified\n").unwrap();
+    fs::write(repo.path.join("new-outside.txt"), "stray\n").unwrap();
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-m", "agent mixed commit"]);
+
+    let program = ProgramSpec {
+        can_modify: vec!["src/".to_string()],
+        cannot_modify: vec!["results.tsv".to_string()],
+    };
+
+    let violations =
+        commands::submit::check_editable_surface(&repo.path, &program, "main").unwrap();
+    assert_eq!(violations.len(), 2, "should detect both violations: {violations:?}");
+
+    commands::submit::strip_violating_files(&repo.path, &violations, "main").unwrap();
+
+    let final_diff =
+        commands::run_git(&repo.path, &["diff", "--name-only", "origin/main...HEAD"]).unwrap();
+    let changed_files: Vec<&str> = final_diff.lines().collect();
+    assert_eq!(
+        changed_files,
+        vec!["src/app.js"],
+        "only editable files should remain in the diff after stripping"
+    );
+
+    let app_content = fs::read_to_string(repo.path.join("src/app.js")).unwrap();
+    assert_eq!(app_content, "// optimized\n", "editable change must be preserved");
+}
+
 fn include_fixture(name: &str) -> &'static str {
     match name {
         "duplicate_claim_issue.json" => include_str!("fixtures/duplicate_claim_issue.json"),


### PR DESCRIPTION
## Summary

Fixes #119.

The contributor workflow agent commits all changed files (including protected files like `results.tsv`) before calling `polyresearch submit`. The lead then policy-rejects the PR, discarding genuine improvements.

This PR adds an auto-remediation guard in `submit` that transparently strips violating files from the branch before pushing -- the submit-time equivalent of `ThesisWorker::commit_editable_surface()` in the worker path.

**How it works:**
1. `check_editable_surface()` runs `git diff --name-only origin/<default_branch>...HEAD` and checks each file against the `ProgramSpec` editable/protected globs (same logic as `policy_check.rs`).
2. If violations are found, `strip_violating_files()` restores each violating file to its base version (or removes it if it was newly added), then commits the cleanup.
3. The push and PR creation proceed with a clean diff containing only editable-surface changes.

The improvement is preserved instead of being rejected.

## Test plan

- [x] `check_editable_surface_detects_violations` -- protected file flagged as violation
- [x] `check_editable_surface_passes_clean_branch` -- branch with only editable files has no violations
- [x] `check_editable_surface_catches_files_outside_editable_surface` -- both protected and out-of-surface files caught
- [x] `strip_violating_files_restores_base_version` -- modified protected file restored to base version
- [x] `strip_violating_files_removes_new_file` -- new file outside surface fully removed
- [x] `submit_strips_violations_and_preserves_editable_changes` -- end-to-end: after stripping, only editable files remain in diff
- [x] All 175 unit tests pass, all 128 e2e tests pass (4 pre-existing ignores)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `submit` now rewrites the local branch by checking out/removing files and making an extra commit before pushing/creating the PR, which could surprise users and has some risk of unintended git state changes.
> 
> **Overview**
> `submit` now checks the branch diff against `origin/<default_branch>...HEAD` and detects any changed files that are *outside the program’s editable surface* or explicitly protected.
> 
> On non-dry-run submits, it automatically strips those violations by restoring base versions (or deleting newly-added files) and commits the cleanup (`polyresearch: strip files outside editable surface`) before pushing/creating the PR; in `--dry-run` it only reports what would be stripped. E2E tests were added to cover detection and stripping behavior, including preserving allowed edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e741f3e860da0fdf728f74c488c1b4a773cad347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->