### PR TITLE
Reject duplicate thesis titles in polyresearch generate

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -57,10 +57,11 @@ Run `polyresearch status`. Read the queue depth (approved, unclaimed theses). Re
 If the queue is below `min_queue_depth`:
 1. Run `polyresearch audit`. If there are critical findings, resolve them first (acknowledge invalid ones, release stuck claims).
 2. Read PROGRAM.md for the research goal and strategy. Read results.tsv to understand what has been tried — including accepted (merged) work, not just failures.
-3. Generate thesis proposals: think of specific, actionable ideas that differ from everything already tried. Do not duplicate approaches from any prior thesis — whether accepted, no_improvement, or crashed. An accepted thesis means its optimization is already in the codebase; proposing the same idea again wastes a cycle.
-4. For each proposal, run: `polyresearch generate --title "<title>" --body "<body>"`
-5. Generate only enough theses to bring the queue back to `min_queue_depth`. Do not over-generate.
-6. After generating, run `polyresearch status` again to confirm queue depth is now at or above `min_queue_depth`.
+3. Run `polyresearch status --json` and extract the full list of thesis titles. Cross-reference those titles with results.tsv and build a dedup list of approaches that must not be repeated.
+4. Generate thesis proposals: think of specific, actionable ideas that differ from everything already tried. Before calling `polyresearch generate`, verify each proposal does not match any title or summary in your dedup list. Do not duplicate approaches from any prior thesis — whether accepted, no_improvement, or crashed. An accepted thesis means its optimization is already in the codebase; proposing the same idea again wastes a cycle.
+5. For each proposal, run: `polyresearch generate --title "<title>" --body "<body>"`. If the CLI rejects the title as a duplicate, do not retry with cosmetic rewording. Think of a genuinely different optimization.
+6. Generate only enough theses to bring the queue back to `min_queue_depth`. Do not over-generate.
+7. After generating, run `polyresearch status` again to confirm queue depth is now at or above `min_queue_depth`.
 
 If the queue is already at or above `min_queue_depth`, proceed to step 5.
 
@@ -89,4 +90,5 @@ Sleep 60 seconds, then go back to step 1.
 - Never create worktrees or modify code. Your job is coordination, not experimentation.
 - Stay on the default branch. All your git operations (sync, push) happen on the default branch.
 - Do not run manual `git pull` or `git push` around `polyresearch sync`; the CLI already handles the pull and retry logic internally.
+- The CLI will reject titles that match existing theses. If you see that error, treat it as proof the approach is a duplicate and generate a different idea.
 - If any step errors, do not stop. Log the error and move to the next step. The queue check in step 4 must always run.

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -6,7 +6,7 @@ use crate::commands::duties;
 use crate::commands::guards::{ensure_current_ledger, ensure_lead};
 use crate::commands::{AppContext, print_value};
 use crate::comments::ProtocolComment;
-use crate::state::RepositoryState;
+use crate::state::{RepositoryState, ThesisState};
 
 #[derive(Debug, Serialize)]
 struct GenerateOutput {
@@ -46,6 +46,25 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
             "queue depth is already {} (max_queue_depth = {}), refusing to generate more theses",
             repo_state.queue_depth,
             max_queue_depth
+        ));
+    }
+
+    let duplicates = duplicate_titles(&repo_state, &args.title);
+    if !duplicates.is_empty() {
+        let items: Vec<String> = duplicates
+            .iter()
+            .map(|thesis| {
+                format!(
+                    "  #{} ({}): {}",
+                    thesis.issue.number,
+                    thesis.phase_label(),
+                    thesis.issue.title
+                )
+            })
+            .collect();
+        return Err(eyre!(
+            "proposed title duplicates existing thesis:\n{}\nUse a meaningfully different approach.",
+            items.join("\n")
         ));
     }
 
@@ -115,4 +134,48 @@ pub async fn run(ctx: &AppContext, args: &GenerateArgs) -> Result<()> {
         }
         message
     })
