### PR TITLE
Harden lead workflow to reliably generate theses when queue is low (#125)

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -17,15 +17,23 @@ Your working directory is the project root, checked out to the default branch. Y
 
 ## The loop
 
+You MUST complete ALL steps (1 through 6) in every iteration. Do not exit after any individual step. If a step has nothing to do (e.g. no PRs to decide), skip it and proceed to the next step. Never abort an iteration because one step failed — log the error and continue to the next step.
+
+Keeping the queue at or above `min_queue_depth` is the primary goal of every iteration. Steps 1-3 are housekeeping; step 4 (queue check and generation) is the critical deliverable.
+
 LOOP FOREVER:
 
 ### 1. Sync the ledger
 
 Run `polyresearch sync`. This updates results.tsv with any missing experiment rows and pushes. If sync fails because you are not on the default branch, run `git checkout <default-branch>` first. If it fails because of a non-fast-forward, run `git pull origin <default-branch> --ff-only` and retry.
 
+If sync fails after retries, log the error and proceed to step 2.
+
 ### 2. Policy-check open PRs
 
 Run `polyresearch duties`. Look for policy-check duties. For each one, run `polyresearch policy-check <pr>`. The CLI checks whether the PR only touches files within the editable surface and posts the result.
+
+If there are no policy-check duties, proceed to step 3.
 
 ### 3. Decide ready PRs
 
@@ -33,7 +41,11 @@ Look for decide duties. For each ready PR, run `polyresearch decide <pr>`. The C
 
 If decide fails because of merge conflicts, the CLI will attempt a rebase. If that also fails, the PR will be closed as stale — this is expected. The contributor can rebase and resubmit.
 
-### 4. Check the queue
+If there are no decide duties, proceed to step 4.
+
+### 4. Check the queue and generate theses
+
+This is the most important step. You MUST reach this step every iteration.
 
 Run `polyresearch status`. Read the queue depth (approved, unclaimed theses). Read PROGRAM.md for `min_queue_depth`.
 
@@ -43,6 +55,9 @@ If the queue is below `min_queue_depth`:
 3. Generate thesis proposals: think of specific, actionable ideas that differ from what has already been tried. Do not repeat approaches marked as no_improvement or crashed.
 4. For each proposal, run: `polyresearch generate --title "<title>" --body "<body>"`
 5. Generate only enough theses to bring the queue back to `min_queue_depth`. Do not over-generate.
+6. After generating, run `polyresearch status` again to confirm queue depth is now at or above `min_queue_depth`.
+
+If the queue is already at or above `min_queue_depth`, proceed to step 5.
 
 ### 5. Handle audit findings
 
@@ -51,7 +66,15 @@ If `polyresearch audit` reports findings:
 - **Suspicious (duplicates)**: usually harmless. Acknowledge if they block thesis generation.
 - **Stuck claims**: if a claim has been active for over 24 hours with no attempt, release it: `polyresearch admin release-claim <issue> --node <node> --reason timeout`.
 
-### 6. Sleep and repeat
+### 6. Verify and finish the iteration
+
+Before sleeping or exiting, confirm that this iteration is complete:
+- Sync was attempted (step 1)
+- All policy-check duties were processed (step 2)
+- All decide duties were processed (step 3)
+- Queue depth was checked and generation was attempted if needed (step 4)
+
+If you skipped the queue check (step 4) for any reason, go back and run it now.
 
 Sleep 60 seconds, then go back to step 1.
 
@@ -61,3 +84,4 @@ Sleep 60 seconds, then go back to step 1.
 - Never create worktrees or modify code. Your job is coordination, not experimentation.
 - Stay on the default branch. All your git operations (sync, push) happen on the default branch.
 - If `git pull` fails because of unstaged changes, run `git stash` first, then pull, then `git stash pop`.
+- If any step errors, do not stop. Log the error and move to the next step. The queue check in step 4 must always run.

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -411,7 +411,10 @@ pub fn lead_workflow_prompt(once: bool, sleep_secs: u64) -> String {
 
     if once {
         prompt.push_str(
-            "\n\nIMPORTANT: Run exactly ONE iteration of the loop (steps 1-6), then stop. Do not loop.\n",
+            "\n\nIMPORTANT: Run exactly ONE full iteration — you MUST execute steps 1 through 6 in order, then stop. \
+             Complete every step before exiting. Do not stop after a single step or subset of steps. \
+             If a step has nothing to do (e.g. no PRs to decide), skip it and move to the next step. \
+             You must reach the queue check (step 4) and generate theses if the queue is below min_queue_depth.\n",
         );
     } else {
         prompt.push_str(&format!(
@@ -785,5 +788,35 @@ mod tests {
         assert_eq!(parse_prepare_key(&dir, "prereq_command"), None);
 
         fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn lead_prompt_once_requires_all_steps() {
+        let prompt = lead_workflow_prompt(true, 60);
+        assert!(
+            prompt.contains("steps 1 through 6"),
+            "once prompt must reference all six steps"
+        );
+        assert!(
+            prompt.contains("MUST"),
+            "once prompt must use mandatory language"
+        );
+        assert!(
+            prompt.contains("queue check"),
+            "once prompt must mention the queue check"
+        );
+    }
+
+    #[test]
+    fn lead_prompt_base_has_mandatory_completion() {
+        let prompt = lead_workflow_prompt(false, 60);
+        assert!(
+            prompt.contains("MUST complete ALL steps"),
+            "base prompt must require completing all steps"
+        );
+        assert!(
+            prompt.contains("primary goal"),
+            "base prompt must frame queue depth as the primary goal"
+        );
     }
 }

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -60,6 +60,11 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
                          Lead agent may not have generated enough theses.",
                         repo_state.queue_depth, config.min_queue_depth
                     );
+                    if !once {
+                        eprintln!("Restarting agent to refill queue in {sleep_secs}s...");
+                        tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                        continue;
+                    }
                 }
                 break;
             }

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -51,7 +51,18 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
         .map_err(|e| eyre!("lead workflow agent task failed: {e}"))?;
 
         match result {
-            Ok(()) => break,
+            Ok(()) => {
+                let repo_state =
+                    RepositoryState::derive(&ctx.github, &ctx.config).await?;
+                if repo_state.queue_depth < config.min_queue_depth {
+                    eprintln!(
+                        "Warning: queue depth is {} (min = {}). \
+                         Lead agent may not have generated enough theses.",
+                        repo_state.queue_depth, config.min_queue_depth
+                    );
+                }
+                break;
+            }
             Err(err) => {
                 eprintln!("Lead agent failed: {err}");
                 if once {

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -52,19 +52,29 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
 
         match result {
             Ok(()) => {
-                let repo_state =
-                    RepositoryState::derive(&ctx.github, &ctx.config).await?;
-                if repo_state.queue_depth < config.min_queue_depth {
-                    eprintln!(
-                        "Warning: queue depth is {} (min = {}). \
-                         Lead agent may not have generated enough theses.",
-                        repo_state.queue_depth, config.min_queue_depth
-                    );
-                    if !once {
-                        eprintln!("Restarting agent to refill queue in {sleep_secs}s...");
-                        tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
-                        continue;
+                match RepositoryState::derive(&ctx.github, &ctx.config).await {
+                    Ok(repo_state)
+                        if repo_state.queue_depth < config.min_queue_depth =>
+                    {
+                        eprintln!(
+                            "Warning: queue depth is {} (min = {}). \
+                             Lead agent may not have generated enough theses.",
+                            repo_state.queue_depth, config.min_queue_depth
+                        );
+                        if !once {
+                            eprintln!(
+                                "Restarting agent to refill queue in {sleep_secs}s..."
+                            );
+                            tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                            continue;
+                        }
                     }
+                    Err(err) => {
+                        eprintln!(
+                            "Warning: could not verify queue depth after agent run: {err}"
+                        );
+                    }
+                    _ => {}
                 }
                 break;
             }


### PR DESCRIPTION
## Summary

- Strengthens the lead workflow prompt (`lead-workflow.md`) with mandatory-completion language, explicit step transitions, and error resilience so the agent always reaches the queue check and generation step
- Hardens the `--once` prompt append to explicitly require completing all 6 steps before exiting
- Adds a post-iteration queue-depth check in the Rust wrapper (`lead.rs`) that warns when the agent exits with the queue still below `min_queue_depth`
- Adds two unit tests verifying the prompt contains the required mandatory-completion language

Closes #125

## Test plan

- [x] `cargo check` passes
- [x] New prompt assertion tests pass (`lead_prompt_once_requires_all_steps`, `lead_prompt_base_has_mandatory_completion`)
- [ ] Manual: run `polyresearch lead --once` against a repo with queue below `min_queue_depth` and verify generation happens
- [ ] Manual: verify the post-iteration warning appears if the agent exits without generating enough theses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lead agent control flow and adds a post-run queue-depth verification/restart, which can affect automation behavior and looping in production, though it’s confined to the lead CLI path.
> 
> **Overview**
> Strengthens the lead-agent workflow to more reliably reach the queue check and refill the thesis queue when it drops below `min_queue_depth`.
> 
> Updates `lead-workflow.md` and the `--once` prompt append to **mandate completing steps 1–6**, explicitly prioritize step 4 (queue check/generation), and instruct continuing past step failures. Adds a post-agent-run check in `lead.rs` that warns if the queue is still low and (in non-`--once` mode) sleeps and reruns the agent to keep refilling.
> 
> Adds unit tests asserting the lead prompt includes mandatory-completion language and queue-check requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7bf7db69ab50fd5b457100db50093e29c715d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->