### PR TITLE
Replace surface strip with fail-hard editable-surface enforcement

### DIFF
--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -1,0 +1,101 @@
+You are a polyresearch contributor agent. You claim theses from the queue, run experiments in git worktrees, and report results using CLI commands. You run in a loop until interrupted.
+
+Your working directory is the project root. Thesis experiments happen in worktrees under .worktrees/. Never modify files in the project root - that checkout belongs to the lead.
+
+## Available commands
+
+All coordination goes through the `polyresearch` CLI. Key commands:
+
+- `polyresearch duties` - check for blocking duties. Resolve them before claiming new work.
+- `polyresearch pace` - check hardware budget and API quota. Tells you how many parallel theses you can run.
+- `polyresearch status` - see queue depth, thesis states, claimable work.
+- `polyresearch claim <issue>` - claim a thesis. Prints the worktree path.
+- `polyresearch attempt <issue> --metric <val> --baseline <val> --observation <obs> --summary "<text>"` - record an experiment result.
+- `polyresearch commit <issue> [--message "..."]` - commit only editable-surface changes. Always use this instead of raw `git commit`.
+- `polyresearch submit <issue>` - push and create a PR for an improved thesis. Run from the thesis worktree.
+- `polyresearch release <issue> --reason <no_improvement|timeout|infra_failure>` - release a claim.
+- `polyresearch batch-claim --count N` - claim multiple theses at once.
+- `polyresearch prune` - remove worktrees for resolved/rejected theses and clean up stale directories.
+
+Use `--help` on any command for full flag documentation.
+
+## The loop
+
+LOOP FOREVER:
+
+### 1. Check duties
+
+Run `polyresearch duties`. If blocking duties exist, resolve each one:
+- `submit`: go to the thesis worktree, run `polyresearch submit <issue>`.
+- If submit fails because a PR already exists for the branch, check if the PR was closed. If closed as stale (merge conflicts), try rebasing the branch onto the default branch and resubmit. If the PR was decided as `no_improvement`, release the thesis instead: `polyresearch release <issue> --reason no_improvement`.
+
+### 2. Check pace and compute parallelism
+
+Run `polyresearch pace --json` and parse the JSON output. The key fields are:
+
+- `budget.cores` - CPU cores allocated to you (already scaled by your capacity %)
+- `budget.memory_gb` - memory allocated to you
+- `hardware.available_memory_gb` - memory currently free on the machine
+
+Then read `eval_cores` and `eval_memory_gb` from PREPARE.md. These define the resource footprint of a single experiment run.
+
+Compute how many experiments you can run in parallel:
+
+```
+effective_memory = min(budget.memory_gb, hardware.available_memory_gb)
+by_cores  = floor(budget.cores / eval_cores)
+by_memory = floor(effective_memory / eval_memory_gb)
+max_slots = min(by_cores, by_memory)
+```
+
+If `max_slots` is 0 (machine is overloaded or undersized for the eval footprint), wait 60 seconds and re-check pace before claiming work. If `max_slots` stays 0 after 3 consecutive checks (~3 minutes), set `max_slots = 1` and continue. The machine is permanently undersized for the eval footprint; running one experiment slowly is better than running none.
+
+Also check `rate_limit.is_low`. If true, wait for the reset window (`rate_limit.resets_at`) before making more API requests.
+
+### 3. Find and claim work
+
+Run `polyresearch status` to see claimable theses. Claim up to `max_slots` theses (use `batch-claim --count N` when N > 1). Never claim more theses than your computed `max_slots` allows.
+
+If no work is available, sleep 60 seconds and restart the loop.
+
+### 4. Run the experiment
+
+For each claimed thesis:
+1. The claim command prints the worktree path. `cd` into it.
+2. Read `.polyresearch/thesis.md` for the thesis context and prior attempts.
+3. Run the experiment: implement the idea, run the evaluation per PREPARE.md, iterate if needed.
+4. Write `.polyresearch/result.json` with the result.
+
+Always run experiments sequentially (one at a time), even if you claimed multiple theses. Benchmarks running concurrently compete for CPU, memory, and I/O, which corrupt measurements. `max_slots` controls how many theses you claim per loop iteration, not how many benchmarks you run simultaneously. If you have multiple claimed theses, re-run `polyresearch pace --json` between experiments to adapt to changing system load.
+
+### 5. Record and act on the result
+
+After the experiment, read `.polyresearch/result.json`:
+
+- If improved: run `polyresearch attempt <issue> --metric <val> --baseline <val> --observation improved --summary "<text>"`, then run `polyresearch commit <issue>` and `polyresearch submit <issue>` from the worktree.
+- If `no_improvement`: run `polyresearch attempt <issue> --metric <val> --baseline <val> --observation no_improvement --summary "<text>"`, then `polyresearch release <issue> --reason no_improvement`.
+- If crashed: run `polyresearch attempt <issue> --metric <val> --baseline <val> --observation crashed --summary "<text>"`, then `polyresearch release <issue> --reason infra_failure`.
+
+### 6. Clean up
+
+After releasing a thesis, remove its worktree: `git worktree remove --force <path>`. For submitted (improved) theses, keep the worktree alive until the lead decides the PR - the lead may request revisions.
+
+Then run `polyresearch prune` to remove worktrees for any theses that have been resolved or rejected since the last iteration. This covers submitted theses whose PRs were decided while you were working on other theses.
+
+### 7. Sleep and repeat
+
+Sleep 60 seconds, then go back to step 1.
+
+## Edge case handling
+
+- A thesis keeps crashing: if you have released the same thesis as `infra_failure` multiple times, skip it. Something is structurally wrong with that thesis.
+- Merge conflicts on submit: rebase the thesis branch onto the default branch (`git rebase origin/<default-branch>`), resolve conflicts, then retry submit.
+- Rate limit hit: wait and retry. The CLI will print retry guidance.
+- No claimable work for extended periods: this is normal. The lead generates theses when the queue runs low. Keep looping.
+
+## Important
+
+- Never run `polyresearch sync`, `polyresearch decide`, `polyresearch policy-check`, or `polyresearch generate`. Those are lead-only commands.
+- Never modify files in the project root checkout. Work only in .worktrees/ thesis worktrees.
+- Do not use raw `git add .` or `git commit` for code changes. `polyresearch commit` automatically stages only files within the editable surface.
+- Always record your attempt via `polyresearch attempt` before submitting or releasing. The protocol requires it.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -34,6 +34,7 @@ pub enum Commands {
     Pace,
     Status(StatusArgs),
     Claim(IssueArgs),
+    Commit(CommitArgs),
     BatchClaim(BatchClaimArgs),
     Attempt(AttemptArgs),
     Annotate(AnnotateArgs),
@@ -100,6 +101,14 @@ pub struct StatusArgs {
 #[derive(Debug, Args, Clone)]
 pub struct IssueArgs {
     pub issue: u64,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CommitArgs {
+    pub issue: u64,
+
+    #[arg(long)]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -1,0 +1,60 @@
+use color_eyre::eyre::{Result, eyre};
+use serde::Serialize;
+
+use crate::cli::CommitArgs;
+use crate::commands::guards::require_claimed_thesis;
+use crate::commands::{AppContext, current_branch, print_value, read_node_id, run_git};
+use crate::editable_surface::EditableSurface;
+use crate::state::RepositoryState;
+
+#[derive(Debug, Serialize)]
+struct CommitOutput {
+    issue: u64,
+    branch: String,
+    message: String,
+}
+
+pub async fn run(ctx: &AppContext, args: &CommitArgs) -> Result<()> {
+    let node = read_node_id(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let thesis = require_claimed_thesis(&repo_state, args.issue, &node)?;
+
+    let branch = current_branch(&ctx.repo_root)?;
+    if !branch.starts_with(&format!("thesis/{}-", args.issue)) {
+        return Err(eyre!(
+            "current branch `{branch}` does not look like a thesis branch for issue #{}",
+            args.issue
+        ));
+    }
+
+    let summary = args
+        .message
+        .clone()
+        .unwrap_or_else(|| thesis.issue.title.clone());
+    let message = format!("thesis/{}: {summary}", args.issue);
+
+    if !ctx.cli.dry_run {
+        EditableSurface::from_program(&ctx.program).stage_and_validate(&ctx.repo_root)?;
+        run_git(&ctx.repo_root, &["commit", "-m", &message])?;
+    }
+
+    let output = CommitOutput {
+        issue: args.issue,
+        branch,
+        message,
+    };
+
+    print_value(ctx, &output, |value| {
+        if ctx.cli.dry_run {
+            format!(
+                "Would commit editable-surface changes for thesis #{} on `{}` as `{}`.",
+                value.issue, value.branch, value.message
+            )
+        } else {
+            format!(
+                "Committed editable-surface changes for thesis #{} on `{}` as `{}`.",
+                value.issue, value.branch, value.message
+            )
+        }
+    })
+}

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -9,6 +9,7 @@ use crate::cli::ContributeArgs;
 use crate::commands::{self, AppContext};
 use crate::comments::{Observation, ProtocolComment, ReleaseReason};
 use crate::config::{NodeConfig, ProgramSpec, ProtocolConfig};
+use crate::editable_surface::EditableSurface;
 use crate::github::{GitHubApi, GitHubClient, RepoRef};
 use crate::hardware;
 use crate::state::{RepositoryState, ThesisPhase, ThesisState};
@@ -109,6 +110,7 @@ async fn run_iteration(
     node_config: &NodeConfig,
 ) -> Result<()> {
     let mut repo_state = RepositoryState::derive(&ctx.github, config).await?;
+    let surface = EditableSurface::from_program(program);
 
     // Auto-submit any improved theses that lack an open PR.
     let mut submitted_any = false;
@@ -153,6 +155,19 @@ async fn run_iteration(
                     }
                     continue;
                 }
+                if let Err(err) = commands::submit::ensure_submittable(
+                    &worktree_path,
+                    &surface,
+                    default_branch,
+                    &branch,
+                    thesis.issue.number,
+                ) {
+                    eprintln!(
+                        "Warning: thesis #{} is not ready to submit: {err}",
+                        thesis.issue.number
+                    );
+                    continue;
+                }
                 if !ctx.cli.dry_run {
                     match commands::run_git(&worktree_path, &["push", "-u", "origin", &branch]) {
                         Ok(_) => match ctx.github.create_pull_request(
@@ -183,7 +198,11 @@ async fn run_iteration(
         repo_state = RepositoryState::derive(&ctx.github, config).await?;
     }
 
-    let duty_report = crate::commands::duties::check(ctx, &repo_state, crate::commands::duties::DutyContext::Contribute)?;
+    let duty_report = crate::commands::duties::check(
+        ctx,
+        &repo_state,
+        crate::commands::duties::DutyContext::Contribute,
+    )?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report
             .blocking
@@ -205,7 +224,9 @@ async fn run_iteration(
 
     let claimable_ignoring_cooldown = claimable_theses(&repo_state, node_id, 0);
     let claimable = claimable_theses(&repo_state, node_id, args.sleep_secs);
-    let cooldown_skipped = claimable_ignoring_cooldown.len().saturating_sub(claimable.len());
+    let cooldown_skipped = claimable_ignoring_cooldown
+        .len()
+        .saturating_sub(claimable.len());
     if cooldown_skipped > 0 {
         eprintln!("{cooldown_skipped} thesis(es) skipped due to crash cooldown");
     }
@@ -386,7 +407,10 @@ pub fn is_crash_cooldown(
 
     for r in &thesis.releases {
         if r.node == node_id
-            && matches!(r.reason, ReleaseReason::InfraFailure | ReleaseReason::Timeout)
+            && matches!(
+                r.reason,
+                ReleaseReason::InfraFailure | ReleaseReason::Timeout
+            )
         {
             count += 1;
             last_crash = Some(match last_crash {
@@ -477,7 +501,6 @@ fn parse_eval_footprint_memory(repo_root: &Path) -> f64 {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0)
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -611,10 +634,7 @@ mod tests {
         let now = Utc::now();
         let mut releases = Vec::new();
         for i in 0..20 {
-            releases.push(infra_release(
-                "node-a",
-                now - chrono::Duration::seconds(i),
-            ));
+            releases.push(infra_release("node-a", now - chrono::Duration::seconds(i)));
         }
         let thesis = make_thesis_with_releases(releases);
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod batch_claim;
 pub mod bootstrap;
 pub mod claim;
+pub mod commit;
 pub mod contribute;
 pub mod decide;
 pub mod duties;
@@ -66,6 +67,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Pace => pace::run(&ctx).await,
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
+        Commands::Commit(args) => commit::run(&ctx, args).await,
         Commands::BatchClaim(args) => batch_claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,
         Commands::Annotate(args) => annotate::run(&ctx, args).await,

--- a/cli/src/commands/policy_check.rs
+++ b/cli/src/commands/policy_check.rs
@@ -5,6 +5,7 @@ use crate::cli::PrArgs;
 use crate::commands::guards::{ensure_current_ledger, ensure_lead, require_pull_request};
 use crate::commands::{AppContext, print_value};
 use crate::comments::{Outcome, ProtocolComment};
+use crate::editable_surface::EditableSurface;
 use crate::state::{RepositoryState, parse_thesis_number_from_branch};
 
 #[derive(Debug, Serialize)]
@@ -30,19 +31,10 @@ pub async fn run(ctx: &AppContext, args: &PrArgs) -> Result<()> {
         return Err(eyre!("PR #{} already has a policy-pass", args.pr));
     }
 
+    let surface = EditableSurface::from_program(&ctx.program);
     let files = ctx.github.list_pull_request_files(args.pr)?;
-    let violations = files
-        .into_iter()
-        .filter_map(|file| {
-            let editable = ctx.program.is_editable(&file.filename).unwrap_or(false);
-            let protected = ctx.program.is_protected(&file.filename);
-            if editable && !protected {
-                None
-            } else {
-                Some(file.filename)
-            }
-        })
-        .collect::<Vec<_>>();
+    let violations =
+        surface.violations_for_paths(files.iter().map(|file| file.filename.as_str()))?;
 
     let passed = violations.is_empty();
     if !ctx.cli.dry_run {

--- a/cli/src/commands/submit.rs
+++ b/cli/src/commands/submit.rs
@@ -1,10 +1,15 @@
+use std::path::PathBuf;
+
 use color_eyre::eyre::{Result, eyre};
 use serde::Serialize;
 
 use crate::cli::IssueArgs;
 use crate::commands::guards::require_claimed_thesis;
-use crate::commands::{AppContext, current_branch, print_value, push_current_branch, read_node_id};
+use crate::commands::{
+    AppContext, current_branch, print_value, push_current_branch, read_node_id, run_git,
+};
 use crate::comments::Observation;
+use crate::editable_surface::EditableSurface;
 use crate::state::RepositoryState;
 
 #[derive(Debug, Serialize)]
@@ -40,11 +45,19 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
         return Err(eyre!("branch `{branch}` already has an open PR"));
     }
 
+    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+    ensure_submittable(
+        &ctx.repo_root,
+        &EditableSurface::from_program(&ctx.program),
+        &default_branch,
+        &branch,
+        args.issue,
+    )?;
+
     if !ctx.cli.dry_run {
         push_current_branch(&ctx.repo_root)?;
     }
 
-    let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
     let pr = if ctx.cli.dry_run {
         None
     } else {
@@ -85,4 +98,61 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
             )
         }
     })
+}
+
+pub fn ensure_submittable(
+    repo_root: &PathBuf,
+    surface: &EditableSurface,
+    default_branch: &str,
+    branch: &str,
+    issue: u64,
+) -> Result<()> {
+    let changed_files = changed_submission_files(repo_root, surface, default_branch)?;
+    if changed_files.is_empty() {
+        return Err(eyre!(
+            "branch `{branch}` has no file changes compared to `{default_branch}`; nothing to submit"
+        ));
+    }
+
+    let violations = check_editable_surface(repo_root, surface, default_branch)?;
+    if !violations.is_empty() {
+        return Err(eyre!(
+            "branch `{branch}` has {} file(s) outside the editable surface: {}. Use `polyresearch commit {issue}` to re-commit only editable changes.",
+            violations.len(),
+            violations.join(", ")
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn changed_submission_files(
+    repo_root: &PathBuf,
+    surface: &EditableSurface,
+    default_branch: &str,
+) -> Result<Vec<String>> {
+    let diff_ref = diff_ref(repo_root, default_branch);
+    surface.changed_files_against(repo_root, &diff_ref)
+}
+
+pub fn check_editable_surface(
+    repo_root: &PathBuf,
+    surface: &EditableSurface,
+    default_branch: &str,
+) -> Result<Vec<String>> {
+    let diff_ref = diff_ref(repo_root, default_branch);
+    surface.violations_against(repo_root, &diff_ref)
+}
+
+fn submission_base_ref(repo_root: &PathBuf, default_branch: &str) -> String {
+    let remote_ref = format!("origin/{default_branch}");
+    if run_git(repo_root, &["rev-parse", "--verify", &remote_ref]).is_ok() {
+        remote_ref
+    } else {
+        default_branch.to_string()
+    }
+}
+
+fn diff_ref(repo_root: &PathBuf, default_branch: &str) -> String {
+    format!("{}...HEAD", submission_base_ref(repo_root, default_branch))
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -445,6 +445,13 @@ pub struct ProgramSpec {
 }
 
 impl ProgramSpec {
+    pub fn from_globs(can_modify: Vec<String>, cannot_modify: Vec<String>) -> Self {
+        Self {
+            can_modify,
+            cannot_modify,
+        }
+    }
+
     pub fn load(repo_root: &Path, _config: &ProtocolConfig) -> Result<Self> {
         let path = repo_root.join("PROGRAM.md");
         let contents = fs::read_to_string(&path)
@@ -453,10 +460,7 @@ impl ProgramSpec {
         let can_modify = parse_markdown_list(&contents, "## What you CAN modify");
         let cannot_modify = parse_markdown_list(&contents, "## What you CANNOT modify");
 
-        Ok(Self {
-            can_modify,
-            cannot_modify,
-        })
+        Ok(Self::from_globs(can_modify, cannot_modify))
     }
 
     pub fn editable_globset(&self) -> Result<GlobSet> {

--- a/cli/src/editable_surface.rs
+++ b/cli/src/editable_surface.rs
@@ -1,0 +1,226 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use color_eyre::eyre::{Result, eyre};
+
+use crate::commands::run_git;
+use crate::config::ProgramSpec;
+
+pub const ALWAYS_PROTECTED: [&str; 4] = [
+    ".polyresearch/",
+    ".polyresearch-node.toml",
+    "PROGRAM.md",
+    "PREPARE.md",
+];
+
+#[derive(Debug, Clone)]
+pub struct EditableSurface {
+    program: ProgramSpec,
+}
+
+impl EditableSurface {
+    pub fn new(editable_globs: Vec<String>, protected_globs: Vec<String>) -> Self {
+        Self {
+            program: canonicalize_program(ProgramSpec::from_globs(editable_globs, protected_globs)),
+        }
+    }
+
+    pub fn from_program(program: &ProgramSpec) -> Self {
+        Self {
+            program: canonicalize_program(program.clone()),
+        }
+    }
+
+    pub fn allows_path(&self, file_path: &str) -> Result<bool> {
+        Ok(self.program.is_editable(file_path)? && !self.program.is_protected(file_path))
+    }
+
+    pub fn stage_and_validate(&self, repo_root: &PathBuf) -> Result<()> {
+        clear_staging(repo_root)?;
+
+        for file in working_tree_changes(repo_root)? {
+            if self.allows_path(&file)? {
+                run_git(repo_root, &["add", "--all", "--", &file])?;
+            }
+        }
+
+        let violations = self.validate_staged_files(repo_root)?;
+        if !violations.is_empty() {
+            clear_staging(repo_root)?;
+            return Err(eyre!(
+                "staged files outside the editable surface: {}",
+                violations.join(", ")
+            ));
+        }
+
+        if self.staged_files(repo_root)?.is_empty() {
+            return Err(eyre!("no changes to commit within the editable surface"));
+        }
+
+        Ok(())
+    }
+
+    pub fn staged_files(&self, repo_root: &PathBuf) -> Result<Vec<String>> {
+        let output = run_git(repo_root, &["diff", "--cached", "--name-only"])?;
+        Ok(parse_output_lines(&output))
+    }
+
+    pub fn validate_staged_files(&self, repo_root: &PathBuf) -> Result<Vec<String>> {
+        let staged = self.staged_files(repo_root)?;
+        self.violations_for_paths(staged.iter().map(String::as_str))
+    }
+
+    pub fn changed_files_against(
+        &self,
+        repo_root: &PathBuf,
+        diff_ref: &str,
+    ) -> Result<Vec<String>> {
+        let output = run_git(repo_root, &["diff", "--name-only", diff_ref])?;
+        Ok(parse_output_lines(&output))
+    }
+
+    pub fn violations_against(&self, repo_root: &PathBuf, diff_ref: &str) -> Result<Vec<String>> {
+        let changed = self.changed_files_against(repo_root, diff_ref)?;
+        self.violations_for_paths(changed.iter().map(String::as_str))
+    }
+
+    pub fn violations_for_paths<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Vec<String>> {
+        let mut violations = Vec::new();
+        for file in paths {
+            if !self.allows_path(file)? {
+                violations.push(file.to_string());
+            }
+        }
+        Ok(violations)
+    }
+}
+
+fn canonicalize_program(mut program: ProgramSpec) -> ProgramSpec {
+    for path in ALWAYS_PROTECTED {
+        if !program
+            .cannot_modify
+            .iter()
+            .any(|existing| existing == path)
+        {
+            program.cannot_modify.push(path.to_string());
+        }
+    }
+    program
+}
+
+fn clear_staging(repo_root: &PathBuf) -> Result<()> {
+    run_git(repo_root, &["reset", "HEAD", "--", "."])?;
+    Ok(())
+}
+
+fn working_tree_changes(repo_root: &PathBuf) -> Result<Vec<String>> {
+    let mut files = BTreeSet::new();
+    for args in [
+        &["diff", "--name-only", "--relative"][..],
+        &["diff", "--cached", "--name-only", "--relative"][..],
+        &["ls-files", "--others", "--exclude-standard"][..],
+    ] {
+        let output = run_git(repo_root, args)?;
+        files.extend(parse_output_lines(&output));
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn parse_output_lines(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::EditableSurface;
+
+    fn test_repo(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("polyresearch-editable-surface-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn git(path: &PathBuf, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo(path: &PathBuf) {
+        git(path, &["init"]);
+        git(path, &["config", "user.name", "Test User"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        fs::write(path.join("README.md"), "test\n").unwrap();
+        git(path, &["add", "README.md"]);
+        git(path, &["commit", "-m", "init"]);
+        git(path, &["branch", "-M", "main"]);
+    }
+
+    #[test]
+    fn validate_staged_files_rejects_protected_paths() {
+        let repo = test_repo("validate-staged");
+        init_repo(&repo);
+
+        fs::create_dir_all(repo.join("src")).unwrap();
+        fs::create_dir_all(repo.join(".polyresearch")).unwrap();
+        fs::write(repo.join("src/app.ts"), "export const value = 1;\n").unwrap();
+        fs::write(repo.join(".polyresearch/result.json"), "{\"metric\":1}\n").unwrap();
+        git(&repo, &["add", "src/app.ts", ".polyresearch/result.json"]);
+
+        let surface = EditableSurface::new(vec!["src/".to_string()], vec![]);
+        let violations = surface.validate_staged_files(&repo).unwrap();
+        assert_eq!(violations, vec![".polyresearch/result.json".to_string()]);
+
+        let _ = fs::remove_dir_all(&repo);
+    }
+
+    #[test]
+    fn stage_and_validate_commits_only_allowed_changes() {
+        let repo = test_repo("stage-and-validate");
+        init_repo(&repo);
+
+        fs::create_dir_all(repo.join("src")).unwrap();
+        fs::write(repo.join("src/app.ts"), "export const value = 1;\n").unwrap();
+        git(&repo, &["add", "src/app.ts"]);
+        git(&repo, &["commit", "-m", "add source"]);
+
+        fs::create_dir_all(repo.join(".polyresearch")).unwrap();
+        fs::write(repo.join("src/app.ts"), "export const value = 2;\n").unwrap();
+        fs::write(repo.join(".polyresearch/result.json"), "{\"metric\":2}\n").unwrap();
+
+        let surface = EditableSurface::new(vec!["src/".to_string()], vec![]);
+        surface.stage_and_validate(&repo).unwrap();
+
+        let staged = git(&repo, &["diff", "--cached", "--name-only"]);
+        assert_eq!(staged, "src/app.ts");
+
+        let _ = fs::remove_dir_all(&repo);
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod commands;
 pub mod comments;
 pub mod config;
+pub mod editable_surface;
 pub mod github;
 pub mod github_debug;
 pub mod hardware;

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -8,6 +8,7 @@ use crate::agent::{self, AgentOutcome, ExperimentResult, RecoveredMetric};
 use crate::commands;
 use crate::comments::{Observation, ProtocolComment, ReleaseReason};
 use crate::config::MetricDirection;
+use crate::editable_surface::EditableSurface;
 use crate::github::GitHubApi;
 use crate::state::ThesisState;
 
@@ -200,6 +201,16 @@ impl ThesisWorker {
 
         if result.is_improved() && !dry_run {
             self.commit_editable_surface()?;
+            commands::submit::ensure_submittable(
+                &self.worktree_path,
+                &EditableSurface::new(
+                    self.ctx.editable_globs.clone(),
+                    self.ctx.protected_globs.clone(),
+                ),
+                &self.ctx.default_branch,
+                &self.branch,
+                self.ctx.issue_number,
+            )?;
             commands::run_git(&self.worktree_path, &["push", "-u", "origin", &self.branch])?;
 
             let default_branch = &self.ctx.default_branch;
@@ -392,28 +403,11 @@ impl ThesisWorker {
     }
 
     fn commit_editable_surface(&self) -> Result<()> {
-        for glob in &self.ctx.editable_globs {
-            let _ = commands::run_git(&self.worktree_path, &["add", glob]);
-        }
-
-        let always_protected = [
-            ".polyresearch/",
-            ".polyresearch-node.toml",
-            "PROGRAM.md",
-            "PREPARE.md",
-        ];
-        for path in &always_protected {
-            let _ = commands::run_git(&self.worktree_path, &["reset", "HEAD", "--", path]);
-        }
-        for glob in &self.ctx.protected_globs {
-            let _ = commands::run_git(&self.worktree_path, &["reset", "HEAD", "--", glob]);
-        }
-
-        let has_staged =
-            commands::run_git(&self.worktree_path, &["diff", "--cached", "--quiet"]).is_err();
-        if !has_staged {
-            return Err(eyre!("no changes to commit within the editable surface"));
-        }
+        EditableSurface::new(
+            self.ctx.editable_globs.clone(),
+            self.ctx.protected_globs.clone(),
+        )
+        .stage_and_validate(&self.worktree_path)?;
 
         commands::run_git(
             &self.worktree_path,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -10,7 +10,7 @@ use color_eyre::eyre::{Result, eyre};
 use polyresearch::agent;
 use polyresearch::cli::{
     AdminArgs, AdminCommands, AdminReleaseClaimArgs, AdminReopenThesisArgs, AttemptArgs,
-    BatchClaimArgs, Cli, Commands, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
+    BatchClaimArgs, Cli, Commands, CommitArgs, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
     NodeOverrides, PrArgs, ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
@@ -352,6 +352,67 @@ fn run_git(path: &PathBuf, args: &[&str]) {
         args,
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn git_output(path: &PathBuf, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn write_program_md_with_surface(path: &PathBuf, can_modify: &[&str], cannot_modify: &[&str]) {
+    let can_modify = can_modify
+        .iter()
+        .map(|pattern| format!("- `{pattern}`"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let cannot_modify = cannot_modify
+        .iter()
+        .map(|pattern| format!("- `{pattern}`"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        path.join("PROGRAM.md"),
+        format!(
+            "required_confirmations: 0\n\
+             metric_tolerance: 0.01\n\
+             metric_direction: higher_is_better\n\
+             lead_github_login: lead\n\
+             maintainer_github_login: lead\n\
+             auto_approve: true\n\
+             assignment_timeout: 24h\n\
+             review_timeout: 12h\n\
+             min_queue_depth: 0\n\
+             max_queue_depth: 5\n\
+             cli_version: 0.5.3\n\
+             \n\
+             ## Goal\n\
+             \n\
+             Test goal.\n\
+             \n\
+             ## What you CAN modify\n\
+             \n\
+             {can_modify}\n\
+             \n\
+             ## What you CANNOT modify\n\
+             \n\
+             {cannot_modify}\n\
+             \n\
+             ## Constraints\n\
+             \n\
+             Keep tests deterministic.\n"
+        ),
+    )
+    .unwrap();
 }
 
 fn env_lock() -> &'static Mutex<()> {
@@ -899,6 +960,329 @@ async fn attempt_rejects_node_without_canonical_claim() {
     .await
     .unwrap_err();
     assert!(error.to_string().contains("not currently claimed"));
+}
+
+#[tokio::test]
+async fn commit_command_commits_only_editable_surface_changes() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("commit-surface");
+    init_git_repo(&repo.path);
+    write_program_md_with_surface(&repo.path, &["src/"], &[]);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/app.ts"), "export const value = 1;\n").unwrap();
+    run_git(&repo.path, &["add", "PROGRAM.md", "src/app.ts"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+    run_git(&repo.path, &["checkout", "-b", "thesis/60-commit-surface"]);
+
+    fs::write(repo.path.join("src/app.ts"), "export const value = 2;\n").unwrap();
+    fs::create_dir_all(repo.path.join(".polyresearch")).unwrap();
+    fs::write(
+        repo.path.join(".polyresearch/result.json"),
+        "{\"metric\":2}\n",
+    )
+    .unwrap();
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 60,
+        title: "Commit surface".to_string(),
+        body: Some("Test thesis.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+    };
+    let comments = vec![
+        IssueComment {
+            id: 6001,
+            body: ProtocolComment::Approval { thesis: 60 }.render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::hours(1),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 6002,
+            body: ProtocolComment::Claim {
+                thesis: 60,
+                node: "test-node".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(50),
+            updated_at: None,
+        },
+    ];
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(60, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Commit(CommitArgs {
+            issue: 60,
+            message: None,
+        }),
+    );
+    ctx.program = ProgramSpec::from_globs(vec!["src/".to_string()], vec![]);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::commit::run(
+        &ctx,
+        &CommitArgs {
+            issue: 60,
+            message: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        git_output(&repo.path, &["log", "-1", "--pretty=%s"]),
+        "thesis/60: Commit surface"
+    );
+    assert_eq!(
+        git_output(&repo.path, &["diff", "--name-only", "HEAD~1..HEAD"]),
+        "src/app.ts"
+    );
+    let status = git_output(&repo.path, &["status", "--short"]);
+    assert!(
+        status.contains(".polyresearch/"),
+        "protected polyresearch outputs should remain uncommitted, got:\n{status}"
+    );
+    assert!(
+        !status.contains("src/app.ts"),
+        "editable file should be clean after commit, got:\n{status}"
+    );
+}
+
+#[tokio::test]
+async fn submit_rejects_branch_without_diff_from_default_branch() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("submit-empty");
+    init_git_repo(&repo.path);
+    write_program_md_with_surface(&repo.path, &["src/"], &[]);
+    run_git(&repo.path, &["add", "PROGRAM.md"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+    run_git(&repo.path, &["checkout", "-b", "thesis/60-empty-submit"]);
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 60,
+        title: "Empty submit".to_string(),
+        body: Some("Test thesis.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+    };
+    let comments = vec![
+        IssueComment {
+            id: 6001,
+            body: ProtocolComment::Approval { thesis: 60 }.render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::hours(1),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 6002,
+            body: ProtocolComment::Claim {
+                thesis: 60,
+                node: "test-node".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(50),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 6003,
+            body: ProtocolComment::Attempt {
+                thesis: 60,
+                branch: "thesis/60-empty-submit".to_string(),
+                metric: 0.95,
+                baseline_metric: Some(0.90),
+                observation: Observation::Improved,
+                summary: "improved".to_string(),
+                annotations: None,
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(20),
+            updated_at: None,
+        },
+    ];
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(60, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Submit(IssueArgs { issue: 60 }),
+    );
+    ctx.program = ProgramSpec::from_globs(vec!["src/".to_string()], vec![]);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let error = commands::submit::run(&ctx, &IssueArgs { issue: 60 })
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("has no file changes compared to `main`; nothing to submit"),
+        "submit should stop empty branches before pushing, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn submit_rejects_branches_with_protected_files() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("submit-protected");
+    init_git_repo(&repo.path);
+    write_program_md_with_surface(&repo.path, &["src/"], &[]);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/app.ts"), "export const value = 1;\n").unwrap();
+    run_git(&repo.path, &["add", "PROGRAM.md", "src/app.ts"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+    run_git(
+        &repo.path,
+        &["checkout", "-b", "thesis/61-protected-submit"],
+    );
+
+    fs::write(repo.path.join("src/app.ts"), "export const value = 2;\n").unwrap();
+    fs::create_dir_all(repo.path.join(".polyresearch")).unwrap();
+    fs::write(
+        repo.path.join(".polyresearch/result.json"),
+        "{\"metric\":2}\n",
+    )
+    .unwrap();
+    run_git(&repo.path, &["add", "-A"]);
+    run_git(&repo.path, &["commit", "-m", "manual commit"]);
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 61,
+        title: "Protected submit".to_string(),
+        body: Some("Test thesis.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+    };
+    let comments = vec![
+        IssueComment {
+            id: 6101,
+            body: ProtocolComment::Approval { thesis: 61 }.render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::hours(1),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 6102,
+            body: ProtocolComment::Claim {
+                thesis: 61,
+                node: "test-node".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(50),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 6103,
+            body: ProtocolComment::Attempt {
+                thesis: 61,
+                branch: "thesis/61-protected-submit".to_string(),
+                metric: 0.95,
+                baseline_metric: Some(0.90),
+                observation: Observation::Improved,
+                summary: "improved".to_string(),
+                annotations: None,
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(20),
+            updated_at: None,
+        },
+    ];
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(61, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let mut ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Submit(IssueArgs { issue: 61 }),
+    );
+    ctx.program = ProgramSpec::from_globs(vec!["src/".to_string()], vec![]);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let error = commands::submit::run(&ctx, &IssueArgs { issue: 61 })
+        .await
+        .unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("outside the editable surface"),
+        "submit should fail hard on protected files, got: {message}"
+    );
+    assert!(
+        message.contains(".polyresearch/result.json"),
+        "submit should name the violating protected file, got: {message}"
+    );
+    assert!(
+        message.contains("polyresearch commit 61"),
+        "submit should tell the user how to repair the branch, got: {message}"
+    );
 }
 
 #[tokio::test]
@@ -1805,7 +2189,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1832,7 +2218,9 @@ async fn duties_lead_duties_excluded_in_contribute_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -1882,7 +2270,9 @@ async fn duties_lead_duties_included_in_lead_context() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -1909,7 +2299,9 @@ async fn duties_lead_duties_included_in_lead_context() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2044,7 +2436,9 @@ async fn duties_submit_skipped_when_pr_merged() {
             created_at: now,
             closed_at: Some(now),
             merged_at: Some(now),
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2085,7 +2479,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         created_at: now,
         closed_at: None,
         merged_at: None,
-        author: Some(Author { login: "alice".to_string() }),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
         url: None,
         mergeable: None,
     };
@@ -2113,7 +2509,9 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
             created_at: now,
             closed_at: None,
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2136,7 +2534,8 @@ async fn duties_contribute_proceeds_despite_pending_lead_duties() {
         "lead context should see decide as blocking"
     );
 
-    let contribute_report = commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
+    let contribute_report =
+        commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
     assert!(
         contribute_report.blocking.is_empty(),
         "contribute context must not be blocked by lead duties; got: {:?}",
@@ -6129,11 +6528,11 @@ async fn decide_excludes_acknowledged_invalid_from_best_metric() {
     run_git(&repo.path, &["commit", "-m", "setup"]);
 
     let (issues, ic, prs, pc) = make_decidable_state_with_poisoned_prior(
-        1,     // thesis_number (current)
-        50,    // pr_number (current)
-        20421.0, // current_metric
-        15000.0, // baseline
-        17658.0, // prior_valid_metric
+        1,        // thesis_number (current)
+        50,       // pr_number (current)
+        20421.0,  // current_metric
+        15000.0,  // baseline
+        17658.0,  // prior_valid_metric
         218000.0, // poisoned_metric
         "lead",
     );


### PR DESCRIPTION
Fixes #151.

## Summary
- Replace the destructive submit-time strip flow with fail-hard editable-surface validation so branches with protected-file changes or empty diffs are rejected before push/PR creation.
- Add a shared `EditableSurface` layer plus a new `polyresearch commit <issue>` command so commit, submit, policy-check, worker auto-submit, and contribute auto-submit all use the same enforcement logic.
- Add regression coverage for exact-file staging, empty-submit rejection, and protected-file submit rejection, and update the contributor workflow prompt to route contributors through the new commit command.

## Test plan
- [x] `cargo test`
- [x] `cargo test commit_command_commits_only_editable_surface_changes -- --exact`
- [x] `cargo test submit_rejects_branch_without_diff_from_default_branch -- --exact`
- [x] `cargo test submit_rejects_branches_with_protected_files -- --exact`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the thesis submission path to reject empty or policy-violating branches (instead of stripping files), and adds a new commit flow that automatically stages only allowed files—mistakes here could block valid submissions or inadvertently omit intended changes.
> 
> **Overview**
> **Enforces editable-surface compliance end-to-end.** Introduces a shared `EditableSurface` helper that stages only allowed changes and detects protected-file violations, and wires it into `worker` auto-commits, `policy-check`, and contribute auto-submit.
> 
> **Adds a new `polyresearch commit <issue> [--message]` command** that validates the thesis is claimed/on the expected `thesis/<issue>-` branch, then commits only editable-surface changes.
> 
> **Makes `polyresearch submit` fail hard before push/PR creation** by checking for (1) a non-empty diff vs the default branch and (2) no changes outside the editable surface, with guidance to repair via `polyresearch commit`.
> 
> Updates the contributor workflow prompt accordingly and adds regression tests covering commit staging behavior and submit rejection for empty diffs/protected files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc9e9ccf5fcde23e8e34fbc949627792d995431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->