### PR TITLE
Fix: clear active_claims on resolved theses (#139)

### DIFF
--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -321,6 +321,12 @@ impl ThesisState {
             ThesisPhase::Submitted
         };
 
+        let active_claims = if matches!(phase, ThesisPhase::Resolved { .. }) {
+            vec![]
+        } else {
+            active_claims
+        };
+
         let best_attempt_metric = attempts.iter().fold(None, |current, attempt| {
             Some(select_metric(
                 current,
@@ -698,6 +704,151 @@ mod tests {
         };
 
         assert_eq!(thesis.maintainer_summary(false), "PR rejected");
+    }
+
+    #[test]
+    fn resolved_thesis_clears_active_claims() {
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/claimed_no_attempts_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(&fixture.lead_github_login);
+
+        let claimed =
+            ThesisState::derive(fixture.issue.clone(), fixture.comments.clone(), &[], &config)
+                .unwrap();
+        assert!(matches!(claimed.phase, ThesisPhase::Claimed));
+        assert_eq!(claimed.active_claims.len(), 1);
+
+        let pr_with_decision = PullRequestState {
+            pr: PullRequest {
+                number: 50,
+                title: "Candidate for thesis #20".to_string(),
+                body: None,
+                state: "MERGED".to_string(),
+                head_ref_name: "thesis/20-claimed-attempt-1".to_string(),
+                head_ref_oid: Some("deadbeef".to_string()),
+                base_ref_name: Some("main".to_string()),
+                created_at: chrono::Utc::now(),
+                closed_at: None,
+                merged_at: Some(chrono::Utc::now()),
+                author: None,
+                url: None,
+                mergeable: None,
+            },
+            thesis_number: Some(20),
+            policy_pass: true,
+            maintainer_approved: false,
+            maintainer_rejected: false,
+            review_claims: vec![],
+            reviews: vec![],
+            decision: Some(DecisionRecord {
+                outcome: crate::comments::Outcome::Accepted,
+                candidate_sha: "deadbeef".to_string(),
+                confirmations: 0,
+                created_at: chrono::Utc::now(),
+            }),
+            findings: vec![],
+        };
+
+        let resolved = ThesisState::derive(
+            fixture.issue,
+            fixture.comments,
+            &[pr_with_decision],
+            &config,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            resolved.phase,
+            ThesisPhase::Resolved {
+                outcome: crate::comments::Outcome::Accepted
+            }
+        ));
+        assert!(
+            resolved.active_claims.is_empty(),
+            "active_claims should be empty on a resolved thesis, got: {:?}",
+            resolved.active_claims
+        );
+    }
+
+    #[test]
+    fn resolved_thesis_excluded_from_active_nodes() {
+        use crate::comments::ProtocolComment;
+
+        let fixture: IssueFixture = serde_json::from_str(include_str!(
+            "../tests/fixtures/claimed_no_attempts_issue.json"
+        ))
+        .unwrap();
+        let config = test_config(&fixture.lead_github_login);
+
+        let pr_with_decision = PullRequest {
+            number: 50,
+            title: "Candidate for thesis #20".to_string(),
+            body: None,
+            state: "MERGED".to_string(),
+            head_ref_name: "thesis/20-claimed-attempt-1".to_string(),
+            head_ref_oid: Some("deadbeef".to_string()),
+            base_ref_name: Some("main".to_string()),
+            created_at: chrono::Utc::now(),
+            closed_at: None,
+            merged_at: Some(chrono::Utc::now()),
+            author: None,
+            url: None,
+            mergeable: None,
+        };
+
+        let policy_pass = ProtocolComment::PolicyPass {
+            thesis: 20,
+            candidate_sha: "deadbeef".to_string(),
+        };
+        let decision_comment = ProtocolComment::Decision {
+            thesis: 20,
+            candidate_sha: "deadbeef".to_string(),
+            outcome: crate::comments::Outcome::Accepted,
+            confirmations: 0,
+        };
+        let now = chrono::Utc::now();
+        let pr_comments = vec![
+            IssueComment {
+                id: 9000,
+                body: policy_pass.render(),
+                user: crate::github::CommentUser {
+                    login: fixture.lead_github_login.clone(),
+                },
+                created_at: now - chrono::Duration::minutes(5),
+                updated_at: None,
+            },
+            IssueComment {
+                id: 9001,
+                body: decision_comment.render(),
+                user: crate::github::CommentUser {
+                    login: fixture.lead_github_login.clone(),
+                },
+                created_at: now,
+                updated_at: None,
+            },
+        ];
+
+        let mut issue_comments_map = std::collections::HashMap::new();
+        issue_comments_map.insert(fixture.issue.number, fixture.comments);
+        let mut pr_comments_map = std::collections::HashMap::new();
+        pr_comments_map.insert(50u64, pr_comments);
+
+        let state = RepositoryState::derive_from_fetched(
+            vec![fixture.issue],
+            vec![pr_with_decision],
+            &mut issue_comments_map,
+            &mut pr_comments_map,
+            &config,
+        )
+        .unwrap();
+
+        assert!(
+            state.active_nodes.is_empty(),
+            "active_nodes should not include nodes from resolved theses, got: {:?}",
+            state.active_nodes
+        );
     }
 
     fn exhausted_fixture() -> IssueFixture {


### PR DESCRIPTION
## Summary

- When a thesis is resolved (accepted/rejected via `decide`), `active_claims` now returns empty instead of preserving the stale claim from before the decision.
- This prevents resolved theses from polluting `active_nodes`, which could affect capacity tracking in multi-node setups.

Closes #139

## Approach

In `ThesisState::derive`, after determining the phase, if the phase is `Resolved { .. }`, the `active_claims` vector is replaced with an empty vec. This is retroactive (handles historical stale data without needing new GitHub comments) and requires no extra API calls.

## Test plan

- [x] `resolved_thesis_clears_active_claims` -- verifies a claimed thesis has its `active_claims` cleared when a PR decision makes it `Resolved`
- [x] `resolved_thesis_excluded_from_active_nodes` -- verifies the claiming node does not appear in `active_nodes` at the `RepositoryState` level after resolution
- [x] All 177 unit tests pass (175 existing + 2 new)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized logic change to `ThesisState::derive` plus unit tests; main behavioral impact is that resolved theses no longer contribute nodes to `active_nodes`.
> 
> **Overview**
> When a thesis transitions to `ThesisPhase::Resolved` (via a PR decision), `ThesisState::derive` now clears `active_claims` so stale issue claims don’t persist after resolution.
> 
> Adds regression tests ensuring resolved theses have empty `active_claims` and that `RepositoryState.active_nodes` excludes nodes from resolved theses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b215062e9a4622d17591b030ee863affc086d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->