### PR TITLE
Fix sync to pull and push results.tsv to origin

### DIFF
--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -1,8 +1,10 @@
+use std::path::PathBuf;
+
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::commands::guards::ensure_lead;
-use crate::commands::{AppContext, commit_file, current_branch, print_value};
+use crate::commands::{AppContext, commit_file, current_branch, print_value, run_git};
 use crate::ledger::Ledger;
 use crate::state::RepositoryState;
 
@@ -12,25 +14,54 @@ struct SyncOutput {
     attempts: Vec<String>,
 }
 
+/// Fetch the default branch from origin and fast-forward the local branch.
+/// If local has unpushed commits (prior sync that failed to push), rebase
+/// them onto the remote. If rebase conflicts, abort to keep the repo
+/// workable -- follows the same abort pattern as decide.rs::try_rebase_onto_main.
+fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
+    run_git(repo_root, &["fetch", "origin", branch])?;
+    let remote_ref = format!("origin/{branch}");
+
+    if run_git(repo_root, &["merge", "--ff-only", &remote_ref]).is_ok() {
+        return Ok(());
+    }
+
+    let rebase_result = run_git(repo_root, &["rebase", &remote_ref]);
+    if rebase_result.is_err() {
+        let _ = run_git(repo_root, &["rebase", "--abort"]);
+    }
+    rebase_result.map(|_| ())
+}
+
 pub async fn run(ctx: &AppContext) -> Result<()> {
     ensure_lead(ctx)?;
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let mut ledger = Ledger::load(&ctx.repo_root)?;
-    let missing_rows = ledger.missing_rows(&repo_state);
 
-    if !ctx.cli.dry_run && !missing_rows.is_empty() {
-        let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+
+    if !ctx.cli.dry_run {
         if current_branch(&ctx.repo_root)? != default_branch {
             return Err(eyre!(
                 "`polyresearch sync` must run from the `{default_branch}` branch"
             ));
         }
+        pull_default_branch(&ctx.repo_root, &default_branch)?;
+    }
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let mut ledger = Ledger::load(&ctx.repo_root)?;
+    let missing_rows = ledger.missing_rows(&repo_state);
+
+    if !ctx.cli.dry_run && !missing_rows.is_empty() {
         ledger.append_rows(&missing_rows)?;
         commit_file(
             &ctx.repo_root,
             "results.tsv",
             "Update results.tsv via polyresearch sync.",
         )?;
+    }
+
+    if !ctx.cli.dry_run {
+        run_git(&ctx.repo_root, &["push", "origin", &default_branch])?;
     }
 
     let output = SyncOutput {

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -24,6 +24,7 @@ use scenario_mock::ScenarioGitHub;
 
 struct ScenarioRepo {
     path: PathBuf,
+    bare_path: Option<PathBuf>,
 }
 
 impl ScenarioRepo {
@@ -34,7 +35,10 @@ impl ScenarioRepo {
             .as_nanos();
         let path = env::temp_dir().join(format!("poly-scenario-{name}-{unique}"));
         fs::create_dir_all(&path).unwrap();
-        Self { path }
+        Self {
+            path,
+            bare_path: None,
+        }
     }
 
     fn init_git(&self) {
@@ -154,11 +158,26 @@ Test scenario goal.
         run_git(&self.path, &["add", "-A"]);
         run_git(&self.path, &["commit", "-m", message, "--allow-empty"]);
     }
+
+    fn add_bare_remote(&mut self, branch: &str) {
+        let bare = self.path.with_extension("bare.git");
+        fs::create_dir_all(&bare).unwrap();
+        run_git(&bare, &["init", "--bare"]);
+        run_git(
+            &self.path,
+            &["remote", "add", "origin", &bare.to_string_lossy()],
+        );
+        run_git(&self.path, &["push", "-u", "origin", branch]);
+        self.bare_path = Some(bare);
+    }
 }
 
 impl Drop for ScenarioRepo {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
+        if let Some(bare) = &self.bare_path {
+            let _ = fs::remove_dir_all(bare);
+        }
     }
 }
 
@@ -2933,13 +2952,14 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
 #[tokio::test]
 async fn scenario_sync_accepts_master_default_branch() {
     let _guard = EnvGuard::lock_clean();
-    let repo = ScenarioRepo::new("sync-master");
+    let mut repo = ScenarioRepo::new("sync-master");
     repo.init_git_on_branch("master");
     repo.write_program_md_with_branch("lead", Some("master"));
     repo.write_prepare_md();
     repo.write_results_tsv();
     repo.write_node_config("test-node", "echo noop");
     repo.commit_all("setup");
+    repo.add_bare_remote("master");
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
 


### PR DESCRIPTION
Closes #134

## Summary

- `polyresearch sync` now fetches the default branch from origin and fast-forwards (or rebases) before deriving state, then pushes after committing. Previously it only committed locally, leaving results.tsv unpushed.
- Adds `pull_default_branch()` which fetches, attempts `--ff-only` merge, falls back to rebase, and aborts on conflict (same pattern as `decide.rs::try_rebase_onto_main`).
- Updates the `scenario_sync_accepts_master_default_branch` test to use a bare remote so the fetch/push code paths are exercised.

## Test plan

- [x] `cargo test scenario_sync` passes (both sync scenarios)
- [x] Full `cargo test` passes (352 tests, 0 failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `polyresearch sync` to mutate git state by fetching/fast-forwarding (or rebasing) and pushing to `origin`, which could impact local repos if conflicts or unexpected history divergence occur. Scope is limited to the sync command and adds conflict-abort safeguards plus test coverage via a bare remote.
> 
> **Overview**
> `polyresearch sync` now **synchronizes the default branch with `origin`**: it fetches and fast-forwards the local default branch (falling back to a rebase that aborts on conflict) *before* deriving state and appending to `results.tsv`, and then pushes the default branch back to `origin` after committing.
> 
> Tests were updated to exercise the new fetch/push paths by adding support for a temporary bare `origin` remote in scenario repos and using it in the `master` default-branch sync scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626bb94c30a2534f2b5ae9823834f0efbd9c124b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->