### PR TITLE
Prevent lead from generating theses that duplicate already-accepted work

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -51,8 +51,8 @@ Run `polyresearch status`. Read the queue depth (approved, unclaimed theses). Re
 
 If the queue is below `min_queue_depth`:
 1. Run `polyresearch audit`. If there are critical findings, resolve them first (acknowledge invalid ones, release stuck claims).
-2. Read PROGRAM.md for the research goal and strategy. Read results.tsv to understand what has been tried.
-3. Generate thesis proposals: think of specific, actionable ideas that differ from what has already been tried. Do not repeat approaches marked as no_improvement or crashed.
+2. Read PROGRAM.md for the research goal and strategy. Read results.tsv to understand what has been tried — including accepted (merged) work, not just failures.
+3. Generate thesis proposals: think of specific, actionable ideas that differ from everything already tried. Do not duplicate approaches from any prior thesis — whether accepted, no_improvement, or crashed. An accepted thesis means its optimization is already in the codebase; proposing the same idea again wastes a cycle.
 4. For each proposal, run: `polyresearch generate --title "<title>" --body "<body>"`
 5. Generate only enough theses to bring the queue back to `min_queue_depth`. Do not over-generate.
 6. After generating, run `polyresearch status` again to confirm queue depth is now at or above `min_queue_depth`.

--- a/cli/prompts/thesis-generation.md
+++ b/cli/prompts/thesis-generation.md
@@ -2,6 +2,6 @@ Read PROGRAM.md to understand the goal and constraints. Study results.tsv to see
 
 Generate thesis proposals as a JSON array of objects with "title" and "body" fields. Write the array to .polyresearch/thesis-proposals.json.
 
-Each thesis should be specific and actionable, not a vague direction. Do not propose ideas that echo approaches already marked as no_improvement or crashed — the full history exists to prevent repeating dead ends. Favor ideas that build on successful experiments or combine near-misses. Prefer ideas that simplify the code over ideas that add complexity.
+Each thesis should be specific and actionable, not a vague direction. Do not propose ideas that echo any prior thesis — whether accepted, no_improvement, or crashed. Accepted theses are already merged into the codebase; re-proposing them wastes contributor time. The full history in results.tsv exists to prevent repeating any past work. Favor ideas that build on successful experiments or combine near-misses. Prefer ideas that simplify the code over ideas that add complexity.
 
 Explore different directions. If progress has stalled, propose something more radical.


### PR DESCRIPTION
## Summary

- Strengthens lead-workflow.md and thesis-generation.md prompts to explicitly forbid duplicating accepted (merged) thesis work, not just `no_improvement` or `crashed` approaches.
- Previously the lead could propose the same optimization that was already accepted and merged, wasting a contributor cycle.

Closes #138

## Test plan

- [ ] Run lead agent against a repo with accepted theses in results.tsv; verify generated theses do not echo accepted work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only tightens markdown prompt guidance and does not change runtime code paths. The main risk is over-constraining thesis generation if results history is incomplete or ambiguous.
> 
> **Overview**
> Prevents the lead/thesis-generation prompts from re-proposing optimizations that were already **accepted/merged** by explicitly requiring `results.tsv` review to include accepted work and forbidding duplicates of *any* prior thesis (accepted, `no_improvement`, or `crashed`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4974e6fcd89ba6f49cb1ab84e91e948c9428609b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->