### PR TITLE
Retry lead sync pushes when origin advances

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -5,7 +5,7 @@ Your working directory is the project root, checked out to the default branch. Y
 ## Available commands
 
 - `polyresearch duties` — check for blocking duties (sync, policy-check, decide).
-- `polyresearch sync` — update results.tsv from GitHub state. Pulls, commits, and pushes atomically.
+- `polyresearch sync` — update results.tsv from GitHub state. Pulls, commits, and pushes with automatic retries if the remote advances.
 - `polyresearch policy-check <pr>` — verify a PR only touches files in the editable surface.
 - `polyresearch decide <pr>` — evaluate a PR and post the decision (merge/close).
 - `polyresearch generate --title "<title>" --body "<body>"` — create a new thesis issue.
@@ -26,7 +26,7 @@ LOOP FOREVER:
 
 ### 1. Sync the ledger
 
-Run `polyresearch sync`. This pulls from the remote, updates results.tsv with any missing experiment rows, commits, and pushes — all in one command. If sync fails because you are not on the default branch, run `git checkout <default-branch>` first and retry.
+Run `polyresearch sync`. This pulls from the remote, updates results.tsv with any missing experiment rows, commits, and pushes with automatic retries if the remote advances. If sync fails because you are not on the default branch, run `git checkout <default-branch>` first and retry.
 
 If sync fails after retries, log the error and proceed to step 2.
 
@@ -86,4 +86,5 @@ Sleep 60 seconds, then go back to step 1.
 - Never run `polyresearch claim`, `polyresearch submit`, or `polyresearch release`. Those are contributor commands.
 - Never create worktrees or modify code. Your job is coordination, not experimentation.
 - Stay on the default branch. All your git operations (sync, push) happen on the default branch.
+- Do not run manual `git pull` or `git push` around `polyresearch sync`; the CLI already handles the pull and retry logic internally.
 - If any step errors, do not stop. Log the error and move to the next step. The queue check in step 4 must always run.

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -10,11 +10,24 @@ use crate::state::RepositoryState;
 
 const SYNC_COMMIT_MESSAGE: &str = "Update results.tsv via polyresearch sync.";
 const PUSH_RETRY_LIMIT: usize = 3;
+const SYNC_RESTART_LIMIT: usize = 3;
 
 #[derive(Debug, Serialize)]
 struct SyncOutput {
     added_rows: usize,
     attempts: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PullOutcome {
+    Updated,
+    ResetSyncCommits,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PushOutcome {
+    Pushed,
+    RestartSync,
 }
 
 /// Fetch the default branch from origin and fast-forward the local branch.
@@ -38,12 +51,12 @@ fn local_sync_commits_only(repo_root: &PathBuf, remote_ref: &str) -> Result<bool
             .all(|message| *message == SYNC_COMMIT_MESSAGE))
 }
 
-fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
+fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<PullOutcome> {
     run_git(repo_root, &["fetch", "origin", branch])?;
     let remote_ref = format!("origin/{branch}");
 
     if run_git(repo_root, &["merge", "--ff-only", &remote_ref]).is_ok() {
-        return Ok(());
+        return Ok(PullOutcome::Updated);
     }
 
     let rebase_result = run_git(repo_root, &["rebase", &remote_ref]);
@@ -55,12 +68,12 @@ fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
                 "Rebase onto `{remote_ref}` failed for sync-only local commits; resetting to origin and re-deriving results.tsv."
             );
             run_git(repo_root, &["reset", "--hard", &remote_ref])?;
-            return Ok(());
+            return Ok(PullOutcome::ResetSyncCommits);
         }
         return Err(rebase_error);
     }
 
