### PR TITLE
Commit bootstrap benchmark helper files

### DIFF
--- a/cli/prompts/bootstrap-setup.md
+++ b/cli/prompts/bootstrap-setup.md
@@ -4,4 +4,6 @@ In PROGRAM.md: set lead_github_login and maintainer_github_login. Update the CAN
 
 In PREPARE.md: write a real benchmark command that produces a parseable METRIC=<number> line. Fill in the setup steps so a fresh machine can reproduce the evaluation.
 
+If you create helper scripts for evaluation (for example benchmark runners or harness wrappers), place them under `.polyresearch/` or `bench/`. Those setup-time helper files will be committed with the bootstrap setup.
+
 Do NOT create or modify any source code files.

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -46,6 +46,7 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     // Post-agent cleanup: re-normalize in case the agent mangled required sections,
     // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
     normalize_program_md(&repo_root)?;
+    normalize_file_endings(&repo_root)?;
     let untracked_after_agent = untracked_files(&repo_root);
     let mut agent_created_files: Vec<String> = untracked_after_agent
         .difference(&untracked_before_agent)
@@ -279,6 +280,8 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>, login: &str) -> Res
             .wrap_err_with(|| format!("failed to create {}", polyresearch_dir.display()))?;
     }
 
+    ensure_gitignore_entry(repo_root, ".polyresearch-node.toml")?;
+
     Ok(())
 }
 
@@ -406,7 +409,8 @@ fn untracked_files(repo_root: &Path) -> HashSet<String> {
 pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> Result<()> {
     let repo = repo_root.to_path_buf();
 
-    let mut setup_paths: Vec<String> = ["PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch"]
+    let mut setup_paths: Vec<String> =
+        ["PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch", ".gitignore"]
         .into_iter()
         .filter(|f| repo_root.join(f).exists())
         .map(str::to_string)
@@ -425,6 +429,10 @@ pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> 
     }
 
     let setup_path_refs: Vec<&str> = setup_paths.iter().map(String::as_str).collect();
+
+    let mut reset_args: Vec<&str> = vec!["reset", "--"];
+    reset_args.extend(setup_path_refs.iter().copied());
+    let _ = commands::run_git(&repo, &reset_args);
 
     let mut add_args: Vec<&str> = vec!["add", "-f", "--"];
     add_args.extend(setup_path_refs.iter().copied());
@@ -453,6 +461,12 @@ pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> 
     }
     commands::run_git(&repo, &commit_args)?;
 
