### PR TITLE
Commit bootstrap benchmark helper files

### DIFF
--- a/cli/prompts/bootstrap-setup.md
+++ b/cli/prompts/bootstrap-setup.md
@@ -4,4 +4,6 @@ In PROGRAM.md: set lead_github_login and maintainer_github_login. Update the CAN
 
 In PREPARE.md: write a real benchmark command that produces a parseable METRIC=<number> line. Fill in the setup steps so a fresh machine can reproduce the evaluation.
 
+If you create helper scripts for evaluation (for example benchmark runners or harness wrappers), place them under `.polyresearch/` or `bench/`. Those setup-time helper files will be committed with the bootstrap setup.
+
 Do NOT create or modify any source code files.

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -38,13 +39,21 @@ pub async fn run(ctx: &AppContext, args: &BootstrapArgs) -> Result<()> {
         }
     }
 
+    let untracked_before_agent = untracked_files(&repo_root);
+
     spawn_setup_agent(&repo_root, &args.overrides, ctx.cli.verbose, &login)?;
 
     // Post-agent cleanup: re-normalize in case the agent mangled required sections,
     // then commit+push the agent's changes (PROGRAM.md/PREPARE.md with project details).
     normalize_program_md(&repo_root)?;
     normalize_file_endings(&repo_root)?;
-    commit_and_push_setup_files(&repo_root)?;
+    let untracked_after_agent = untracked_files(&repo_root);
+    let mut agent_created_files: Vec<String> = untracked_after_agent
+        .difference(&untracked_before_agent)
+        .cloned()
+        .collect();
+    agent_created_files.sort();
+    commit_and_push_setup_files(&repo_root, &agent_created_files)?;
 
     eprintln!("Bootstrap complete.");
     Ok(())
@@ -386,10 +395,21 @@ fn spawn_setup_agent(
     Ok(())
 }
 
-pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
+fn untracked_files(repo_root: &Path) -> HashSet<String> {
+    commands::run_git(
+        &repo_root.to_path_buf(),
+        &["status", "--porcelain", "--untracked-files=all"],
+    )
+    .unwrap_or_default()
+    .lines()
+    .filter_map(|line| line.strip_prefix("?? ").map(str::to_string))
+    .collect()
+}
+
+pub fn commit_and_push_setup_files(repo_root: &Path, extra_paths: &[String]) -> Result<()> {
     let repo = repo_root.to_path_buf();
 
-    let setup_paths: Vec<&str> = [
+    let mut setup_paths: Vec<String> = [
         "PROGRAM.md",
         "PREPARE.md",
         "results.tsv",
@@ -398,25 +418,36 @@ pub fn commit_and_push_setup_files(repo_root: &Path) -> Result<()> {
     ]
     .into_iter()
     .filter(|f| repo_root.join(f).exists())
+    .map(str::to_string)
     .collect();
+
+    for path in extra_paths {
+        if repo_root.join(path).exists() && !setup_paths.contains(path) {
+            setup_paths.push(path.clone());
+        }
+    }
+
+    setup_paths.sort();
 
     if setup_paths.is_empty() {
         return Ok(());
     }
 
+    let setup_path_refs: Vec<&str> = setup_paths.iter().map(String::as_str).collect();
+
     let mut reset_args: Vec<&str> = vec!["reset", "--"];
-    reset_args.extend(&setup_paths);
+    reset_args.extend(setup_path_refs.iter().copied());
     let _ = commands::run_git(&repo, &reset_args);
 
     let mut add_args: Vec<&str> = vec!["add", "-f", "--"];
-    add_args.extend(&setup_paths);
+    add_args.extend(setup_path_refs.iter().copied());
     commands::run_git(&repo, &add_args)?;
 
     // Query which of our paths actually have staged changes. This scopes the
     // commit to only setup files (preventing leakage from a dirty index) and
     // avoids "pathspec didn't match" errors on empty directories like .polyresearch/.
     let mut diff_args: Vec<&str> = vec!["diff", "--cached", "--name-only", "--"];
-    diff_args.extend(&setup_paths);
+    diff_args.extend(setup_path_refs.iter().copied());
     let diff_output = commands::run_git(&repo, &diff_args).unwrap_or_default();
     let staged_files: Vec<String> = diff_output
         .lines()

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2989,7 +2989,7 @@ async fn bootstrap_commit_cleans_agent_whitespace_diffs() {
     fs::write(&program_path, staged_program.trim_end()).unwrap();
     fs::write(&prepare_path, format!("{}  \n", staged_prepare.trim_end())).unwrap();
 
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     let status_output = Command::new("git")
         .args([
@@ -3078,7 +3078,7 @@ async fn bootstrap_commits_setup_files_with_allowlist_gitignore() {
         "expected setup files to be ignored by allowlist .gitignore, got: {ignored}"
     );
 
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Verify git status is clean for setup files even though .gitignore hides them.
     let status_output = Command::new("git")

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1817,7 +1817,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1844,7 +1846,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -1894,7 +1898,9 @@ async fn duties_lead_duties_included_in_lead_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1921,7 +1927,9 @@ async fn duties_lead_duties_included_in_lead_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2056,7 +2064,9 @@ async fn duties_submit_skipped_when_pr_merged() {
             created_at: now,
             closed_at: Some(now),
             merged_at: Some(now),
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2473,7 +2483,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -2501,7 +2513,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2524,7 +2538,8 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         "lead context should see decide as blocking"
     );
 
-    let contribute_report = commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
+    let contribute_report =
+        commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
     assert!(
         contribute_report.blocking.is_empty(),
         "contribute context must not be blocked by lead duties; got: {:?}",
@@ -2872,7 +2887,6 @@ async fn bootstrap_commits_setup_files() {
 
     commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
-
     let check_ignore_output = Command::new("git")
         .args(["check-ignore", ".polyresearch-node.toml"])
         .current_dir(&repo.path)
@@ -2883,7 +2897,7 @@ async fn bootstrap_commits_setup_files() {
         ".polyresearch-node.toml should be gitignored"
     );
 
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Verify git status is clean for setup files
     let status_output = Command::new("git")
@@ -3098,6 +3112,63 @@ async fn bootstrap_commits_setup_files_with_allowlist_gitignore() {
 }
 
 #[tokio::test]
+async fn bootstrap_commits_agent_created_benchmark_files() {
+    let repo = TestRepo::new("bootstrap-benchmark-files");
+    init_git_repo(&repo.path);
+
+    let bare = TestRepo::new("bootstrap-benchmark-files-bare");
+    let _ = fs::remove_dir_all(&bare.path);
+    Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            &repo.path.to_string_lossy(),
+            &bare.path.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    run_git(
+        &repo.path,
+        &["remote", "add", "origin", &bare.path.to_string_lossy()],
+    );
+
+    commands::bootstrap::write_templates(&repo.path, Some("Test goal"), "lead").unwrap();
+    commands::bootstrap::normalize_program_md(&repo.path).unwrap();
+
+    fs::create_dir_all(repo.path.join("bench")).unwrap();
+    fs::write(
+        repo.path.join("bench/eval.js"),
+        "console.log('benchmark helper');\n",
+    )
+    .unwrap();
+
+    let extra_paths = vec!["bench/eval.js".to_string()];
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &extra_paths).unwrap();
+
+    let show_output = Command::new("git")
+        .args(["show", "HEAD", "--name-only", "--format="])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let files = String::from_utf8(show_output.stdout).unwrap();
+    assert!(
+        files.contains("bench/eval.js"),
+        "bench/eval.js not in commit: {files}"
+    );
+
+    let status_output = Command::new("git")
+        .args(["status", "--porcelain", "--", "bench/eval.js"])
+        .current_dir(&repo.path)
+        .output()
+        .unwrap();
+    let status = String::from_utf8(status_output.stdout).unwrap();
+    assert!(
+        status.trim().is_empty(),
+        "benchmark helper should be clean after commit, got: {status}"
+    );
+}
+
+#[tokio::test]
 async fn bootstrap_commit_is_idempotent() {
     let repo = TestRepo::new("bootstrap-commit-idempotent");
     init_git_repo(&repo.path);
@@ -3120,10 +3191,10 @@ async fn bootstrap_commit_is_idempotent() {
 
     commands::bootstrap::write_templates(&repo.path, None, "lead").unwrap();
     commands::bootstrap::normalize_program_md(&repo.path).unwrap();
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Second call should not error (nothing to commit)
-    commands::bootstrap::commit_and_push_setup_files(&repo.path).unwrap();
+    commands::bootstrap::commit_and_push_setup_files(&repo.path, &[]).unwrap();
 
     // Should still be only one setup commit
     let log_output = Command::new("git")
@@ -6578,11 +6649,11 @@ async fn decide_excludes_acknowledged_invalid_from_best_metric() {
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state_with_poisoned_prior(
-        1,     // thesis_number (current)
-        50,    // pr_number (current)
-        20421.0, // current_metric
-        15000.0, // baseline
-        17658.0, // prior_valid_metric
+        1,        // thesis_number (current)
+        50,       // pr_number (current)
+        20421.0,  // current_metric
+        15000.0,  // baseline
+        17658.0,  // prior_valid_metric
         218000.0, // poisoned_metric
         "lead",
     );


### PR DESCRIPTION
## Summary
- commit benchmark helper files created by the bootstrap agent so `PREPARE.md` never points at missing evaluators
- preserve the newer hybrid bootstrap cleanup while extending `commit_and_push_setup_files()` to stage extra agent-created files
- update bootstrap e2e coverage for the helper-file path and the new helper signature

## Dependency
This PR replaces #158, which targeted `main` by mistake.

This branch still depends on #161 for a clean full-suite run because `hybrid-agent-cli` currently has the preexisting `scenario_sync_accepts_master_default_branch` failure until that sync fix lands.

## Test plan
- [x] `cargo test bootstrap_commits_ --test e2e`
- [ ] `cargo test` (`tests/scenarios.rs::scenario_sync_accepts_master_default_branch` still fails on the current `hybrid-agent-cli` base)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap’s git staging/commit logic and expands what files can be committed automatically based on detected untracked paths, which could accidentally capture unintended files if detection is wrong.
> 
> **Overview**
> Bootstrap now snapshots untracked files before/after the setup agent runs and includes any newly-created paths in the setup commit, extending `commit_and_push_setup_files` to accept and stage extra file paths.
> 
> The bootstrap setup prompt is updated to direct evaluation helper scripts into `.polyresearch/` or `bench/`, and e2e coverage is updated for the new commit function signature plus a new test that verifies agent-created benchmark helpers are committed and leave a clean working tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19b59678516bfbe35a0d03b205e7a80ae43511c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->