### PR TITLE
Fix bootstrap leaving a dirty worktree

### DIFF
--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -43,6 +43,7 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
     // Post-agent cleanup: re-normalize in case the agent mangled required sections,
     // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
     normalize_program_md(&repo_root)?;
+    normalize_file_endings(&repo_root)?;
     commit_and_push_setup_files(&repo_root)?;
 
     eprintln!("Bootstrap complete.");
@@ -270,6 +271,8 @@ pub fn write_templates(repo_root: &Path, goal: Option<&str>, login: &str) -> Res
             .wrap_err_with(|| format!("failed to create {}", polyresearch_dir.display()))?;
     }
 
+    ensure_gitignore_entry(repo_root, ".polyresearch-node.toml")?;
+
     Ok(())
 }
 
@@ -386,14 +389,24 @@ fn spawn_setup_agent(
 pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
     let repo = repo_root.to_path_buf();
 
-    let setup_paths: Vec<&str> = ["PROGRAM.md", "PREPARE.md", "results.tsv", ".polyresearch"]
-        .into_iter()
-        .filter(|f| repo_root.join(f).exists())
-        .collect();
+    let setup_paths: Vec<&str> = [
+        "PROGRAM.md",
+        "PREPARE.md",
+        "results.tsv",
+        ".polyresearch",
+        ".gitignore",
+    ]
+    .into_iter()
+    .filter(|f| repo_root.join(f).exists())
+    .collect();
 
     if setup_paths.is_empty() {
         return Ok(());
     }
+
+    let mut reset_args: Vec<&str> = vec!["reset", "--"];
+    reset_args.extend(&setup_paths);
+    let _ = commands::run_git(&repo, &reset_args);
 
     let mut add_args: Vec<&str> = vec!["add", "-f", "--"];
     add_args.extend(&setup_paths);
@@ -422,6 +435,12 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
     }
     commands::run_git(&repo, &commit_args)?;
 
