### PR TITLE
Stream workflow agent output

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -449,8 +449,8 @@ pub fn spawn_workflow_agent(
     cmd.args(&parts[1..]);
     cmd.current_dir(work_dir);
     cmd.stdin(Stdio::piped());
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
 
     eprintln!(
         "Spawning workflow agent in {}...",
@@ -458,30 +458,31 @@ pub fn spawn_workflow_agent(
     );
     let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;
 
-    child
-        .stdin
-        .take()
-        .ok_or_else(|| eyre!("failed to open stdin pipe for workflow agent"))?
-        .write_all(prompt.as_bytes())
-        .wrap_err("failed to write prompt to agent stdin")?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| eyre!("failed to open stdin pipe for workflow agent"))?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .wrap_err("failed to write prompt to agent stdin")?;
+    }
 
-    let output = child
-        .wait_with_output()
+    let status = child
+        .wait()
         .wrap_err("failed to wait for workflow agent")?;
 
-    if !output.status.success() {
-        log_subprocess_failure(
-            "Workflow agent",
-            &output,
-            verbose,
-            Some(agent_command),
-            Some(work_dir),
-        );
-        let code = output
-            .status
+    if !status.success() {
+        let code = status
             .code()
             .map(|c| c.to_string())
             .unwrap_or_else(|| "signal".into());
+        if verbose {
+            eprintln!("[verbose] Command: {agent_command}");
+            eprintln!("[verbose] Working directory: {}", work_dir.display());
+            eprintln!("[verbose] Exit code: {code}");
+        }
+        eprintln!("Workflow agent exited with status {code}");
         return Err(eyre!("workflow agent exited with status {code}"));
     }
 


### PR DESCRIPTION
## Summary
- Switch `spawn_workflow_agent` to stream workflow agent stdout/stderr directly to the terminal with `Stdio::inherit()` instead of buffering everything until exit.
- Keep stdin piping for prompt delivery while waiting on the child process with `wait()`.
- Depends on `hybrid-agent-cli` (PR #118); this PR targets that branch directly because the workflow-agent code for issue #120 lives there.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (same pre-existing failure on `hybrid-agent-cli`: `scenario_sync_accepts_master_default_branch` in `cli/tests/scenarios.rs` because the test fixture lacks an `origin` remote)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess I/O handling for `spawn_workflow_agent`, which can affect UX and error diagnostics (no longer captures stdout/stderr for postmortem logging). Failure handling is simplified but should be validated across shells/environments.
> 
> **Overview**
> `spawn_workflow_agent` now **streams workflow-agent stdout/stderr directly to the terminal** by switching from piped output + `wait_with_output()` to `Stdio::inherit()` + `wait()`.
> 
> It keeps stdin piping to deliver the prompt (explicitly dropping the stdin handle after writing) and replaces the previous captured-output failure logger with a simpler verbose-only print of command/working dir/exit code before returning an error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5b91c6046b95d36cc852fd9548f42924c35bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->