### PR TITLE
Enable GitHub Issues on forked repos during bootstrap

### DIFF
--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -7,7 +7,7 @@ use color_eyre::eyre::{Context, Result, eyre};
 use crate::cli::BootstrapArgs;
 use crate::commands::{self, AppContext};
 use crate::config::NodeConfig;
-use crate::github::RepoRef;
+use crate::github::{GitHubClient, RepoRef};
 
 pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     let (repo_root, login) = scaffold(ctx, args)?;
@@ -139,28 +139,6 @@ fn get_current_login() -> Result<String> {
     Ok(login)
 }
 
-fn enable_issues(owner: &str, name: &str) {
-    eprintln!("Enabling GitHub Issues on {owner}/{name}...");
-    let result = Command::new("gh")
-        .args([
-            "api",
-            &format!("repos/{owner}/{name}"),
-            "--method",
-            "PATCH",
-            "-f",
-            "has_issues=true",
-        ])
-        .output();
-    match result {
-        Ok(output) if output.status.success() => {}
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("Warning: could not enable Issues: {stderr}");
-        }
-        Err(e) => eprintln!("Warning: could not enable Issues: {e}"),
-    }
-}
-
 fn fork_and_clone(upstream: &RepoRef, fork_owner: &str, repo_root: &Path) -> Result<()> {
     if repo_root.join(".git").exists() {
         eprintln!("Repository already exists, skipping clone.");
@@ -206,7 +184,14 @@ fn fork_and_clone(upstream: &RepoRef, fork_owner: &str, repo_root: &Path) -> Res
     )
     .ok();
 
-    enable_issues(fork_owner, &upstream.name);
+    let fork_repo = RepoRef {
+        owner: fork_owner.to_string(),
+        name: upstream.name.clone(),
+    };
+    eprintln!("Enabling GitHub Issues on {}...", fork_repo.slug());
+    if let Err(e) = GitHubClient::new(fork_repo).enable_issues() {
+        eprintln!("Warning: could not enable Issues: {e}");
+    }
 
     Ok(())
 }

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -139,6 +139,28 @@ fn get_current_login() -> Result<String> {
     Ok(login)
 }
 
