### PR TITLE
Contributor agent self-regulates parallelism via pace and capacity

### DIFF
--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -41,12 +41,12 @@ Compute how many experiments you can run in parallel:
 
 ```
 effective_memory = min(budget.memory_gb, hardware.available_memory_gb)
-by_cores  = floor(budget.cores / eval_cores)       # at least 1
-by_memory = floor(effective_memory / eval_memory_gb) # at least 1
+by_cores  = floor(budget.cores / eval_cores)
+by_memory = floor(effective_memory / eval_memory_gb)
 max_slots = min(by_cores, by_memory)
 ```
 
-If `max_slots` is 0 or negative (machine is overloaded), wait 60 seconds and re-check pace before claiming work.
+If `max_slots` is 0 (machine is overloaded or undersized for the eval footprint), wait 60 seconds and re-check pace before claiming work. If `max_slots` stays 0 after 3 consecutive checks (~3 minutes), proceed with 1 experiment. The machine is permanently undersized for the eval footprint; running one experiment slowly is better than running none.
 
 Also check `rate_limit.is_low`. If true, wait for the reset window (`rate_limit.resets_at`) before making more API requests.
 

--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -46,7 +46,7 @@ by_memory = floor(effective_memory / eval_memory_gb)
 max_slots = min(by_cores, by_memory)
 ```
 
-If `max_slots` is 0 (machine is overloaded or undersized for the eval footprint), wait 60 seconds and re-check pace before claiming work. If `max_slots` stays 0 after 3 consecutive checks (~3 minutes), proceed with 1 experiment. The machine is permanently undersized for the eval footprint; running one experiment slowly is better than running none.
+If `max_slots` is 0 (machine is overloaded or undersized for the eval footprint), wait 60 seconds and re-check pace before claiming work. If `max_slots` stays 0 after 3 consecutive checks (~3 minutes), set `max_slots = 1` and continue. The machine is permanently undersized for the eval footprint; running one experiment slowly is better than running none.
 
 Also check `rate_limit.is_low`. If true, wait for the reset window (`rate_limit.resets_at`) before making more API requests.
 

--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -64,7 +64,7 @@ For each claimed thesis:
 3. Run the experiment: implement the idea, run the evaluation per PREPARE.md, iterate if needed.
 4. Write `.polyresearch/result.json` with the result.
 
-Run experiments sequentially (one at a time) unless `max_slots` from step 2 is greater than 1. Benchmarks running concurrently compete for CPU, memory, and I/O, which corrupts measurements. If you have multiple claimed theses, re-run `polyresearch pace --json` between experiments to adapt to changing system load and recompute `max_slots` before starting the next one.
+Always run experiments sequentially (one at a time), even if you claimed multiple theses. Benchmarks running concurrently compete for CPU, memory, and I/O, which corrupts measurements. `max_slots` controls how many theses you claim per loop iteration, not how many benchmarks you run simultaneously. If you have multiple claimed theses, re-run `polyresearch pace --json` between experiments to adapt to changing system load.
 
 ### 5. Record and act on the result
 

--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -27,13 +27,32 @@ Run `polyresearch duties`. If blocking duties exist, resolve each one:
 - **submit**: go to the thesis worktree, run `polyresearch submit <issue>`.
 - If submit fails because a PR already exists for the branch, check if the PR was closed. If closed as stale (merge conflicts), try rebasing the branch onto the default branch and resubmit. If the PR was decided as non_improvement, release the thesis instead: `polyresearch release <issue> --reason no_improvement`.
 
-### 2. Check pace
+### 2. Check pace and compute parallelism
 
-Run `polyresearch pace`. Read the hardware budget and API budget. Decide how many theses you can work in parallel based on the eval footprint in PREPARE.md. If the API budget is near the limit, wait before making more requests.
+Run `polyresearch pace --json` and parse the JSON output. The key fields are:
+
+- `budget.cores` — CPU cores allocated to you (already scaled by your capacity %)
+- `budget.memory_gb` — memory allocated to you
+- `hardware.available_memory_gb` — memory currently free on the machine
+
+Then read `eval_cores` and `eval_memory_gb` from PREPARE.md. These define the resource footprint of a single experiment run.
+
+Compute how many experiments you can run in parallel:
+
+```
+effective_memory = min(budget.memory_gb, hardware.available_memory_gb)
+by_cores  = floor(budget.cores / eval_cores)       # at least 1
+by_memory = floor(effective_memory / eval_memory_gb) # at least 1
+max_slots = min(by_cores, by_memory)
+```
+
+If `max_slots` is 0 or negative (machine is overloaded), wait 60 seconds and re-check pace before claiming work.
+
+Also check `rate_limit.is_low`. If true, wait for the reset window (`rate_limit.resets_at`) before making more API requests.
 
 ### 3. Find and claim work
 
-Run `polyresearch status` to see claimable theses. If theses are available, claim one (or several with `batch-claim` if parallelism allows).
+Run `polyresearch status` to see claimable theses. Claim up to `max_slots` theses (use `batch-claim --count N` when N > 1). Never claim more theses than your computed `max_slots` allows.
 
 If no work is available, sleep 60 seconds and restart the loop.
 
@@ -44,6 +63,8 @@ For each claimed thesis:
 2. Read `.polyresearch/thesis.md` for the thesis context and prior attempts.
 3. Run the experiment: implement the idea, run the evaluation per PREPARE.md, iterate if needed.
 4. Write `.polyresearch/result.json` with the result.
+
+Run experiments sequentially (one at a time) unless `max_slots` from step 2 is greater than 1. Benchmarks running concurrently compete for CPU, memory, and I/O, which corrupts measurements. If you have multiple claimed theses, re-run `polyresearch pace --json` between experiments to adapt to changing system load and recompute `max_slots` before starting the next one.
 
 ### 5. Record and act on the result
 

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -384,6 +384,7 @@ pub fn contribute_workflow_prompt(
     once: bool,
     sleep_secs: u64,
     max_parallel: Option<usize>,
+    capacity: u8,
 ) -> String {
     let base = include_str!("../prompts/contribute-workflow.md");
     let mut prompt = base.to_string();
@@ -402,6 +403,9 @@ pub fn contribute_workflow_prompt(
             "\nDo not work on more than {max} thesis/theses in parallel.\n"
         ));
     }
+    prompt.push_str(&format!(
+        "\nYour capacity allocation is {capacity}% of this machine's hardware. Use `polyresearch pace --json` to see the resulting budget.\n"
+    ));
     prompt
 }
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -65,6 +65,7 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
         args.once,
         args.sleep_secs,
         args.max_parallel,
+        node_config.effective_capacity(),
     );
     let repo_root = local_ctx.repo_root.clone();
     let verbose = local_ctx.cli.verbose;

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -544,7 +544,7 @@ pub fn calculate_parallelism(
     let by_cores = if eval_cores == 0 {
         budget_cores
     } else {
-        (budget_cores / eval_cores).max(1)
+        budget_cores / eval_cores
     };
     let by_memory = if eval_memory_gb <= 0.0 {
         by_cores
@@ -552,7 +552,7 @@ pub fn calculate_parallelism(
         (effective_memory / eval_memory_gb).floor() as usize
     };
 
-    let mut target = by_cores.min(by_memory.max(1));
+    let mut target = by_cores.min(by_memory);
 
     if let Some(max) = max_parallel {
         target = target.min(max);
@@ -599,8 +599,8 @@ mod tests {
     }
 
     #[test]
-    fn parallelism_at_least_one_when_work_exists() {
-        assert_eq!(calculate_parallelism(1, 0.5, 0.1, 4, 8.0, None, 1), 1);
+    fn parallelism_returns_zero_when_budget_insufficient() {
+        assert_eq!(calculate_parallelism(1, 0.5, 0.1, 4, 8.0, None, 1), 0);
     }
 
     #[test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2672,7 +2672,7 @@ fn worker_parallelism_formula_basics() {
     );
     assert_eq!(
         worker::calculate_parallelism(1, 0.5, 0.1, 4, 8.0, None, 1),
-        1
+        0
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #124.

- Injects the node's `capacity` percentage into the contributor workflow prompt so the agent knows its hardware allocation
- Rewrites Step 2 of `contribute-workflow.md` with an explicit parallelism formula: parse `polyresearch pace --json` output, compare `budget.cores`/`budget.memory_gb` against `eval_cores`/`eval_memory_gb` from PREPARE.md, compute `max_slots`
- Adds a rule in Step 4 to re-check pace between experiments and default to sequential execution, preventing benchmark contention from corrupting metrics

## Test plan

- [x] `cargo build` compiles cleanly
- [x] All 175 unit tests pass (`cargo test --lib`)
- [x] All 128 e2e tests pass (`cargo test --test e2e`)
- [x] 2 pre-existing scenario test failures confirmed on base branch (tracked by #126)
- [ ] Manual: run `polyresearch contribute --once` against a test repo and verify the agent calls `polyresearch pace --json` and respects `max_slots`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the logic that determines how many theses a node will claim (including allowing 0), which can impact throughput and scheduling under low-resource conditions.
> 
> **Overview**
> Updates the contributor agent workflow to **compute a `max_slots` parallelism target** from `polyresearch pace --json` budgets vs. `PREPARE.md` eval footprint (cores/memory), with guidance to pause when capacity is insufficient and to respect API rate-limit signals.
> 
> Injects the node’s **capacity percentage** into the generated contributor prompt, and adjusts `worker::calculate_parallelism` to return **0 when core/memory budgets can’t cover a single eval** (updating unit/e2e tests accordingly) rather than forcing a minimum of 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d60c0d34aaf1544e5aba025fdcae51d4360faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->