### PR TITLE
Make sync pull before commit and push after (fixes #137)

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -5,7 +5,7 @@ Your working directory is the project root, checked out to the default branch. Y
 ## Available commands
 
 - `polyresearch duties` — check for blocking duties (sync, policy-check, decide).
-- `polyresearch sync` — update results.tsv from GitHub state. Commits and pushes.
+- `polyresearch sync` — update results.tsv from GitHub state. Pulls, commits, and pushes atomically.
 - `polyresearch policy-check <pr>` — verify a PR only touches files in the editable surface.
 - `polyresearch decide <pr>` — evaluate a PR and post the decision (merge/close).
 - `polyresearch generate --title "<title>" --body "<body>"` — create a new thesis issue.
@@ -25,7 +25,7 @@ LOOP FOREVER:
 
 ### 1. Sync the ledger
 
-Run `polyresearch sync`. This updates results.tsv with any missing experiment rows and pushes. If sync fails because you are not on the default branch, run `git checkout <default-branch>` first. If it fails because of a non-fast-forward, run `git pull origin <default-branch> --ff-only` and retry.
+Run `polyresearch sync`. This pulls from the remote, updates results.tsv with any missing experiment rows, commits, and pushes — all in one command. If sync fails because you are not on the default branch, run `git checkout <default-branch>` first and retry.
 
 If sync fails after retries, log the error and proceed to step 2.
 
@@ -83,5 +83,4 @@ Sleep 60 seconds, then go back to step 1.
 - Never run `polyresearch claim`, `polyresearch submit`, or `polyresearch release`. Those are contributor commands.
 - Never create worktrees or modify code. Your job is coordination, not experimentation.
 - Stay on the default branch. All your git operations (sync, push) happen on the default branch.
-- If `git pull` fails because of unstaged changes, run `git stash` first, then pull, then `git stash pop`.
 - If any step errors, do not stop. Log the error and move to the next step. The queue check in step 4 must always run.

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -14,12 +14,11 @@ struct SyncOutput {
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let mut ledger = Ledger::load(&ctx.repo_root)?;
-    let missing_rows = ledger.missing_rows(&repo_state);
 
-    if !ctx.cli.dry_run && !missing_rows.is_empty() {
-        let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+
+    // Phase 1: incorporate remote commits (e.g. merged PRs) before touching the ledger.
+    if !ctx.cli.dry_run {
         if current_branch(&ctx.repo_root)? != default_branch {
             return Err(eyre!(
                 "`polyresearch sync` must run from the `{default_branch}` branch"
@@ -29,12 +28,24 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
             &ctx.repo_root,
             &["pull", "origin", &default_branch, "--rebase"],
         )?;
+    }
+
+    // Phase 2: load the (now up-to-date) ledger, compute missing rows, append + commit.
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let mut ledger = Ledger::load(&ctx.repo_root)?;
+    let missing_rows = ledger.missing_rows(&repo_state);
+
+    if !ctx.cli.dry_run && !missing_rows.is_empty() {
         ledger.append_rows(&missing_rows)?;
         commit_file(
             &ctx.repo_root,
             "results.tsv",
             "Update results.tsv via polyresearch sync.",
         )?;
+    }
+
+    // Phase 3: push unconditionally to flush new commits AND any previously-unpushed ones.
+    if !ctx.cli.dry_run {
         run_git(&ctx.repo_root, &["push", "origin", &default_branch])?;
     }
 

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
@@ -12,25 +14,39 @@ struct SyncOutput {
     attempts: Vec<String>,
 }
 
+/// Fetch the default branch from origin and fast-forward the local branch.
+/// If local has unpushed commits (prior sync that failed to push), rebase
+/// them onto the remote. If rebase conflicts, abort to keep the repo
+/// workable -- follows the same abort pattern as decide.rs::try_rebase_onto_main.
+fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
+    run_git(repo_root, &["fetch", "origin", branch])?;
+    let remote_ref = format!("origin/{branch}");
+
+    if run_git(repo_root, &["merge", "--ff-only", &remote_ref]).is_ok() {
+        return Ok(());
+    }
+
+    let rebase_result = run_git(repo_root, &["rebase", &remote_ref]);
+    if rebase_result.is_err() {
+        let _ = run_git(repo_root, &["rebase", "--abort"]);
+    }
+    rebase_result.map(|_| ())
+}
+
 pub async fn run(ctx: &AppContext) -> Result<()> {
     ensure_lead(ctx)?;
 
     let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
 
-    // Phase 1: incorporate remote commits (e.g. merged PRs) before touching the ledger.
     if !ctx.cli.dry_run {
         if current_branch(&ctx.repo_root)? != default_branch {
             return Err(eyre!(
                 "`polyresearch sync` must run from the `{default_branch}` branch"
             ));
         }
-        run_git(
-            &ctx.repo_root,
-            &["pull", "origin", &default_branch, "--rebase"],
-        )?;
+        pull_default_branch(&ctx.repo_root, &default_branch)?;
     }
 
-    // Phase 2: load the (now up-to-date) ledger, compute missing rows, append + commit.
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
     let mut ledger = Ledger::load(&ctx.repo_root)?;
     let missing_rows = ledger.missing_rows(&repo_state);
@@ -44,7 +60,6 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
         )?;
     }
 
-    // Phase 3: push unconditionally to flush new commits AND any previously-unpushed ones.
     if !ctx.cli.dry_run {
         run_git(&ctx.repo_root, &["push", "origin", &default_branch])?;
     }

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::commands::guards::ensure_lead;
-use crate::commands::{AppContext, commit_file, current_branch, print_value};
+use crate::commands::{AppContext, commit_file, current_branch, print_value, run_git};
 use crate::ledger::Ledger;
 use crate::state::RepositoryState;
 
@@ -25,12 +25,17 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
                 "`polyresearch sync` must run from the `{default_branch}` branch"
             ));
         }
+        run_git(
+            &ctx.repo_root,
+            &["pull", "origin", &default_branch, "--rebase"],
+        )?;
         ledger.append_rows(&missing_rows)?;
         commit_file(
             &ctx.repo_root,
             "results.tsv",
             "Update results.tsv via polyresearch sync.",
         )?;
+        run_git(&ctx.repo_root, &["push", "origin", &default_branch])?;
     }
 
     let output = SyncOutput {


### PR DESCRIPTION
## Summary

- `polyresearch sync` now runs `git pull origin <default-branch> --rebase` before committing results.tsv and `git push origin <default-branch>` after, so the remote ledger stays current.
- Removed manual pull/stash recovery instructions from the lead workflow prompt since the CLI handles this atomically.

Fixes #137

## Dependency

This PR targets `hybrid-agent-cli` (PR #118) where the lead workflow prompt lives.

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] Polytest run on a repo where a PR has been merged confirms results.tsv is pushed to the remote after sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `polyresearch sync` to perform automated fetch/ff-merge-or-rebase and a subsequent push, which can affect local git state and fail in conflict scenarios. Limited to the lead-only sync workflow but touches git operations and remote writes.
> 
> **Overview**
> `polyresearch sync` now **synchronizes with `origin/<default-branch>` before updating the ledger** by fetching and attempting a fast-forward merge, then rebasing (with abort-on-failure) if needed.
> 
> After committing `results.tsv`, it **pushes the default branch to origin**, making the command a single pull→update→commit→push flow. The lead workflow prompt is updated to reflect the atomic behavior and removes manual pull/stash guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5333ceb75e852193620fdc82e998290c83b86a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->