+fn enable_issues(owner: &str, name: &str) {
+    eprintln!("Enabling GitHub Issues on {owner}/{name}...");
+    let result = Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{owner}/{name}"),
+            "--method",
+            "PATCH",
+            "-f",
+            "has_issues=true",
+        ])
+        .output();
+    match result {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!("Warning: could not enable Issues: {stderr}");
+        }
+        Err(e) => eprintln!("Warning: could not enable Issues: {e}"),
+    }
+}
+
 fn fork_and_clone(upstream: &RepoRef, fork_owner: &str, repo_root: &Path) -> Result<()> {
     if repo_root.join(".git").exists() {
         eprintln!("Repository already exists, skipping clone.");
@@ -183,6 +205,8 @@ fn fork_and_clone(upstream: &RepoRef, fork_owner: &str, repo_root: &Path) -> Res
         &["remote", "add", "upstream", &upstream_url],
     )
     .ok();
+
+    enable_issues(fork_owner, &upstream.name);
 
     Ok(())
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -31,11 +31,14 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
     let capacity = args.overrides.capacity.unwrap_or(existing_capacity);
 
     if let Ok(false) = ctx.github.repo_has_issues() {
-        eprintln!("Warning: Issues are disabled on this repository (common for forks).");
-        eprintln!(
-            "Enable them: gh api repos/{} --method PATCH -f has_issues=true",
-            ctx.repo.slug()
-        );
+        eprintln!("Issues are disabled on this repository (common for forks). Enabling...");
+        if let Err(e) = ctx.github.enable_issues() {
+            eprintln!(
+                "Warning: could not enable Issues: {e}\n  \
+                 Enable them manually: gh api repos/{} --method PATCH -F has_issues=true",
+                ctx.repo.slug()
+            );
+        }
     }
 
     if !ctx.cli.dry_run {

--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -125,12 +125,26 @@ pub struct GitHubClient {
     repo: RepoRef,
 }
 
+/// A field sent with `gh api`. `Raw` uses `-f` (value is always a JSON string).
+/// `Typed` uses `-F` (gh coerces `true`/`false` to booleans, digits to numbers).
+pub enum ApiField<'a> {
+    Raw(&'a str, &'a str),
+    Typed(&'a str, &'a str),
+}
+
+impl<'a> From<(&'a str, &'a str)> for ApiField<'a> {
+    fn from((key, value): (&'a str, &'a str)) -> Self {
+        ApiField::Raw(key, value)
+    }
+}
+
 pub trait GitHubApi: Send + Sync {
     fn current_login(&self) -> Result<String>;
     fn auth_status(&self) -> Result<String>;
     fn auth_token(&self) -> Result<String>;
     fn get_rate_limit_status(&self) -> Result<RateLimitStatus>;
     fn repo_has_issues(&self) -> Result<bool>;
+    fn enable_issues(&self) -> Result<()>;
     fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>>;
     fn list_issue_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>>;
     fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<Issue>;
@@ -209,6 +223,15 @@ impl GitHubClient {
             .unwrap_or(true))
     }
 
+    pub fn enable_issues(&self) -> Result<()> {
+        self.gh_api_json(
+            "PATCH",
+            &format!("repos/{}/{}", self.repo.owner, self.repo.name),
+            &[ApiField::Typed("has_issues", "true")],
+        )?;
+        Ok(())
+    }
+
     pub fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>> {
         self.gh_json_typed([
             "issue",
@@ -262,11 +285,11 @@ impl GitHubClient {
     }
 
     pub fn add_assignees(&self, issue_number: u64, assignees: &[&str]) -> Result<()> {
-        let fields = assignees
+        let fields: Vec<ApiField> = assignees
             .iter()
             .copied()
-            .map(|assignee| ("assignees[]", assignee))
-            .collect::<Vec<_>>();
+            .map(|assignee| ApiField::Raw("assignees[]", assignee))
+            .collect();
         self.gh_api_json(
             "POST",
             &format!(
@@ -388,7 +411,7 @@ impl GitHubClient {
                 "repos/{}/{}/pulls/{pr_number}",
                 self.repo.owner, self.repo.name
             ),
-            &[("state", "closed")],
+            &[ApiField::Raw("state", "closed")],
         )
     }
 
@@ -399,7 +422,7 @@ impl GitHubClient {
                 "repos/{}/{}/pulls/{pr_number}/merge",
                 self.repo.owner, self.repo.name
             ),
-            &[("merge_method", "merge")],
+            &[ApiField::Raw("merge_method", "merge")],
         )
     }
 
@@ -435,7 +458,8 @@ impl GitHubClient {
     where
         T: DeserializeOwned,
     {
-        let value = self.gh_api_json(method, endpoint, fields)?;
+        let api_fields: Vec<ApiField> = fields.iter().copied().map(Into::into).collect();
+        let value = self.gh_api_json(method, endpoint, &api_fields)?;
         Ok(serde_json::from_value(value)?)
     }
 
@@ -443,15 +467,19 @@ impl GitHubClient {
         &self,
         method: &str,
         endpoint: &str,
-        fields: &[(&str, &str)],
+        fields: &[ApiField],
     ) -> Result<serde_json::Value> {
         let idempotent = method.eq_ignore_ascii_case("GET") || method.eq_ignore_ascii_case("HEAD");
         let mut command = Command::new("gh");
         command.arg("api");
         command.arg("--method").arg(method);
         command.arg(endpoint);
-        for (key, value) in fields {
-            command.arg("-f").arg(format!("{key}={value}"));
+        for field in fields {
+            let (flag, key, value) = match field {
+                ApiField::Raw(k, v) => ("-f", k, v),
+                ApiField::Typed(k, v) => ("-F", k, v),
+            };
+            command.arg(flag).arg(format!("{key}={value}"));
         }
         run_json_command(command, idempotent)
     }
@@ -488,6 +516,10 @@ impl GitHubApi for GitHubClient {
 
     fn repo_has_issues(&self) -> Result<bool> {
         GitHubClient::repo_has_issues(self)
+    }
+
+    fn enable_issues(&self) -> Result<()> {
+        GitHubClient::enable_issues(self)
     }
 
     fn list_thesis_issues(&self, state: IssueListState) -> Result<Vec<Issue>> {
@@ -976,7 +1008,7 @@ fn classify_error_hint(stderr: &str) -> Option<&'static str> {
 
     if lowered.contains("has disabled issues") {
         return Some(
-            "Enable Issues in your repository settings: gh api repos/OWNER/REPO --method PATCH -f has_issues=true",
+            "Enable Issues in your repository settings: gh api repos/OWNER/REPO --method PATCH -F has_issues=true",
         );
     }
 

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -123,6 +123,10 @@ impl GitHubApi for MockGitHubClient {
         Ok(true)
     }
 
+    fn enable_issues(&self) -> Result<()> {
+        Ok(())
+    }
+
     fn list_thesis_issues(&self, _state: IssueListState) -> Result<Vec<Issue>> {
         Ok(self.issues.clone())
     }

--- a/cli/tests/scenario_mock.rs
+++ b/cli/tests/scenario_mock.rs
@@ -204,6 +204,10 @@ impl GitHubApi for ScenarioGitHub {
         Ok(true)
     }
 
+    fn enable_issues(&self) -> Result<()> {
+        Ok(())
+    }
+
     fn list_thesis_issues(&self, _state: IssueListState) -> Result<Vec<Issue>> {
         let s = self.state.lock().unwrap();
         Ok(s.issues.clone())


### PR DESCRIPTION
## Summary
- Adds `enable_issues` helper in `bootstrap.rs` that calls `gh api repos/OWNER/REPO --method PATCH -f has_issues=true` after forking.
- Called at the end of `fork_and_clone()`, covering both explicit `--fork` and auto-fork paths.
- Best-effort: warns on failure instead of aborting bootstrap.

Fixes #135

## Test plan
- [ ] `polyresearch bootstrap <upstream-url>` on a repo you don't own — verify Issues are enabled on the resulting fork.
- [ ] `polyresearch bootstrap <upstream-url> --fork <org>` — verify Issues are enabled on the org fork.
- [ ] `polyresearch bootstrap <url> --no-fork` — verify no enable-issues call is made (direct clone path unchanged).
- [ ] Re-run bootstrap on an already-forked repo with Issues enabled — verify the PATCH is a no-op and no error is printed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, best-effort CLI behavior change that adds a single GitHub API PATCH and refactors argument handling for `gh api` fields.
> 
> **Overview**
> During `bootstrap`, after forking and cloning, the CLI now **best-effort enables GitHub Issues** on the newly created fork via a `PATCH` to `repos/{owner}/{repo}` (warning-only on failure).
> 
> During `init`, if Issues are detected as disabled, the CLI now attempts to enable them automatically and only falls back to an updated manual `gh api ... -F has_issues=true` instruction.
> 
> Internally, `GitHubClient` gains `enable_issues()` and a new `ApiField` abstraction to send either raw (`-f`) or typed (`-F`) fields to `gh api`, with tests/mocks updated to implement the new `GitHubApi::enable_issues` method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5889cb597af5eb32e56cebd232ed668948859195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->