+    let mut checkout_args: Vec<&str> = vec!["checkout", "HEAD", "--"];
+    for f in &staged_files {
+        checkout_args.push(f.as_str());
+    }
+    let _ = commands::run_git(&repo, &checkout_args);
+
     match commands::run_git(&repo, &["push", "origin", "HEAD"]) {
         Ok(_) => eprintln!("Committed and pushed setup files."),
         Err(err) => {
@@ -433,6 +452,34 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
 
 fn detect_default_branch(repo_root: &Path) -> String {
     crate::config::detect_default_branch_from_git(repo_root)
+}
+
+fn ensure_gitignore_entry(repo_root: &Path, entry: &str) -> Result<()> {
+    use std::io::Write;
+
+    let path = repo_root.join(".gitignore");
+    let existing = if path.exists() {
+        fs::read_to_string(&path).wrap_err_with(|| format!("failed to read {}", path.display()))?
+    } else {
+        String::new()
+    };
+
+    if existing.lines().any(|line| line.trim() == entry) {
+        return Ok(());
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .wrap_err_with(|| format!("failed to open {}", path.display()))?;
+
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        writeln!(file).wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+
+    writeln!(file, "{entry}").wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    Ok(())
 }
 
 pub fn normalize_program_md(repo_root: &Path) -> Result<()> {
@@ -461,6 +508,38 @@ pub fn normalize_program_md(repo_root: &Path) -> Result<()> {
     if modified != contents {
         fs::write(&path, &modified)
             .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+pub fn normalize_file_endings(repo_root: &Path) -> Result<()> {
+    for name in ["PROGRAM.md", "PREPARE.md"] {
+        let path = repo_root.join(name);
+        if !path.exists() {
+            continue;
+        }
+
+        let contents = fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+
+        let normalized = if contents.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "{}\n",
+                contents
+                    .lines()
+                    .map(str::trim_end)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+
+        if normalized != contents {
+            fs::write(&path, &normalized)
+                .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+        }
     }
 
     Ok(())

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2437,6 +2437,28 @@ async fn bootstrap_normalizes_program_md_adds_missing_sections() {
 }
 
 #[tokio::test]
+async fn bootstrap_normalize_file_endings_trims_whitespace() {
+    let repo = TestRepo::new("bootstrap-normalize-endings");
+    init_git_repo(&repo.path);
+
+    let program_path = repo.path.join("PROGRAM.md");
+    let prepare_path = repo.path.join("PREPARE.md");
+    fs::write(&program_path, "# Program   \n\n## Goal   \n\nDo stuff.   ").unwrap();
+    fs::write(&prepare_path, "# Setup   \n\nRun it.   ").unwrap();
+
+    commands::bootstrap::normalize_file_endings(&repo.path).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&program_path).unwrap(),
+        "# Program\n\n## Goal\n\nDo stuff.\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&prepare_path).unwrap(),
+        "# Setup\n\nRun it.\n"
+    );
+}
+
+#[tokio::test]
 async fn bootstrap_commits_setup_files() {
     let repo = TestRepo::new("bootstrap-commit");
     init_git_repo(&repo.path);
@@ -2460,6 +2482,17 @@ async fn bootstrap_commits_setup_files() {
 
     commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    let check_ignore_output = Command::new("git")
+        .args(["check-ignore", ".polyresearch-node.toml"])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    assert!(
+        check_ignore_output.status.success(),
+        ".polyresearch-node.toml should be gitignored"
+    );
+
     commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
 
     // Verify git status is clean for setup files
@@ -2472,6 +2505,7 @@ async fn bootstrap_commits_setup_files() {
             "PREPARE.md",
             "results.tsv",
             ".polyresearch",
+            ".gitignore",
         ])
         .current_dir(&repo.path)
         .output()
@@ -2504,6 +2538,93 @@ async fn bootstrap_commits_setup_files() {
     assert!(files.contains("PROGRAM.md"), "PROGRAM.md not in commit");
     assert!(files.contains("PREPARE.md"), "PREPARE.md not in commit");
     assert!(files.contains("results.tsv"), "results.tsv not in commit");
+    assert!(files.contains(".gitignore"), ".gitignore not in commit");
+    assert!(
+        !files.contains(".polyresearch-node.toml"),
+        ".polyresearch-node.toml should not be in commit"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_commit_cleans_agent_whitespace_diffs() {
+    let repo = TestRepo::new("bootstrap-whitespace-clean");
+    init_git_repo(&repo.path);
+
+    let bare = TestRepo::new("bootstrap-whitespace-clean-bare");
+    let _ = fs::remove_dir_all(&bare.path);
+    Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    let program_path = repo.path.join("PROGRAM.md");
+    let prepare_path = repo.path.join("PREPARE.md");
+
+    let staged_program = fs::read_to_string(&program_path)
+        .unwrap()
+        .replace("source code", "source code  ");
+    let staged_prepare = fs::read_to_string(&prepare_path)
+        .unwrap()
+        .replace("METRIC=<number>", "METRIC=<number>  ");
+    fs::write(&program_path, &staged_program).unwrap();
+    fs::write(&prepare_path, &staged_prepare).unwrap();
+    run_git(&repo.path, &["add", "PROGRAM.md", "PREPARE.md"]);
+
+    fs::write(&program_path, staged_program.trim_end()).unwrap();
+    fs::write(&prepare_path, format!("{}  \n", staged_prepare.trim_end())).unwrap();
+
+    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+
+    let status_output = Command::new("git")
+        .args([
+            "status",
+            "--porcelain",
+            "--",
+            "PROGRAM.md",
+            "PREPARE.md",
+            "results.tsv",
+            ".polyresearch",
+            ".gitignore",
+        ])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let status = String::from_utf8(status_output.stdout).unwrap();
+    assert!(
+        status.trim().is_empty(),
+        "setup files should be clean after whitespace cleanup, got: {status}"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_gitignores_node_config() {
+    let repo = TestRepo::new("bootstrap-gitignore-node");
+    init_git_repo(&repo.path);
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+
+    let gitignore = fs::read_to_string(repo.path.join(".gitignore")).unwrap();
+    let matches = gitignore
+        .lines()
+        .filter(|line| line.trim() == ".polyresearch-node.toml")
+        .count();
+    assert_eq!(
+        matches, 1,
+        ".gitignore should contain one node config entry"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- normalize `PROGRAM.md` and `PREPARE.md` before the setup commit so trailing whitespace and missing final newlines do not leave bootstrap with tracked diffs
- reset and restage the setup file set before committing, then sync the committed files back to `HEAD` so agent-side partial staging does not leave the worktree dirty
- add `.polyresearch-node.toml` to generated `.gitignore` entries and cover the bootstrap cleanup path with focused e2e regression tests

## Test plan
- [x] `cargo test --test e2e bootstrap_`

Closes #150.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap’s git staging/commit flow and post-agent file normalization; mistakes could cause unintended staging/overwriting of user changes or still leave repos dirty. Changes are localized to setup files and covered by new e2e regression tests, reducing risk.
> 
> **Overview**
> **Bootstrap now performs additional cleanup to avoid leaving a dirty repo after the setup agent runs.** It re-normalizes `PROGRAM.md`/`PREPARE.md` to trim trailing whitespace and enforce a final newline via new `normalize_file_endings()`.
> 
> The setup commit flow is hardened by including `.gitignore` in the tracked setup set, explicitly `git reset`ing and re-adding only the setup paths before committing, and then checking out the committed paths from `HEAD` to clear any agent-induced partial-staging/worktree diffs.
> 
> Bootstrap template generation now ensures `.polyresearch-node.toml` is added once to `.gitignore`, with new e2e tests covering whitespace normalization, gitignore behavior, and clean/idempotent setup commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528ead009ee7b6b9bf23f7d5907bd342813ba036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->