### PR TITLE
Fix bootstrap on repos with allowlist-style .gitignore

### DIFF
--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -386,7 +386,7 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let mut add_args: Vec<&str> = vec!["add", "--"];
+    let mut add_args: Vec<&str> = vec!["add", "-f", "--"];
     add_args.extend(&setup_paths);
     commands::run_git(&repo, &add_args)?;
 


### PR DESCRIPTION
## Summary
- Use `git add -f` instead of plain `git add` when staging polyresearch setup files (PROGRAM.md, PREPARE.md, results.tsv, `.polyresearch/`) during bootstrap.
- Repos with allowlist-style `.gitignore` (`/*` + `!` negations) reject `git add` for files not in the allowlist. The `-f` flag overrides this, which is correct since these files are part of the polyresearch protocol and must be tracked.

Closes #136

## Test plan
- [ ] Run `polyresearch bootstrap` against a repo with an allowlist `.gitignore` (e.g. `alanzabihi/ini`) and confirm setup files are committed successfully.
- [ ] Run `polyresearch bootstrap` against a repo with a standard `.gitignore` and confirm no regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the bootstrap staging command that only affects how polyresearch setup files are added to the index, with minimal impact outside bootstrap flows.
> 
> **Overview**
> Fixes `polyresearch bootstrap` in repos with allowlist-style `.gitignore` by staging setup artifacts (`PROGRAM.md`, `PREPARE.md`, `results.tsv`, `.polyresearch/`) via `git add -f` instead of plain `git add`, ensuring required files can be committed even when ignored by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54eb1da6e57fd2dccc82e2b2a9450dcf6139826c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->