-    Ok(())
+    Ok(PullOutcome::Updated)
 }
 
 fn is_non_fast_forward_push_error(error: &color_eyre::Report) -> bool {
@@ -72,17 +85,19 @@ fn is_non_fast_forward_push_error(error: &color_eyre::Report) -> bool {
         || message.contains("failed to update ref")
 }
 
-fn push_with_retry(repo_root: &PathBuf, branch: &str, max_retries: usize) -> Result<()> {
+fn push_with_retry(repo_root: &PathBuf, branch: &str, max_retries: usize) -> Result<PushOutcome> {
     for attempt in 0..=max_retries {
         match run_git(repo_root, &["push", "origin", branch]) {
-            Ok(_) => return Ok(()),
+            Ok(_) => return Ok(PushOutcome::Pushed),
             Err(error) if attempt < max_retries && is_non_fast_forward_push_error(&error) => {
                 eprintln!(
                     "Push of `{branch}` was rejected as non-fast-forward; pulling and retrying ({}/{})",
                     attempt + 1,
                     max_retries + 1
                 );
-                pull_default_branch(repo_root, branch)?;
+                if pull_default_branch(repo_root, branch)? == PullOutcome::ResetSyncCommits {
+                    return Ok(PushOutcome::RestartSync);
+                }
             }
             Err(error) => return Err(error),
         }
@@ -102,28 +117,45 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
                 "`polyresearch sync` must run from the `{default_branch}` branch"
             ));
         }
-        pull_default_branch(&ctx.repo_root, &default_branch)?;
     }
 
