### PR TITLE
Prune worktrees for resolved/rejected theses (#140)

### DIFF
--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -14,6 +14,7 @@ All coordination goes through the `polyresearch` CLI. Key commands:
 - `polyresearch submit <issue>` — push and create a PR for an improved thesis. Run from the thesis worktree.
 - `polyresearch release <issue> --reason <no_improvement|timeout|infra_failure>` — release a claim.
 - `polyresearch batch-claim --count N` — claim multiple theses at once.
+- `polyresearch prune` — remove worktrees for resolved/rejected theses and clean up stale directories.
 
 Use `--help` on any command for full flag documentation.
 
@@ -76,7 +77,9 @@ After the experiment, read `.polyresearch/result.json`:
 
 ### 6. Clean up
 
-After releasing or submitting, remove the worktree: `git worktree remove --force <path>`. For submitted (improved) theses, keep the worktree alive — the lead may request revisions.
+After releasing a thesis, remove its worktree: `git worktree remove --force <path>`. For submitted (improved) theses, keep the worktree alive until the lead decides the PR — the lead may request revisions.
+
+Then run `polyresearch prune` to remove worktrees for any theses that have been resolved or rejected since the last iteration. This covers submitted theses whose PRs were decided while you were working on other theses.
 
 ### 7. Sleep and repeat
 

--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -14,6 +14,7 @@ Your working directory is the project root, checked out to the default branch. Y
 - `polyresearch pace` — check API budget.
 - `polyresearch admin release-claim <issue> --node <node> --reason <reason>` — force-release a stuck claim.
 - `polyresearch admin acknowledge-invalid <comment-id> --note "<text>"` — acknowledge an invalid finding.
+- `polyresearch prune` — remove worktrees for resolved/rejected theses and clean up stale directories.
 
 ## The loop
 
@@ -40,6 +41,8 @@ If there are no policy-check duties, proceed to step 3.
 Look for decide duties. For each ready PR, run `polyresearch decide <pr>`. The CLI evaluates the PR's metric, compares it against the baseline and best accepted, and posts the decision.
 
 If decide fails because of merge conflicts, the CLI will attempt a rebase. If that also fails, the PR will be closed as stale — this is expected. The contributor can rebase and resubmit.
+
+After processing all decide duties, run `polyresearch prune` to remove worktrees left behind by decided theses. This is safe to run even when no worktrees exist.
 
 If there are no decide duties, proceed to step 4.
 

--- a/cli/src/commands/prune.rs
+++ b/cli/src/commands/prune.rs
@@ -6,9 +6,11 @@ use color_eyre::eyre::{Context, Result};
 use serde::Serialize;
 
 use crate::commands::{AppContext, print_value, run_git};
+use crate::state::{RepositoryState, ThesisPhase};
 
 #[derive(Debug, Serialize)]
 struct PruneOutput {
+    removed_worktrees: Vec<String>,
     removed_directories: Vec<String>,
     skipped_directories: Vec<String>,
 }
@@ -17,17 +19,43 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     run_git(&ctx.repo_root, &["worktree", "prune"])?;
 
     let worktree_root = ctx.repo_root.join(".worktrees");
-    let registered = registered_worktree_paths(&ctx.repo_root)?;
+    let mut registered = registered_worktree_paths(&ctx.repo_root)?;
+    let mut removed_worktrees = Vec::new();
     let mut removed_directories = Vec::new();
     let mut skipped_directories = Vec::new();
 
     if worktree_root.exists() {
+        let terminal_issues = terminal_thesis_issues(ctx).await;
+
         for entry in fs::read_dir(&worktree_root)
             .wrap_err_with(|| format!("failed to read {}", worktree_root.display()))?
         {
             let entry = entry?;
             let path = entry.path();
-            if !path.is_dir() || registered.contains(&path) {
+            if !path.is_dir() {
+                continue;
+            }
+
+            if let Some(issue_num) = parse_issue_from_dirname(&path) {
+                if terminal_issues.contains(&issue_num) {
+                    if registered.contains(&path) {
+                        let path_arg = path.to_string_lossy().into_owned();
+                        run_git(&ctx.repo_root, &["worktree", "remove", "--force", &path_arg])
+                            .wrap_err_with(|| {
+                                format!("failed to remove worktree {}", path.display())
+                            })?;
+                        registered.remove(&path);
+                    } else {
+                        fs::remove_dir_all(&path).wrap_err_with(|| {
+                            format!("failed to remove directory {}", path.display())
+                        })?;
+                    }
+                    removed_worktrees.push(path.display().to_string());
+                    continue;
+                }
+            }
+
+            if registered.contains(&path) {
                 continue;
             }
 
@@ -44,25 +72,39 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
     }
 
     let output = PruneOutput {
+        removed_worktrees,
         removed_directories,
         skipped_directories,
     };
 
     print_value(ctx, &output, |value| {
-        if value.removed_directories.is_empty() && value.skipped_directories.is_empty() {
-            "Pruned git worktree metadata. No stale worktree directories found.".to_string()
-        } else if value.skipped_directories.is_empty() {
-            format!(
-                "Pruned git worktree metadata and removed {} stale worktree directories.",
-                value.removed_directories.len()
-            )
-        } else {
-            format!(
-                "Pruned git worktree metadata, removed {} stale worktree directories, and skipped {} non-empty directories.",
-                value.removed_directories.len(),
-                value.skipped_directories.len()
-            )
+        let mut parts = Vec::new();
+        parts.push("Pruned git worktree metadata.".to_string());
+        if !value.removed_worktrees.is_empty() {
+            parts.push(format!(
+                "Removed {} resolved thesis worktree(s).",
+                value.removed_worktrees.len()
+            ));
         }
+        if !value.removed_directories.is_empty() {
+            parts.push(format!(
+                "Removed {} stale empty director(ies).",
+                value.removed_directories.len()
+            ));
+        }
+        if !value.skipped_directories.is_empty() {
+            parts.push(format!(
+                "Skipped {} non-empty director(ies).",
+                value.skipped_directories.len()
+            ));
+        }
+        if value.removed_worktrees.is_empty()
+            && value.removed_directories.is_empty()
+            && value.skipped_directories.is_empty()
+        {
+            parts.push("No stale worktree directories found.".to_string());
+        }
+        parts.join(" ")
     })
 }
 
@@ -77,4 +119,30 @@ fn registered_worktree_paths(repo_root: &PathBuf) -> Result<HashSet<PathBuf>> {
     }
 
     Ok(paths)
+}
+
+fn parse_issue_from_dirname(path: &PathBuf) -> Option<u64> {
+    let name = path.file_name()?.to_str()?;
+    let (number, _) = name.split_once('-')?;
+    number.parse::<u64>().ok()
+}
+
+async fn terminal_thesis_issues(ctx: &AppContext) -> HashSet<u64> {
+    let state = RepositoryState::derive(&ctx.github, &ctx.config).await;
+    let Ok(state) = state else {
+        eprintln!("warning: could not fetch thesis state from GitHub; skipping resolved-worktree cleanup");
+        return HashSet::new();
+    };
+
+    state
+        .theses
+        .iter()
+        .filter(|thesis| {
+            matches!(
+                thesis.phase,
+                ThesisPhase::Resolved { .. } | ThesisPhase::Rejected
+            )
+        })
+        .map(|thesis| thesis.issue.number)
+        .collect()
 }

--- a/cli/src/commands/prune.rs
+++ b/cli/src/commands/prune.rs
@@ -88,13 +88,13 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
         }
         if !value.removed_directories.is_empty() {
             parts.push(format!(
-                "Removed {} stale empty director(ies).",
+                "Removed {} stale empty directory(ies).",
                 value.removed_directories.len()
             ));
         }
         if !value.skipped_directories.is_empty() {
             parts.push(format!(
-                "Skipped {} non-empty director(ies).",
+                "Skipped {} non-empty directory(ies).",
                 value.skipped_directories.len()
             ));
         }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -4941,6 +4941,67 @@ async fn prune_preserves_active_worktrees() {
     );
 }
 