+    let mut checkout_args: Vec<&str> = vec!["checkout", "HEAD", "--"];
+    for f in &staged_files {
+        checkout_args.push(f.as_str());
+    }
+    let _ = commands::run_git(&repo, &checkout_args);
+
     match commands::run_git(&repo, &["push", "origin", "HEAD"]) {
         Ok(_) => eprintln!("Committed and pushed setup files."),
         Err(err) => {
@@ -464,6 +478,34 @@ pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> 
 
 fn detect_default_branch(repo_root: &Path) -> String {
     crate::config::detect_default_branch_from_git(repo_root)
+}
+
+fn ensure_gitignore_entry(repo_root: &Path, entry: &str) -> Result<()> {
+    use std::io::Write;
+
+    let path = repo_root.join(".gitignore");
+    let existing = if path.exists() {
+        fs::read_to_string(&path).wrap_err_with(|| format!("failed to read {}", path.display()))?
+    } else {
+        String::new()
+    };
+
+    if existing.lines().any(|line| line.trim() == entry) {
+        return Ok(());
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .wrap_err_with(|| format!("failed to open {}", path.display()))?;
+
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        writeln!(file).wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+
+    writeln!(file, "{entry}").wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    Ok(())
 }
 
 pub fn normalize_program_md(repo_root: &Path) -> Result<()> {
@@ -492,6 +534,38 @@ pub fn normalize_program_md(repo_root: &Path) -> Result<()> {
     if modified != contents {
         fs::write(&path, &modified)
             .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+pub fn normalize_file_endings(repo_root: &Path) -> Result<()> {
+    for name in ["PROGRAM.md", "PREPARE.md"] {
+        let path = repo_root.join(name);
+        if !path.exists() {
+            continue;
+        }
+
+        let contents =
+            fs::read_to_string(&path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+
+        let normalized = if contents.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "{}\n",
+                contents
+                    .lines()
+                    .map(str::trim_end)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+
+        if normalized != contents {
+            fs::write(&path, &normalized)
+                .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+        }
     }
 
     Ok(())

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -38,12 +39,20 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         }
     }
 
+    let untracked_before_agent = untracked_files(&repo_root);
+
     spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose, &login)?;
 
     // Post-agent cleanup: re-normalize in case the agent mangled required sections,
     // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
     normalize_program_md(&repo_root)?;
-    commit_and_push_setup_files(&repo_root)?;
+    let untracked_after_agent = untracked_files(&repo_root);
+    let mut agent_created_files: Vec<String> = untracked_after_agent
+        .difference(&untracked_before_agent)
+        .cloned()
+        .collect();
+    agent_created_files.sort();
+    commit_and_push_setup_files(&repo_root, &agent_created_files)?;
 
     eprintln!("Bootstrap complete.");
     Ok(())
@@ -383,27 +392,49 @@ fn spawn_setup_agent(
     Ok(())
 }
 
-pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
+fn untracked_files(repo_root: &Path) -> HashSet<String> {
+    commands::run_git(
+        &repo_root.to_path_buf(),
+        &["status", "--porcelain", "--untracked-files=all"],
+    )
+    .unwrap_or_default()
+    .lines()
+    .filter_map(|line| line.strip_prefix("?? ").map(str::to_string))
+    .collect()
+}
+
+pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> Result<()> {
     let repo = repo_root.to_path_buf();
 
-    let setup_paths: Vec<&str> = ["PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch"]
+    let mut setup_paths: Vec<String> = ["PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch"]
         .into_iter()
         .filter(|f| repo_root.join(f).exists())
+        .map(str::to_string)
         .collect();
+
+    for path in extra_paths {
+        if repo_root.join(path).exists() && !setup_paths.contains(path) {
+            setup_paths.push(path.clone());
+        }
+    }
+
+    setup_paths.sort();
 
     if setup_paths.is_empty() {
         return Ok(());
     }
 
+    let setup_path_refs: Vec<&str> = setup_paths.iter().map(String::as_str).collect();
+
     let mut add_args: Vec<&str> = vec!["add", "-f", "--"];
-    add_args.extend(&setup_paths);
+    add_args.extend(setup_path_refs.iter().copied());
     commands::run_git(&repo, &add_args)?;
 
     // Query which of our paths actually have staged changes. This scopes the
     // commit to only setup files (preventing leakage from a dirty index) and
     // avoids "pathspec didn't match" errors on empty directories like .polyresearch/.
     let mut diff_args: Vec<&str> = vec!["diff", "--cached", "--name-only", "--"];
-    diff_args.extend(&setup_paths);
+    diff_args.extend(setup_path_refs.iter().copied());
     let diff_output = commands::run_git(&repo, &diff_args).unwrap_or_default();
     let staged_files: Vec<String> = diff_output
         .lines()

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2437,6 +2437,28 @@ async fn bootstrap_normalizes_program_md_adds_missing_sections() {
 }
 
 #[tokio::test]
+async fn bootstrap_normalize_file_endings_trims_whitespace() {
+    let repo = TestRepo::new("bootstrap-normalize-endings");
+    init_git_repo(&repo.path);
+
+    let program_path = repo.path.join("PROGRAM.md");
+    let prepare_path = repo.path.join("PREPARE.md");
+    fs::write(&program_path, "# Program   \n\n## Goal   \n\nDo stuff.   ").unwrap();
+    fs::write(&prepare_path, "# Setup   \n\nRun it.   ").unwrap();
+
+    commands::bootstrap::normalize_file_endings(&repo.path).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&program_path).unwrap(),
+        "# Program\n\n## Goal\n\nDo stuff.\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&prepare_path).unwrap(),
+        "# Setup\n\nRun it.\n"
+    );
+}
+
+#[tokio::test]
 async fn bootstrap_commits_setup_files() {
     let repo = TestRepo::new("bootstrap-commit");
     init_git_repo(&repo.path);
@@ -2460,6 +2482,17 @@ async fn bootstrap_commits_setup_files() {
 
     commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    let check_ignore_output = Command::new("git")
+        .args(["check-ignore", ".polyresearch-node.toml"])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    assert!(
+        check_ignore_output.status.success(),
+        ".polyresearch-node.toml should be gitignored"
+    );
+
     commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Verify git status is clean for setup files
@@ -2472,6 +2505,7 @@ async fn bootstrap_commits_setup_files() {
             "PREPARE.md",
             "results.tsv",
             ".polyresearch",
+            ".gitignore",
         ])
         .current_dir(&repo.path)
         .output()
@@ -2504,6 +2538,93 @@ async fn bootstrap_commits_setup_files() {
     assert!(files.contains("PROGRAM.md"), "PROGRAM.md not in commit");
     assert!(files.contains("PREPARE.md"), "PREPARE.md not in commit");
     assert!(files.contains("results.tsv"), "results.tsv not in commit");
+    assert!(files.contains(".gitignore"), ".gitignore not in commit");
+    assert!(
+        !files.contains(".polyresearch-node.toml"),
+        ".polyresearch-node.toml should not be in commit"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_commit_cleans_agent_whitespace_diffs() {
+    let repo = TestRepo::new("bootstrap-whitespace-clean");
+    init_git_repo(&repo.path);
+
+    let bare = TestRepo::new("bootstrap-whitespace-clean-bare");
+    let _ = fs::remove_dir_all(&bare.path);
+    Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    let program_path = repo.path.join("PROGRAM.md");
+    let prepare_path = repo.path.join("PREPARE.md");
+
+    let staged_program = fs::read_to_string(&program_path)
+        .unwrap()
+        .replace("source code", "source code  ");
+    let staged_prepare = fs::read_to_string(&prepare_path)
+        .unwrap()
+        .replace("METRIC=<number>", "METRIC=<number>  ");
+    fs::write(&program_path, &staged_program).unwrap();
+    fs::write(&prepare_path, &staged_prepare).unwrap();
+    run_git(&repo.path, &["add", "PROGRAM.md", "PREPARE.md"]);
+
+    fs::write(&program_path, staged_program.trim_end()).unwrap();
+    fs::write(&prepare_path, format!("{}  \n", staged_prepare.trim_end())).unwrap();
+
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
+
+    let status_output = Command::new("git")
+        .args([
+            "status",
+            "--porcelain",
+            "--",
+            "PROGRAM.md",
+            "PREPARE.md",
+            "results.tsv",
+            ".polyresearch",
+            ".gitignore",
+        ])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let status = String::from_utf8(status_output.stdout).unwrap();
+    assert!(
+        status.trim().is_empty(),
+        "setup files should be clean after whitespace cleanup, got: {status}"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_gitignores_node_config() {
+    let repo = TestRepo::new("bootstrap-gitignore-node");
+    init_git_repo(&repo.path);
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+
+    let gitignore = fs::read_to_string(repo.path.join(".gitignore")).unwrap();
+    let matches = gitignore
+        .lines()
+        .filter(|line| line.trim() == ".polyresearch-node.toml")
+        .count();
+    assert_eq!(
+        matches, 1,
+        ".gitignore should contain one node config entry"
+    );
 }
 
 #[tokio::test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1805,9 +1805,7 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author {
-            login: "alice".to_string(),
-        }),
+        author: Some(Author { login: "alice".to_string() }),
         url: None,
         mergeable: None,
     };
@@ -1834,9 +1832,7 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author {
-                login: "alice".to_string(),
-            }),
+            author: Some(Author { login: "alice".to_string() }),
             url: None,
             mergeable: None,
         },
@@ -1886,9 +1882,7 @@ async fn duties_lead_duties_included_in_lead_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author {
-            login: "alice".to_string(),
-        }),
+        author: Some(Author { login: "alice".to_string() }),
         url: None,
         mergeable: None,
     };
@@ -1915,9 +1909,7 @@ async fn duties_lead_duties_included_in_lead_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author {
-                login: "alice".to_string(),
-            }),
+            author: Some(Author { login: "alice".to_string() }),
             url: None,
             mergeable: None,
         },