+}
+
+fn duplicate_titles<'a>(
+    repo_state: &'a RepositoryState,
+    proposed_title: &str,
+) -> Vec<&'a ThesisState> {
+    let normalized_proposed = normalize_title(proposed_title);
+    repo_state
+        .theses
+        .iter()
+        .filter(|thesis| normalize_title(&thesis.issue.title) == normalized_proposed)
+        .collect()
+}
+
+fn normalize_title(title: &str) -> String {
+    let stripped: String = title
+        .to_lowercase()
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || ch.is_whitespace())
+        .collect();
+    stripped.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_title;
+
+    #[test]
+    fn normalize_title_lowercases_and_strips() {
+        assert_eq!(
+            normalize_title("Regex Caching Optimization!"),
+            "regex caching optimization"
+        );
+    }
+
+    #[test]
+    fn normalize_title_collapses_whitespace() {
+        assert_eq!(normalize_title("  foo   bar  "), "foo bar");
+    }
+
+    #[test]
+    fn normalize_title_strips_punctuation() {
+        assert_eq!(normalize_title("use SIMD (AVX-512)"), "use simd avx512");
+    }
 }

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -152,7 +152,7 @@ fn normalize_title(title: &str) -> String {
     let stripped: String = title
         .to_lowercase()
         .chars()
-        .filter(|ch| ch.is_alphanumeric() || ch.is_whitespace())
+        .map(|ch| if ch.is_alphanumeric() { ch } else { ' ' })
         .collect();
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -176,6 +176,14 @@ mod tests {
 
     #[test]
     fn normalize_title_strips_punctuation() {
-        assert_eq!(normalize_title("use SIMD (AVX-512)"), "use simd avx512");
+        assert_eq!(normalize_title("use SIMD (AVX-512)"), "use simd avx 512");
+    }
+
+    #[test]
+    fn normalize_title_treats_punctuation_as_separator() {
+        assert_eq!(
+            normalize_title("regex-caching/optimization"),
+            "regex caching optimization"
+        );
     }
 }

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -372,6 +372,19 @@ impl ThesisState {
             .map(|attempt| attempt.metric)
     }
 
+    pub fn phase_label(&self) -> String {
+        match &self.phase {
+            ThesisPhase::Submitted => "submitted".to_string(),
+            ThesisPhase::Approved => "approved".to_string(),
+            ThesisPhase::Exhausted => "exhausted".to_string(),
+            ThesisPhase::Claimed => "claimed".to_string(),
+            ThesisPhase::CandidateSubmitted => "candidate_submitted".to_string(),
+            ThesisPhase::InReview => "in_review".to_string(),
+            ThesisPhase::Resolved { outcome } => outcome.to_string(),
+            ThesisPhase::Rejected => "rejected".to_string(),
+        }
+    }
+
     pub fn is_claimed_by(&self, node: &str) -> bool {
         self.active_claims.iter().any(|claim| claim.node == node)
     }
@@ -578,6 +591,45 @@ mod tests {
     }
 
     #[test]
+    fn phase_label_returns_correct_strings() {
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Submitted).phase_label(),
+            "submitted"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Approved).phase_label(),
+            "approved"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Exhausted).phase_label(),
+            "exhausted"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Claimed).phase_label(),
+            "claimed"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::CandidateSubmitted).phase_label(),
+            "candidate_submitted"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::InReview).phase_label(),
+            "in_review"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Resolved {
+                outcome: Outcome::Accepted,
+            })
+            .phase_label(),
+            "accepted"
+        );
+        assert_eq!(
+            thesis_with_phase(ThesisPhase::Rejected).phase_label(),
+            "rejected"
+        );
+    }
+
+    #[test]
     fn marks_no_improvement_releases_as_exhausted() {
         let fixture = exhausted_fixture();
         let config = test_config(&fixture.lead_github_login);
@@ -714,9 +766,13 @@ mod tests {
         .unwrap();
         let config = test_config(&fixture.lead_github_login);
 
-        let claimed =
-            ThesisState::derive(fixture.issue.clone(), fixture.comments.clone(), &[], &config)
-                .unwrap();
+        let claimed = ThesisState::derive(
+            fixture.issue.clone(),
+            fixture.comments.clone(),
+            &[],
+            &config,
+        )
+        .unwrap();
         assert!(matches!(claimed.phase, ThesisPhase::Claimed));
         assert_eq!(claimed.active_claims.len(), 1);
 
@@ -856,6 +912,33 @@ mod tests {
             "../tests/fixtures/exhausted_thesis_issue.json"
         ))
         .unwrap()
+    }
+
+    fn thesis_with_phase(phase: ThesisPhase) -> ThesisState {
+        ThesisState {
+            issue: Issue {
+                number: 999,
+                title: "Example thesis".to_string(),
+                body: None,
+                state: "OPEN".to_string(),
+                labels: vec![],
+                created_at: chrono::Utc::now(),
+                closed_at: None,
+                author: None,
+                url: None,
+            },
+            phase,
+            approved: false,
+            maintainer_approved: false,
+            maintainer_rejected: false,
+            active_claims: vec![],
+            releases: vec![],
+            attempts: vec![],
+            pull_requests: vec![],
+            best_attempt_metric: None,
+            invalidated_attempt_branches: BTreeSet::new(),
+            findings: vec![],
+        }
     }
 
     fn test_config(lead_github_login: &str) -> ProtocolConfig {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -5596,6 +5596,46 @@ async fn generate_rejects_case_insensitive_duplicate() {
 }
 
 #[tokio::test]
+async fn generate_rejects_punctuation_variant_duplicate() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("generate-punctuation-duplicate");
+    let (issue, comments) = make_approved_generate_issue(44, "Regex caching optimization", "lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(44, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "regex-caching optimization".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    let err = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "regex-caching optimization".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("duplicates existing thesis"));
+    assert!(
+        mock.created_issues.lock().unwrap().is_empty(),
+        "punctuation-only title variation should not create a new issue"
+    );
+}
+
+#[tokio::test]
 async fn generate_succeeds_below_max_queue_depth() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("generate-below-max");

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -5443,6 +5443,39 @@ async fn admin_reopen_thesis_reopens_closed_issue() {
 // Category 8: Queue management / generate
 // ===========================================================================
 
+fn make_approved_generate_issue(
+    number: u64,
+    title: &str,
+    lead: &str,
+) -> (Issue, Vec<IssueComment>) {
+    let created_at = chrono::Utc::now();
+    let issue = Issue {
+        number,
+        title: title.to_string(),
+        body: Some("Test thesis body.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at,
+        closed_at: None,
+        author: Some(Author {
+            login: lead.to_string(),
+        }),
+        url: Some(format!("https://github.com/test/repo/issues/{number}")),
+    };
+    let comments = vec![IssueComment {
+        id: number * 100,
+        body: ProtocolComment::Approval { thesis: number }.render(),
+        user: CommentUser {
+            login: lead.to_string(),
+        },
+        created_at: created_at + chrono::Duration::seconds(1),
+        updated_at: None,
+    }];
+    (issue, comments)
+}
+
 #[tokio::test]
 async fn generate_refuses_at_max_queue_depth() {
     let _guard = NodeIdEnvGuard::lock_clean();
@@ -5479,6 +5512,90 @@ async fn generate_refuses_at_max_queue_depth() {
 }
 
 #[tokio::test]
+async fn generate_rejects_duplicate_title() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("generate-duplicate-title");
+    let (issue, comments) = make_approved_generate_issue(41, "Regex caching optimization", "lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(41, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "Regex caching optimization".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    let err = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Regex caching optimization".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("duplicates existing thesis"));
+    assert!(
+        err.to_string()
+            .contains("#41 (approved): Regex caching optimization")
+    );
+    assert!(
+        mock.created_issues.lock().unwrap().is_empty(),
+        "duplicate title should not create a new issue"
+    );
+}
+
+#[tokio::test]
+async fn generate_rejects_case_insensitive_duplicate() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("generate-case-insensitive-duplicate");
+    let (issue, comments) = make_approved_generate_issue(42, "Regex caching optimization", "lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(42, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        true,
+        Commands::Generate(GenerateArgs {
+            title: "REGEX CACHING OPTIMIZATION".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    let err = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "REGEX CACHING OPTIMIZATION".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("duplicates existing thesis"));
+    assert!(
+        mock.created_issues.lock().unwrap().is_empty(),
+        "duplicate title should not create a new issue"
+    );
+}
+
+#[tokio::test]
 async fn generate_succeeds_below_max_queue_depth() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("generate-below-max");
@@ -5510,6 +5627,44 @@ async fn generate_succeeds_below_max_queue_depth() {
     )
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn generate_allows_unique_title() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("generate-unique-title");
+    let (issue, comments) = make_approved_generate_issue(43, "Regex caching optimization", "lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![issue],
+        HashMap::from([(43, comments)]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Generate(GenerateArgs {
+            title: "SIMD vectorization".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "SIMD vectorization".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let created = mock.created_issues.lock().unwrap();
+    assert_eq!(created.len(), 1, "unique title should create one issue");
+    assert_eq!(created[0].title, "SIMD vectorization");
 }
 
 #[tokio::test]

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use polyresearch::cli::{
-    BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides, PrArgs,
+    BootstrapArgs, Cli, Commands, ContributeArgs, GenerateArgs, LeadArgs, NodeOverrides, PrArgs,
 };
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
@@ -909,6 +909,86 @@ async fn scenario_contribute_agent_failure() {
 // ---------------------------------------------------------------------------
 // Lead scenarios
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_generate_rejects_duplicate_thesis() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("generate-duplicate");
+    repo.init_git();
+    repo.write_full_setup("lead", "lead-node", "echo noop");
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(70, "Speed up inference", "lead");
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(70, comments);
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Generate(GenerateArgs {
+            title: "Speed up inference".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    let err = commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Speed up inference".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("duplicates existing thesis"));
+    assert!(
+        github.created_issues().is_empty(),
+        "duplicate thesis should not create a new issue"
+    );
+}
+
+#[tokio::test]
+async fn scenario_generate_accepts_unique_thesis() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("generate-unique");
+    repo.init_git();
+    repo.write_full_setup("lead", "lead-node", "echo noop");
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(71, "Speed up inference", "lead");
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(71, comments);
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Generate(GenerateArgs {
+            title: "Reduce memory allocation".to_string(),
+            body: "Body".to_string(),
+        }),
+    );
+
+    commands::generate::run(
+        &ctx,
+        &GenerateArgs {
+            title: "Reduce memory allocation".to_string(),
+            body: "Body".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let created = github.created_issues();
+    assert_eq!(created.len(), 1, "unique thesis should create one issue");
+    assert_eq!(created[0].title, "Reduce memory allocation");
+}
 
 #[tokio::test]
 #[ignore = "hybrid workflow delegates lead orchestration to the agent; Rust-side loop removed in PR #118"]


### PR DESCRIPTION
## Summary
- reject duplicate thesis titles in `polyresearch generate` by normalizing proposed titles against existing thesis issues before creating a new one
- include the conflicting thesis number and current thesis phase in the duplicate error so the lead can pick a genuinely different idea
- strengthen the lead workflow prompt and add unit, e2e, and scenario coverage for duplicate thesis generation

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets`

References #138.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new validation that can block thesis creation by treating normalized titles as duplicates, which may impact lead workflows if the matching logic is too strict. Covered by new unit and e2e/scenario tests, reducing regression risk.
> 
> **Overview**
> `polyresearch generate` now **refuses to create a thesis** when the proposed title matches an existing thesis title after normalization (case-insensitive, punctuation/whitespace agnostic), and returns an error listing the conflicting thesis numbers and their current phase.
> 
> Adds `ThesisState::phase_label()` for readable phase strings, updates the lead workflow prompt to explicitly deduplicate via `status --json`, and introduces unit + e2e/scenario tests to ensure duplicate titles are rejected and unique titles still create issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a020d7c3f1bcfa4ee56f49a82bf547d0bd948a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->