-    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let mut ledger = Ledger::load(&ctx.repo_root)?;
-    let missing_rows = ledger.missing_rows(&repo_state);
+    let mut restart_count = 0;
+    let output = loop {
+        if !ctx.cli.dry_run {
+            let _ = pull_default_branch(&ctx.repo_root, &default_branch)?;
+        }
 
-    if !ctx.cli.dry_run && !missing_rows.is_empty() {
-        ledger.append_rows(&missing_rows)?;
-        commit_file(&ctx.repo_root, "results.tsv", SYNC_COMMIT_MESSAGE)?;
-    }
+        let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+        let mut ledger = Ledger::load(&ctx.repo_root)?;
+        let missing_rows = ledger.missing_rows(&repo_state);
 
-    if !ctx.cli.dry_run {
-        push_with_retry(&ctx.repo_root, &default_branch, PUSH_RETRY_LIMIT)?;
-    }
+        if !ctx.cli.dry_run && !missing_rows.is_empty() {
+            ledger.append_rows(&missing_rows)?;
+            commit_file(&ctx.repo_root, "results.tsv", SYNC_COMMIT_MESSAGE)?;
+        }
 
-    let output = SyncOutput {
-        added_rows: missing_rows.len(),
-        attempts: missing_rows
-            .iter()
-            .map(|row| row.attempt.clone())
-            .collect::<Vec<_>>(),
+        if !ctx.cli.dry_run {
+            match push_with_retry(&ctx.repo_root, &default_branch, PUSH_RETRY_LIMIT)? {
+                PushOutcome::Pushed => {}
+                PushOutcome::RestartSync => {
+                    restart_count += 1;
+                    if restart_count > SYNC_RESTART_LIMIT {
+                        return Err(eyre!(
+                            "`polyresearch sync` had to discard local sync commits repeatedly while retrying push; rerun sync after the branch settles"
+                        ));
+                    }
+                    continue;
+                }
+            }
+        }
+
+        break SyncOutput {
+            added_rows: missing_rows.len(),
+            attempts: missing_rows
+                .iter()
+                .map(|row| row.attempt.clone())
+                .collect::<Vec<_>>(),
+        };
     };
 
     print_value(ctx, &output, |value| {

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -8,6 +8,9 @@ use crate::commands::{AppContext, commit_file, current_branch, print_value, run_
 use crate::ledger::Ledger;
 use crate::state::RepositoryState;
 
+const SYNC_COMMIT_MESSAGE: &str = "Update results.tsv via polyresearch sync.";
+const PUSH_RETRY_LIMIT: usize = 3;
+
 #[derive(Debug, Serialize)]
 struct SyncOutput {
     added_rows: usize,
@@ -17,7 +20,24 @@ struct SyncOutput {
 /// Fetch the default branch from origin and fast-forward the local branch.
 /// If local has unpushed commits (prior sync that failed to push), rebase
 /// them onto the remote. If rebase conflicts, abort to keep the repo
-/// workable -- follows the same abort pattern as decide.rs::try_rebase_onto_main.
+/// workable. When the local commits are only prior sync commits, discard
+/// them and re-derive from origin instead of leaving the branch stuck.
+fn local_sync_commits_only(repo_root: &PathBuf, remote_ref: &str) -> Result<bool> {
+    let local_commits = run_git(
+        repo_root,
+        &["log", "--format=%s", &format!("{remote_ref}..HEAD")],
+    )?;
+    let commit_messages = local_commits
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+
+    Ok(!commit_messages.is_empty()
+        && commit_messages
+            .iter()
+            .all(|message| *message == SYNC_COMMIT_MESSAGE))
+}
+
 fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
     run_git(repo_root, &["fetch", "origin", branch])?;
     let remote_ref = format!("origin/{branch}");
@@ -28,9 +48,47 @@ fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<()> {
 
     let rebase_result = run_git(repo_root, &["rebase", &remote_ref]);
     if rebase_result.is_err() {
+        let rebase_error = rebase_result.unwrap_err();
         let _ = run_git(repo_root, &["rebase", "--abort"]);
+        if local_sync_commits_only(repo_root, &remote_ref)? {
+            eprintln!(
+                "Rebase onto `{remote_ref}` failed for sync-only local commits; resetting to origin and re-deriving results.tsv."
+            );
+            run_git(repo_root, &["reset", "--hard", &remote_ref])?;
+            return Ok(());
+        }
+        return Err(rebase_error);
     }
-    rebase_result.map(|_| ())
+
+    Ok(())
+}
+
+fn is_non_fast_forward_push_error(error: &color_eyre::Report) -> bool {
+    let message = error.to_string();
+    message.contains("non-fast-forward")
+        || message.contains("fetch first")
+        || message.contains("Updates were rejected because the remote contains work")
+        || message.contains("cannot lock ref")
+        || message.contains("failed to update ref")
+}
+
+fn push_with_retry(repo_root: &PathBuf, branch: &str, max_retries: usize) -> Result<()> {
+    for attempt in 0..=max_retries {
+        match run_git(repo_root, &["push", "origin", branch]) {
+            Ok(_) => return Ok(()),
+            Err(error) if attempt < max_retries && is_non_fast_forward_push_error(&error) => {
+                eprintln!(
+                    "Push of `{branch}` was rejected as non-fast-forward; pulling and retrying ({}/{})",
+                    attempt + 1,
+                    max_retries + 1
+                );
+                pull_default_branch(repo_root, branch)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!()
 }
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
@@ -53,15 +111,11 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
 
     if !ctx.cli.dry_run && !missing_rows.is_empty() {
         ledger.append_rows(&missing_rows)?;
-        commit_file(
-            &ctx.repo_root,
-            "results.tsv",
-            "Update results.tsv via polyresearch sync.",
-        )?;
+        commit_file(&ctx.repo_root, "results.tsv", SYNC_COMMIT_MESSAGE)?;
     }
 
     if !ctx.cli.dry_run {
-        run_git(&ctx.repo_root, &["push", "origin", &default_branch])?;
+        push_with_retry(&ctx.repo_root, &default_branch, PUSH_RETRY_LIMIT)?;
     }
 
     let output = SyncOutput {

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -292,6 +292,48 @@ git -C \"{racer}\" push origin {branch}\n",
     );
 }
 
+fn install_one_time_conflicting_results_hook(
+    repo_path: &Path,
+    racer_path: &Path,
+    branch: &str,
+    results_line: &str,
+) {
+    let hook_path = repo_path.join(".git").join("hooks").join("pre-push");
+    let hook_path_arg = hook_path.to_string_lossy().into_owned();
+    let marker_path = repo_path.join(".git").join("sync-push-conflict-ran");
+    let results_path = racer_path.join("results.tsv");
+    let script = format!(
+        "#!/bin/sh\n\
+MARKER=\"{marker}\"\n\
+if [ -f \"$MARKER\" ]; then\n\
+  exit 0\n\
+fi\n\
+touch \"$MARKER\"\n\
+git -C \"{racer}\" fetch origin {branch}\n\
+git -C \"{racer}\" checkout -B {branch} origin/{branch}\n\
+printf '%s\\n' '{results_line}' >> \"{results_path}\"\n\
+git -C \"{racer}\" add results.tsv\n\
+git -C \"{racer}\" commit -m \"add conflicting results row during sync push\"\n\
+git -C \"{racer}\" push origin {branch}\n",
+        marker = marker_path.display(),
+        racer = racer_path.display(),
+        branch = branch,
+        results_line = results_line,
+        results_path = results_path.display(),
+    );
+
+    fs::write(&hook_path, script).unwrap();
+    let status = Command::new("chmod")
+        .args(["+x", hook_path_arg.as_str()])
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "chmod +x failed for {}",
+        hook_path.display()
+    );
+}
+
 fn mock_agent_path() -> String {
     let manifest = env!("CARGO_MANIFEST_DIR");
     format!("{manifest}/tests/mock_agent.sh")
@@ -3339,6 +3381,182 @@ async fn scenario_sync_retries_push_after_remote_advances() {
         race_file.trim(),
         "race",
         "remote advance hook should have fired exactly once"
+    );
+}
+
+#[tokio::test]
+async fn scenario_sync_rederives_after_resetting_conflicting_sync_commit() {
+    let _guard = EnvGuard::lock_clean();
+    let parent = ScenarioRepo::new("sync-reset-retry");
+    let (clone_path, bare_path) = setup_remote_clone(&parent, "sync-reset-work", "master");
+    write_sync_repo_files(&clone_path, "lead", "master", "test-node");
+    run_git(&clone_path, &["add", "-A"]);
+    run_git(&clone_path, &["commit", "-m", "setup"]);
+    run_git(&clone_path, &["push", "origin", "master"]);
+
+    let bare_path_arg = bare_path.to_string_lossy().into_owned();
+    run_git(&parent.path, &["clone", &bare_path_arg, "sync-reset-racer"]);
+    let racer_path = parent.path.join("sync-reset-racer");
+    run_git(&racer_path, &["config", "user.name", "Race"]);
+    run_git(&racer_path, &["config", "user.email", "race@test.com"]);
+    install_one_time_conflicting_results_hook(
+        &clone_path,
+        &racer_path,
+        "master",
+        "#999\tthesis/race\t1.0000\t0.9000\taccepted\tRace row",
+    );
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 1,
+        title: "Test thesis".to_string(),
+        body: Some("Test".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+    };
+    let approval_comment = IssueComment {
+        id: 100,
+        body: ProtocolComment::Approval { thesis: 1 }.render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::hours(1),
+        updated_at: None,
+    };
+    let claim_comment = IssueComment {
+        id: 101,
+        body: ProtocolComment::Claim {
+            thesis: 1,
+            node: "worker".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(50),
+        updated_at: None,
+    };
+    let attempt_comment = IssueComment {
+        id: 102,
+        body: ProtocolComment::Attempt {
+            thesis: 1,
+            branch: "thesis/1-test".to_string(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Test".to_string(),
+            annotations: None,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(40),
+        updated_at: None,
+    };
+    let pr = PullRequest {
+        number: 2,
+        title: "Thesis #1: Test thesis".to_string(),
+        body: Some("References #1".to_string()),
+        state: "MERGED".to_string(),
+        head_ref_name: "thesis/1-test".to_string(),
+        head_ref_oid: Some("abc".to_string()),
+        base_ref_name: Some("master".to_string()),
+        created_at: now - chrono::Duration::minutes(30),
+        closed_at: None,
+        merged_at: Some(now - chrono::Duration::minutes(20)),
+        author: Some(Author {
+            login: "contrib".to_string(),
+        }),
+        url: None,
+        mergeable: None,
+    };
+    let policy_pass_comment = IssueComment {
+        id: 199,
+        body: ProtocolComment::PolicyPass {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(18),
+        updated_at: None,
+    };
+    let decision_comment = IssueComment {
+        id: 200,
+        body: ProtocolComment::Decision {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+            outcome: polyresearch::comments::Outcome::Accepted,
+            confirmations: 0,
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(15),
+        updated_at: None,
+    };
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(1, vec![approval_comment, claim_comment, attempt_comment]);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(2, vec![policy_pass_comment, decision_comment]);
+
+    let ctx = make_scenario_ctx(
+        clone_path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Sync,
+    );
+
+    let result = commands::sync::run(&ctx).await;
+    assert!(
+        result.is_ok(),
+        "sync should re-derive and push results.tsv after resetting a conflicting sync commit: {result:?}"
+    );
+
+    let local_results = fs::read_to_string(clone_path.join("results.tsv")).unwrap();
+    assert!(
+        local_results.contains("thesis/1-test"),
+        "local results.tsv should still include the merged attempt after restart"
+    );
+    assert!(
+        local_results.contains("thesis/race"),
+        "local results.tsv should preserve the remote row that caused the conflict"
+    );
+
+    let remote_results = run_git_output(
+        &parent.path,
+        &["--git-dir", &bare_path_arg, "show", "master:results.tsv"],
+    );
+    assert!(
+        remote_results.contains("thesis/1-test"),
+        "remote results.tsv should include the merged attempt after restart"
+    );
+    assert!(
+        remote_results.contains("thesis/race"),
+        "remote results.tsv should keep the conflicting remote row after restart"
+    );
+    assert_eq!(
+        remote_results
+            .lines()
+            .filter(|line| line.contains("thesis/1-test"))
+            .count(),
+        1,
+        "the restarted sync should push exactly one row for the merged attempt"
     );
 }
 

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -170,6 +170,128 @@ fn run_git(path: &Path, args: &[&str]) {
     );
 }
 
+fn run_git_output(path: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn write_sync_repo_files(path: &Path, lead: &str, default_branch: &str, node_id: &str) {
+    fs::write(
+        path.join("PROGRAM.md"),
+        format!(
+            r#"# Research Program
+
+cli_version: {version}
+default_branch: {default_branch}
+lead_github_login: {lead}
+maintainer_github_login: {lead}
+metric_tolerance: 0.01
+metric_direction: higher_is_better
+required_confirmations: 0
+auto_approve: true
+min_queue_depth: 5
+assignment_timeout: 24h
+
+## Goal
+
+Test scenario goal.
+
+## What you CAN modify
+
+- `src/`
+
+## What you CANNOT modify
+
+- `PREPARE.md`
+- `docs/`
+"#,
+            version = env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .unwrap();
+    fs::write(
+        path.join("PREPARE.md"),
+        "# Evaluation\n\neval_cores: 1\neval_memory_gb: 1.0\n",
+    )
+    .unwrap();
+    fs::write(
+        path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
+    fs::write(
+        path.join(".polyresearch-node.toml"),
+        format!("node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"echo noop\"\n"),
+    )
+    .unwrap();
+}
+
+fn setup_remote_clone(parent: &ScenarioRepo, clone_dir: &str, branch: &str) -> (PathBuf, PathBuf) {
+    let bare_path = parent.path.join(format!("{clone_dir}-remote.git"));
+    let clone_path = parent.path.join(clone_dir);
+    let bare_path_arg = bare_path.to_string_lossy().into_owned();
+
+    fs::create_dir_all(&bare_path).unwrap();
+    run_git(&bare_path, &["init", "--bare"]);
+    run_git(&parent.path, &["clone", &bare_path_arg, clone_dir]);
+    run_git(&clone_path, &["config", "user.name", "Test"]);
+    run_git(&clone_path, &["config", "user.email", "test@test.com"]);
+    fs::write(clone_path.join("README.md"), "initial\n").unwrap();
+    run_git(&clone_path, &["add", "README.md"]);
+    run_git(&clone_path, &["commit", "-m", "init"]);
+    run_git(&clone_path, &["branch", "-M", branch]);
+    run_git(&clone_path, &["push", "-u", "origin", branch]);
+
+    (clone_path, bare_path)
+}
+
+fn install_one_time_remote_advance_hook(repo_path: &Path, racer_path: &Path, branch: &str) {
+    let hook_path = repo_path.join(".git").join("hooks").join("pre-push");
+    let hook_path_arg = hook_path.to_string_lossy().into_owned();
+    let marker_path = repo_path.join(".git").join("sync-push-race-ran");
+    let race_file = racer_path.join("race.txt");
+    let script = format!(
+        "#!/bin/sh\n\
+MARKER=\"{marker}\"\n\
+if [ -f \"$MARKER\" ]; then\n\
+  exit 0\n\
+fi\n\
+touch \"$MARKER\"\n\
+git -C \"{racer}\" fetch origin {branch}\n\
+git -C \"{racer}\" checkout -B {branch} origin/{branch}\n\
+printf 'race\\n' >> \"{race_file}\"\n\
+git -C \"{racer}\" add race.txt\n\
+git -C \"{racer}\" commit -m \"advance remote during sync push\"\n\
+git -C \"{racer}\" push origin {branch}\n",
+        marker = marker_path.display(),
+        racer = racer_path.display(),
+        branch = branch,
+        race_file = race_file.display(),
+    );
+
+    fs::write(&hook_path, script).unwrap();
+    let status = Command::new("chmod")
+        .args(["+x", hook_path_arg.as_str()])
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "chmod +x failed for {}",
+        hook_path.display()
+    );
+}
+
 fn mock_agent_path() -> String {
     let manifest = env!("CARGO_MANIFEST_DIR");
     format!("{manifest}/tests/mock_agent.sh")
@@ -798,16 +920,16 @@ async fn scenario_lead_accept_pr() {
     );
 
     let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
 
     let result = commands::lead::decide_ready_prs(&ctx, &config, &repo_state);
 
-    assert!(result.is_ok(), "decide_ready_prs should succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "decide_ready_prs should succeed: {result:?}"
+    );
     assert!(github.is_pr_merged(50), "PR #50 should be merged");
     assert!(
         github.is_issue_closed(40),
@@ -927,16 +1049,16 @@ async fn scenario_lead_reject_non_improvement() {
     );
 
     let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
 
     let result = commands::lead::decide_ready_prs(&ctx, &config, &repo_state);
 
-    assert!(result.is_ok(), "decide_ready_prs should succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "decide_ready_prs should succeed: {result:?}"
+    );
     assert!(github.is_pr_closed(51), "PR #51 should be closed");
     assert!(
         !github.is_issue_closed(41),
@@ -1303,16 +1425,16 @@ async fn scenario_lead_closes_conflicting_pr_as_stale() {
     );
 
     let config = polyresearch::config::ProtocolConfig::load(&repo.path).unwrap();
-    let repo_state = RepositoryState::derive(
-        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
-        &config,
-    )
-    .await
-    .unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
 
     let result = commands::lead::decide_ready_prs(&ctx, &config, &repo_state);
 
-    assert!(result.is_ok(), "decide_ready_prs should succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "decide_ready_prs should succeed: {result:?}"
+    );
     assert!(
         !github.is_pr_merged(55),
         "conflicting PR #55 should NOT be merged"
@@ -3031,6 +3153,7 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
 #[tokio::test]
 async fn scenario_sync_accepts_master_default_branch() {
     let _guard = EnvGuard::lock_clean();
+<<<<<<< HEAD
     let mut repo = ScenarioRepo::new("sync-master");
     repo.init_git_on_branch("master");
     repo.write_program_md_with_branch("lead", Some("master"));
@@ -3039,11 +3162,19 @@ async fn scenario_sync_accepts_master_default_branch() {
     repo.write_node_config("test-node", "echo noop");
     repo.commit_all("setup");
     repo.add_bare_remote("master");
+=======
+    let parent = ScenarioRepo::new("sync-master");
+    let (clone_path, _bare_path) = setup_remote_clone(&parent, "sync-master-work", "master");
+    write_sync_repo_files(&clone_path, "lead", "master", "test-node");
+    run_git(&clone_path, &["add", "-A"]);
+    run_git(&clone_path, &["commit", "-m", "setup"]);
+    run_git(&clone_path, &["push", "origin", "master"]);
+>>>>>>> 803c8fe (Retry lead sync pushes when origin advances so results.tsv is retried and reaches the remote instead of getting stranded locally.)
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
 
     let ctx = make_scenario_ctx(
-        repo.path.clone(),
+        clone_path,
         Arc::clone(&github) as Arc<dyn GitHubApi>,
         "lead",
         false,
@@ -3054,6 +3185,171 @@ async fn scenario_sync_accepts_master_default_branch() {
     assert!(
         result.is_ok(),
         "sync should succeed on master with default_branch: master: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_sync_retries_push_after_remote_advances() {
+    let _guard = EnvGuard::lock_clean();
+    let parent = ScenarioRepo::new("sync-push-retry");
+    let (clone_path, bare_path) = setup_remote_clone(&parent, "sync-push-work", "master");
+    write_sync_repo_files(&clone_path, "lead", "master", "test-node");
+    run_git(&clone_path, &["add", "-A"]);
+    run_git(&clone_path, &["commit", "-m", "setup"]);
+    run_git(&clone_path, &["push", "origin", "master"]);
+
+    let bare_path_arg = bare_path.to_string_lossy().into_owned();
+    run_git(&parent.path, &["clone", &bare_path_arg, "sync-push-racer"]);
+    let racer_path = parent.path.join("sync-push-racer");
+    run_git(&racer_path, &["config", "user.name", "Race"]);
+    run_git(&racer_path, &["config", "user.email", "race@test.com"]);
+    install_one_time_remote_advance_hook(&clone_path, &racer_path, "master");
+
+    let now = chrono::Utc::now();
+    let issue = Issue {
+        number: 1,
+        title: "Test thesis".to_string(),
+        body: Some("Test".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: None,
+    };
+    let approval_comment = IssueComment {
+        id: 100,
+        body: ProtocolComment::Approval { thesis: 1 }.render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::hours(1),
+        updated_at: None,
+    };
+    let claim_comment = IssueComment {
+        id: 101,
+        body: ProtocolComment::Claim {
+            thesis: 1,
+            node: "worker".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(50),
+        updated_at: None,
+    };
+    let attempt_comment = IssueComment {
+        id: 102,
+        body: ProtocolComment::Attempt {
+            thesis: 1,
+            branch: "thesis/1-test".to_string(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Test".to_string(),
+            annotations: None,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contrib".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(40),
+        updated_at: None,
+    };
+    let pr = PullRequest {
+        number: 2,
+        title: "Thesis #1: Test thesis".to_string(),
+        body: Some("References #1".to_string()),
+        state: "MERGED".to_string(),
+        head_ref_name: "thesis/1-test".to_string(),
+        head_ref_oid: Some("abc".to_string()),
+        base_ref_name: Some("master".to_string()),
+        created_at: now - chrono::Duration::minutes(30),
+        closed_at: None,
+        merged_at: Some(now - chrono::Duration::minutes(20)),
+        author: Some(Author {
+            login: "contrib".to_string(),
+        }),
+        url: None,
+        mergeable: None,
+    };
+    let policy_pass_comment = IssueComment {
+        id: 199,
+        body: ProtocolComment::PolicyPass {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(18),
+        updated_at: None,
+    };
+    let decision_comment = IssueComment {
+        id: 200,
+        body: ProtocolComment::Decision {
+            thesis: 1,
+            candidate_sha: "abc".to_string(),
+            outcome: polyresearch::comments::Outcome::Accepted,
+            confirmations: 0,
+        }
+        .render(),
+        user: CommentUser {
+            login: "lead".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(15),
+        updated_at: None,
+    };
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(1, vec![approval_comment, claim_comment, attempt_comment]);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(2, vec![policy_pass_comment, decision_comment]);
+
+    let ctx = make_scenario_ctx(
+        clone_path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Sync,
+    );
+
+    let result = commands::sync::run(&ctx).await;
+    assert!(
+        result.is_ok(),
+        "sync should recover after the first push loses a non-fast-forward race: {result:?}"
+    );
+
+    let local_results = fs::read_to_string(clone_path.join("results.tsv")).unwrap();
+    assert!(
+        local_results.contains("thesis/1-test"),
+        "local results.tsv should include the merged attempt after retry"
+    );
+
+    let remote_results = run_git_output(
+        &parent.path,
+        &["--git-dir", &bare_path_arg, "show", "master:results.tsv"],
+    );
+    assert!(
+        remote_results.contains("thesis/1-test"),
+        "remote results.tsv should include the merged attempt after retry"
+    );
+
+    let race_file = run_git_output(
+        &parent.path,
+        &["--git-dir", &bare_path_arg, "show", "master:race.txt"],
+    );
+    assert_eq!(
+        race_file.trim(),
+        "race",
+        "remote advance hook should have fired exactly once"
     );
 }
 
@@ -4026,7 +4322,9 @@ fn count_prior_rejections_excludes_rejections_that_predate_claim() {
                 created_at: now - chrono::Duration::hours(8),
                 closed_at: Some(now - chrono::Duration::hours(5)),
                 merged_at: None,
-                author: Some(Author { login: "contributor-a".to_string() }),
+                author: Some(Author {
+                    login: "contributor-a".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -3153,23 +3153,12 @@ async fn scenario_decide_idempotent_no_duplicate_comment() {
 #[tokio::test]
 async fn scenario_sync_accepts_master_default_branch() {
     let _guard = EnvGuard::lock_clean();
-<<<<<<< HEAD
-    let mut repo = ScenarioRepo::new("sync-master");
-    repo.init_git_on_branch("master");
-    repo.write_program_md_with_branch("lead", Some("master"));
-    repo.write_prepare_md();
-    repo.write_results_tsv();
-    repo.write_node_config("test-node", "echo noop");
-    repo.commit_all("setup");
-    repo.add_bare_remote("master");
-=======
     let parent = ScenarioRepo::new("sync-master");
     let (clone_path, _bare_path) = setup_remote_clone(&parent, "sync-master-work", "master");
     write_sync_repo_files(&clone_path, "lead", "master", "test-node");
     run_git(&clone_path, &["add", "-A"]);
     run_git(&clone_path, &["commit", "-m", "setup"]);
     run_git(&clone_path, &["push", "origin", "master"]);
->>>>>>> 803c8fe (Retry lead sync pushes when origin advances so results.tsv is retried and reaches the remote instead of getting stranded locally.)
 
     let github = Arc::new(ScenarioGitHub::new("lead"));
 


### PR DESCRIPTION
## Summary
- retry `polyresearch sync` pushes when origin advances between the pull and push steps, including the ref-lock rejection reproduced by issue #137
- reset sync-only local commits after a failed rebase so the lead can re-derive `results.tsv` from origin instead of leaving the branch stranded
- update the lead workflow prompt and add a sync scenario that reproduces the first-push race against origin

## Test plan
- [x] `cargo test --test scenarios scenario_sync_`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `polyresearch sync` git/push flow (including hard resets and retries), which could impact how the lead updates and publishes `results.tsv` under concurrent remote updates; behavior is covered by new race/conflict scenario tests but still touches critical repo mutation paths.
> 
> **Overview**
> Makes `polyresearch sync` resilient to concurrent updates on the default branch by **retrying `git push` when origin advances** (detecting common non-fast-forward/ref-lock errors, pulling, and retrying up to a limit).
> 
> If rebasing local changes onto `origin/<default>` fails and the local commits are *only prior sync commits*, the command now **hard-resets to origin and restarts the sync loop** to re-derive and re-commit `results.tsv` instead of leaving the branch stranded.
> 
> Updates the lead workflow prompt to reflect the new retry behavior and warns against manual `git pull/push`, and adds/adjusts scenario tests that reproduce push races and conflicting `results.tsv` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34007cd2296e8b019d466b20158f829ede1553a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->