@@ -2052,9 +2044,7 @@ async fn duties_submit_skipped_when_pr_merged() {
             created_at: now,
             closed_at: Some(now),
             merged_at: Some(now),
-            author: Some(Author {
-                login: "alice".to_string(),
-            }),
+            author: Some(Author { login: "alice".to_string() }),
             url: None,
             mergeable: None,
         },
@@ -2095,9 +2085,7 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author {
-            login: "alice".to_string(),
-        }),
+        author: Some(Author { login: "alice".to_string() }),
         url: None,
         mergeable: None,
     };
@@ -2125,9 +2113,7 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author {
-                login: "alice".to_string(),
-            }),
+            author: Some(Author { login: "alice".to_string() }),
             url: None,
             mergeable: None,
         },
@@ -2150,8 +2136,7 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         "lead context should see decide as blocking"
     );
 
-    let contribute_report =
-        commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
+    let contribute_report = commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
     assert!(
         contribute_report.blocking.is_empty(),
         "contribute context must not be blocked by lead duties; got: {:?}",
@@ -2510,6 +2495,86 @@ async fn bootstrap_commits_setup_files() {
     );
 
     // Verify committed files
+    let show_output = Command::new("git")
+        .args(["show", "HEAD", "--name-only", "--format="])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let files = String::from_utf8(show_output.stdout).unwrap();
+    assert!(files.contains("PROGRAM.md"), "PROGRAM.md not in commit");
+    assert!(files.contains("PREPARE.md"), "PREPARE.md not in commit");
+    assert!(files.contains("results.tsv"), "results.tsv not in commit");
+}
+
+#[tokio::test]
+async fn bootstrap_commits_setup_files_with_allowlist_gitignore() {
+    let repo = TestRepo::new("bootstrap-commit-allowlist-gitignore");
+    init_git_repo(&repo.path);
+
+    // Create a bare remote so push succeeds
+    let bare = TestRepo::new("bootstrap-commit-allowlist-gitignore-bare");
+    let _ = fs::remove_dir_all(&bare.path);
+    Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
+
+    fs::write(repo.path.join(".gitignore"), "/*\n!/.gitignore\n").unwrap();
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    let ignored_output = Command::new("git")
+        .args([
+            "check-ignore",
+            "PROGRAM.md",
+            "PREPARE.md",
+            "results.tsv",
+            ".polyresearch",
+        ])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let ignored = String::from_utf8(ignored_output.stdout).unwrap();
+    assert!(
+        ignored.contains("PROGRAM.md")
+            && ignored.contains("PREPARE.md")
+            && ignored.contains("results.tsv")
+            && ignored.contains(".polyresearch"),
+        "expected setup files to be ignored by allowlist .gitignore, got: {ignored}"
+    );
+
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
+
+    // Verify git status is clean for setup files even though .gitignore hides them.
+    let status_output = Command::new("git")
+        .args([
+            "status",
+            "--porcelain",
+            "--",
+            "PROGRAM.md",
+            "PREPARE.md",
+            "results.tsv",
+            ".polyresearch",
+        ])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let status = String::from_utf8(status_output.stdout).unwrap();
+    assert!(
+        status.trim().is_empty(),
+        "setup files should be clean after commit, got: {status}"
+    );
+
     let show_output = Command::new("git")
         .args(["show", "HEAD", "--name-only", "--format="])
         .current_dir(&repo.path)
@@ -6000,11 +6065,11 @@ async fn decide_excludes_acknowledged_invalid_from_best_metric() {
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state_with_poisoned_prior(
-        1,        // thesis_number (current)
-        50,       // pr_number (current)
-        20421.0,  // current_metric
-        15000.0,  // baseline
-        17658.0,  // prior_valid_metric
+        1,     // thesis_number (current)
+        50,    // pr_number (current)
+        20421.0, // current_metric
+        15000.0, // baseline
+        17658.0, // prior_valid_metric
         218000.0, // poisoned_metric
         "lead",
     );

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1805,7 +1805,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1832,7 +1834,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -1882,7 +1886,9 @@ async fn duties_lead_duties_included_in_lead_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1909,7 +1915,9 @@ async fn duties_lead_duties_included_in_lead_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2044,7 +2052,9 @@ async fn duties_submit_skipped_when_pr_merged() {
             created_at: now,
             closed_at: Some(now),
             merged_at: Some(now),
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2085,7 +2095,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -2113,7 +2125,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2136,7 +2150,8 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         "lead context should see decide as blocking"
     );
 
-    let contribute_report = commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
+    let contribute_report =
+        commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
     assert!(
         contribute_report.blocking.is_empty(),
         "contribute context must not be blocked by lead duties; got: {:?}",
@@ -2460,7 +2475,7 @@ async fn bootstrap_commits_setup_files() {
 
     commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Verify git status is clean for setup files
     let status_output = Command::new("git")
@@ -2507,6 +2522,63 @@ async fn bootstrap_commits_setup_files() {
 }
 
 #[tokio::test]
+async fn bootstrap_commits_agent_created_benchmark_files() {
+    let repo = TestRepo::new("bootstrap-benchmark-files");
+    init_git_repo(&repo.path);
+
+    let bare = TestRepo::new("bootstrap-benchmark-files-bare");
+    let _ = fs::remove_dir_all(&bare.path);
+    Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    fs::create_dir_all(repo.path.join("bench")).unwrap();
+    fs::write(
+        repo.path.join("bench/eval.js"),
+        "console.log('benchmark helper');\n",
+    )
+    .unwrap();
+
+    let extra_paths = vec!["bench/eval.js".to_string()];
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &extra_paths).unwrap();
+
+    let show_output = Command::new("git")
+        .args(["show", "HEAD", "--name-only", "--format="])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let files = String::from_utf8(show_output.stdout).unwrap();
+    assert!(
+        files.contains("bench/eval.js"),
+        "bench/eval.js not in commit: {files}"
+    );
+
+    let status_output = Command::new("git")
+        .args(["status", "--porcelain", "--", "bench/eval.js"])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let status = String::from_utf8(status_output.stdout).unwrap();
+    assert!(
+        status.trim().is_empty(),
+        "benchmark helper should be clean after commit, got: {status}"
+    );
+}
+
+#[tokio::test]
 async fn bootstrap_commit_is_idempotent() {
     let repo = TestRepo::new("bootstrap-commit-idempotent");
     init_git_repo(&repo.path);
@@ -2529,10 +2601,10 @@ async fn bootstrap_commit_is_idempotent() {
 
     commands::bootstrap::write_templates(&repo.path, None, "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Second call should not error (nothing to commit)
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Should still be only one setup commit
     let log_output = Command::new("git")
@@ -5928,11 +6000,11 @@ async fn decide_excludes_acknowledged_invalid_from_best_metric() {
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state_with_poisoned_prior(
-        1,     // thesis_number (current)
-        50,    // pr_number (current)
-        20421.0, // current_metric
-        15000.0, // baseline
-        17658.0, // prior_valid_metric
+        1,        // thesis_number (current)
+        50,       // pr_number (current)
+        20421.0,  // current_metric
+        15000.0,  // baseline
+        17658.0,  // prior_valid_metric
         218000.0, // poisoned_metric
         "lead",
     );


### PR DESCRIPTION
Fixes #149.

## Summary
- snapshot untracked files before and after the bootstrap setup agent runs
- include newly created helper scripts in the setup commit so PREPARE.md cannot point at missing benchmark files
- cover the new benchmark-file path in e2e tests and clarify the bootstrap prompt guidance

## Test plan
- [x] cargo test -q bootstrap_commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git staging/commit behavior in the bootstrap flow, so bugs could accidentally omit needed files or commit unintended untracked files despite the scoped path selection.
> 
> **Overview**
> Bootstrap now snapshots untracked files before/after the setup agent runs and includes any newly created files in the setup commit, preventing `PREPARE.md` from pointing to missing benchmark helper scripts.
> 
> `commit_and_push_setup_files` was updated to accept an `extra_paths` allowlist (merged with the standard setup files) and tests were updated/extended with a new e2e case asserting a `bench/eval.js` helper gets committed and the working tree remains clean. The bootstrap agent prompt guidance was also clarified to direct helper scripts into `.polyresearch/` or `bench/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e64855aa277972ca9428fc83616b9b92cde665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->