+#[tokio::test]
+async fn prune_removes_worktrees_for_terminal_theses() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("prune-terminal");
+    init_git_repo(&repo.path);
+
+    let rejected_wt = repo.path.join(".worktrees").join("5-closed-thesis");
+    fs::create_dir_all(&rejected_wt).unwrap();
+    fs::write(rejected_wt.join("result.json"), "{}").unwrap();
+
+    let active_wt = repo.path.join(".worktrees").join("10-active-thesis");
+    fs::create_dir_all(&active_wt).unwrap();
+    fs::write(active_wt.join("result.json"), "{}").unwrap();
+
+    let closed_issue = Issue {
+        number: 5,
+        title: "Closed thesis".to_string(),
+        body: None,
+        state: "CLOSED".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: chrono::Utc::now(),
+        closed_at: Some(chrono::Utc::now()),
+        author: None,
+        url: None,
+    };
+    let open_issue = Issue {
+        number: 10,
+        title: "Active thesis".to_string(),
+        body: None,
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: chrono::Utc::now(),
+        closed_at: None,
+        author: None,
+        url: None,
+    };
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![closed_issue, open_issue],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Prune);
+
+    commands::prune::run(&ctx).await.unwrap();
+
+    assert!(
+        !rejected_wt.exists(),
+        "worktree for rejected (closed) thesis should be removed"
+    );
+    assert!(
+        active_wt.exists(),
+        "worktree for active (open) thesis should be preserved"
+    );
+}
+
 // ===========================================================================
 // Category 3 (partial): Multi-node contention
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Enhanced `polyresearch prune` to detect thesis worktrees in terminal states (Resolved or Rejected) by querying GitHub, and force-remove them. Falls back gracefully if the API is unavailable.
- Updated `contribute-workflow.md` to add `polyresearch prune` after step 6 (clean up), covering submitted theses whose PRs were decided while the contributor worked on other theses.
- Updated `lead-workflow.md` to run `polyresearch prune` after processing decide duties (step 3).

Closes #140

## Test plan

- [x] `prune_removes_empty_stale_worktree_directories` -- existing test, still passes
- [x] `prune_preserves_active_worktrees` -- existing test, still passes
- [x] `prune_removes_worktrees_for_terminal_theses` -- new test: creates worktrees for a CLOSED (rejected) thesis and an OPEN thesis, verifies only the rejected one is removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds GitHub-backed logic to `polyresearch prune` that can force-remove local worktrees based on remote thesis state, so mistakes or API/state mismatches could delete in-progress local directories. Changes are scoped to pruning behavior and workflow docs.
> 
> **Overview**
> **`polyresearch prune` now cleans up resolved/rejected thesis worktrees automatically.** It queries GitHub-derived `RepositoryState` to detect terminal (`Resolved`/`Rejected`) theses and then force-removes matching `.worktrees/<issue>-*` entries (via `git worktree remove --force` when registered, or `rm -r` when unregistered), while retaining existing cleanup of empty/unregistered directories and emitting richer output.
> 
> The contributor and lead workflow prompts are updated to include running `polyresearch prune` during cleanup/after PR decisions, and an e2e test is added to verify terminal-thesis worktrees are removed while active ones are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17fe01edc3fd328ed12a73db18437d02b9bdac7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->