### PR TITLE
Pipe workflow prompt via stdin instead of CLI argument

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 use std::thread;
@@ -440,13 +441,23 @@ pub fn spawn_workflow_agent(
     let mut cmd = Command::new(&parts[0]);
     cmd.args(&parts[1..]);
     cmd.current_dir(work_dir);
-    cmd.arg(prompt);
+    cmd.stdin(Stdio::piped());
 
     eprintln!(
         "Spawning workflow agent in {}...",
         work_dir.display(),
     );
-    let output = cmd.output().wrap_err("failed to spawn workflow agent")?;
+    let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .wrap_err("failed to write prompt to agent stdin")?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .wrap_err("failed to wait for workflow agent")?;
 
     if !output.status.success() {
         log_subprocess_failure(

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -442,6 +442,8 @@ pub fn spawn_workflow_agent(
     cmd.args(&parts[1..]);
     cmd.current_dir(work_dir);
     cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
 
     eprintln!(
         "Spawning workflow agent in {}...",
@@ -449,11 +451,12 @@ pub fn spawn_workflow_agent(
     );
     let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(prompt.as_bytes())
-            .wrap_err("failed to write prompt to agent stdin")?;
-    }
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| eyre!("failed to open stdin pipe for workflow agent"))?
+        .write_all(prompt.as_bytes())
+        .wrap_err("failed to write prompt to agent stdin")?;
 
     let output = child
         .wait_with_output()


### PR DESCRIPTION
## Summary

- Passes the workflow prompt to the agent subprocess via stdin instead of appending it as a CLI argument, avoiding prompt exposure in `ps aux` and shell argument length limits.

Closes #123.

## Relevant files

- `cli/src/agent.rs` — `spawn_workflow_agent` function

## Test plan

- [x] `cargo check` passes
- [x] All 175 unit tests pass (`cargo test --lib`)
- [ ] Manual verification: run `polyresearch contribute --once` and confirm the agent receives the prompt correctly via stdin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the workflow agent receives its prompt (stdin instead of argv), which could break compatibility with agents that only read command-line args; otherwise the change is localized to process spawning.
> 
> **Overview**
> Workflow agent execution now **pipes the prompt over stdin** instead of passing it as a command-line argument, reducing prompt exposure in process listings and avoiding argv length limits.
> 
> `spawn_workflow_agent` switches from `Command::output()` with `cmd.arg(prompt)` to spawning a child with piped stdio, writing `prompt` into `stdin`, and then waiting via `wait_with_output()` while still capturing stdout/stderr for error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7538dc980f08cdfb72c2a8a71d26024fa0d6d773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->