### PR TITLE
Fix duplicate claim with inconsistent node name (#156)

### DIFF
--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -95,7 +95,7 @@ Sleep 60 seconds, then go back to step 1.
 
 ## Important
 
-- Never run `polyresearch sync`, `polyresearch decide`, `polyresearch policy-check`, or `polyresearch generate`. Those are lead-only commands.
+- Never run `polyresearch init`, `polyresearch sync`, `polyresearch decide`, `polyresearch policy-check`, or `polyresearch generate`. Those are either setup-only or lead-only commands.
 - Never modify files in the project root checkout. Work only in .worktrees/ thesis worktrees.
 - Do not use raw `git add .` or `git commit` for code changes. `polyresearch commit` automatically stages only files within the editable surface.
 - Always record your attempt via `polyresearch attempt` before submitting or releasing. The protocol requires it.

--- a/cli/src/commands/bootstrap.rs
+++ b/cli/src/commands/bootstrap.rs
@@ -88,7 +88,7 @@ pub fn scaffold(ctx: &AppContext, args: &BootstrapArgs) -> Result<(std::path::Pa
 
     write_templates(&repo_root, args.goal.as_deref(), &login)?;
     ensure_lead_login(&repo_root, &login)?;
-    initialize_node(&repo_root, &args.overrides)?;
+    initialize_node(&repo_root, &args.overrides, &login)?;
     normalize_program_md(&repo_root)?;
 
     Ok((repo_root, login))
@@ -351,8 +351,12 @@ fn replace_goal_section(template: &str, goal: &str) -> String {
     )
 }
 
-fn initialize_node(repo_root: &Path, overrides: &crate::cli::NodeOverrides) -> Result<()> {
-    commands::ensure_node_config(repo_root)?;
+fn initialize_node(
+    repo_root: &Path,
+    overrides: &crate::cli::NodeOverrides,
+    login: &str,
+) -> Result<()> {
+    commands::ensure_node_config(repo_root, login)?;
     if overrides.has_any() {
         let config = NodeConfig::load(repo_root)?;
         config.with_overrides(overrides).save(repo_root)?;

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -52,7 +52,8 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
         }
     };
 
-    ensure_node_config(&ctx.repo_root)?;
+    let login = local_ctx.github.current_login()?;
+    ensure_node_config(&ctx.repo_root, &login)?;
     let node_config = NodeConfig::load(&ctx.repo_root)?.with_overrides(&args.overrides);
     let node_id = node_config.node_id.clone();
     let agent_command = node_config.agent.command.clone();
@@ -117,8 +118,8 @@ fn clone_repo(url: &str, repo_root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn ensure_node_config(repo_root: &Path) -> Result<()> {
-    commands::ensure_node_config(repo_root)
+fn ensure_node_config(repo_root: &Path, login: &str) -> Result<()> {
+    commands::ensure_node_config(repo_root, login)
 }
 
 pub fn is_crash_cooldown(

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,12 +1,10 @@
-use std::env;
-use std::process::Command;
-
 use color_eyre::eyre::Result;
-use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::InitArgs;
-use crate::commands::{AppContext, print_value, read_node_config, write_node_config};
+use crate::commands::{
+    AppContext, default_machine_id, print_value, read_node_config, write_node_config,
+};
 use crate::config::DEFAULT_CAPACITY;
 
 #[derive(Debug, Serialize)]
@@ -58,26 +56,4 @@ pub async fn run(ctx: &AppContext, args: &InitArgs) -> Result<()> {
             value.repo, value.node, value.github_login, value.capacity
         )
     })
-}
-
-fn default_machine_id() -> String {
-    let hostname = resolve_hostname();
-    let suffix: u16 = rand::rng().random();
-    format!("{hostname}-{suffix:04x}")
-}
-
-fn resolve_hostname() -> String {
-    if let Ok(hostname) = env::var("HOSTNAME")
-        && !hostname.trim().is_empty()
-    {
-        return hostname;
-    }
-
-    let output = Command::new("hostname").output();
-    match output {
-        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
-            .map(|value| value.trim().to_string())
-            .unwrap_or_else(|_| "local".to_string()),
-        _ => "local".to_string(),
-    }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -151,7 +151,7 @@ pub(crate) fn resolve_hostname() -> String {
     if let Ok(hostname) = env::var("HOSTNAME")
         && !hostname.trim().is_empty()
     {
-        return hostname;
+        return hostname.trim().to_string();
     }
 
     let output = Command::new("hostname").output();
@@ -305,4 +305,56 @@ pub fn slugify(input: &str) -> String {
         }
     }
     output.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_hostname;
+    use std::env;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn hostname_env_lock() -> &'static Mutex<()> {
+        static HOSTNAME_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        HOSTNAME_ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct HostnameEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        previous: Option<String>,
+    }
+
+    impl HostnameEnvGuard {
+        fn set(value: &str) -> Self {
+            let guard = hostname_env_lock()
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let previous = env::var("HOSTNAME").ok();
+            unsafe {
+                env::set_var("HOSTNAME", value);
+            }
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for HostnameEnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(previous) => unsafe {
+                    env::set_var("HOSTNAME", previous);
+                },
+                None => unsafe {
+                    env::remove_var("HOSTNAME");
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_hostname_trims_hostname_env_var() {
+        let _guard = HostnameEnvGuard::set("worker-host  \n");
+        assert_eq!(resolve_hostname(), "worker-host");
+    }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -23,12 +23,14 @@ pub mod status;
 pub mod submit;
 pub mod sync;
 
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 
 use color_eyre::eyre::{Context, Result, eyre};
+use rand::RngExt;
 use serde::Serialize;
 
 use crate::cli::{Cli, Commands};
@@ -139,26 +141,36 @@ pub fn write_node_config(
     config.with_overrides(overrides).save(repo_root)
 }
 
-pub fn ensure_node_config(repo_root: &Path) -> Result<()> {
+pub(crate) fn default_machine_id() -> String {
+    let hostname = resolve_hostname();
+    let suffix: u16 = rand::rng().random();
+    format!("{hostname}-{suffix:04x}")
+}
+
+pub(crate) fn resolve_hostname() -> String {
+    if let Ok(hostname) = env::var("HOSTNAME")
+        && !hostname.trim().is_empty()
+    {
+        return hostname;
+    }
+
+    let output = Command::new("hostname").output();
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+            .map(|value| value.trim().to_string())
+            .unwrap_or_else(|_| "local".to_string()),
+        _ => "local".to_string(),
+    }
+}
+
+pub fn ensure_node_config(repo_root: &Path, login: &str) -> Result<()> {
     let config_path = repo_root.join(".polyresearch-node.toml");
     if config_path.exists() {
         return Ok(());
     }
     eprintln!("No node config found, initializing...");
-    let hostname = Command::new("hostname")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-    let suffix: String = {
-        use rand::RngExt;
-        let mut rng = rand::rng();
-        (0..4)
-            .map(|_| format!("{:x}", rng.random_range(0u8..16)))
-            .collect()
-    };
-    let node_id = format!("{hostname}-{suffix}");
+    let machine_id = default_machine_id();
+    let node_id = format!("{login}/{machine_id}");
     write_node_config(repo_root, &node_id, &crate::cli::NodeOverrides::default())?;
     eprintln!("Initialized node as `{node_id}`");
     Ok(())

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -390,6 +390,42 @@ fn clear_node_id_env() {
     }
 }
 
+fn expected_hostname() -> String {
+    if let Ok(hostname) = env::var("HOSTNAME")
+        && !hostname.trim().is_empty()
+    {
+        return hostname;
+    }
+
+    let output = Command::new("hostname").output();
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+            .map(|value| value.trim().to_string())
+            .unwrap_or_else(|_| "local".to_string()),
+        _ => "local".to_string(),
+    }
+}
+
+fn assert_login_prefixed_node_id(node_id: &str, login: &str) {
+    let (actual_login, machine_id) = node_id
+        .split_once('/')
+        .unwrap_or_else(|| panic!("node_id should contain a login prefix: {node_id}"));
+    assert_eq!(actual_login, login);
+
+    let expected_prefix = format!("{}-", expected_hostname());
+    assert!(
+        machine_id.starts_with(&expected_prefix),
+        "node_id should start with hostname prefix `{expected_prefix}`, got `{machine_id}`"
+    );
+
+    let suffix = &machine_id[expected_prefix.len()..];
+    assert_eq!(suffix.len(), 4, "node suffix should be 4 hex chars");
+    assert!(
+        suffix.chars().all(|c| c.is_ascii_hexdigit()),
+        "node suffix should be hex, got `{suffix}`"
+    );
+}
+
 #[tokio::test]
 async fn init_writes_node_identity() {
     let _guard = NodeIdEnvGuard::lock_clean();
@@ -433,6 +469,29 @@ async fn init_writes_node_identity() {
     assert_eq!(config.node_id, "lead/test-node");
     assert_eq!(config.api_budget, DEFAULT_API_BUDGET);
     assert_eq!(config.capacity, 50);
+}
+
+#[test]
+fn ensure_node_config_includes_login_prefix() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("ensure-node-config-prefix");
+
+    commands::ensure_node_config(&repo.path, "alice").unwrap();
+
+    let config = NodeConfig::load(&repo.path).unwrap();
+    assert_login_prefixed_node_id(&config.node_id, "alice");
+}
+
+#[test]
+fn ensure_node_config_skips_existing_config() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("ensure-node-config-existing");
+    write_node_config(&repo.path, "alice/existing-node");
+
+    commands::ensure_node_config(&repo.path, "alice").unwrap();
+
+    let config = NodeConfig::load(&repo.path).unwrap();
+    assert_eq!(config.node_id, "alice/existing-node");
 }
 
 #[tokio::test]
@@ -812,6 +871,40 @@ async fn claim_rejects_already_claimed_thesis() {
         }),
     );
     commands::write_node_id(&repo.path, "node-b").unwrap();
+
+    let error = commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("not claimable"));
+}
+
+#[tokio::test]
+async fn claim_rejects_thesis_with_active_claim_different_node_format() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("claim-format-mismatch");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "alice/node-a").unwrap();
 
     let error = commands::claim::run(
         &ctx,

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -394,7 +394,7 @@ fn expected_hostname() -> String {
     if let Ok(hostname) = env::var("HOSTNAME")
         && !hostname.trim().is_empty()
     {
-        return hostname;
+        return hostname.trim().to_string();
     }
 
     let output = Command::new("hostname").output();

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use polyresearch::cli::{BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides};
+use polyresearch::cli::{
+    BootstrapArgs, Cli, Commands, ContributeArgs, IssueArgs, LeadArgs, NodeOverrides,
+};
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
-use polyresearch::config::{DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig};
+use polyresearch::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch::github::{
     Author, CommentUser, GitHubApi, Issue, IssueComment, Label, PullRequest, RepoRef,
 };
@@ -184,6 +186,42 @@ fn run_git_output(path: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn expected_hostname() -> String {
+    if let Ok(hostname) = env::var("HOSTNAME")
+        && !hostname.trim().is_empty()
+    {
+        return hostname;
+    }
+
+    let output = Command::new("hostname").output();
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+            .map(|value| value.trim().to_string())
+            .unwrap_or_else(|_| "local".to_string()),
+        _ => "local".to_string(),
+    }
+}
+
+fn assert_login_prefixed_node_id(node_id: &str, login: &str) {
+    let (actual_login, machine_id) = node_id
+        .split_once('/')
+        .unwrap_or_else(|| panic!("node_id should contain a login prefix: {node_id}"));
+    assert_eq!(actual_login, login);
+
+    let expected_prefix = format!("{}-", expected_hostname());
+    assert!(
+        machine_id.starts_with(&expected_prefix),
+        "node_id should start with hostname prefix `{expected_prefix}`, got `{machine_id}`"
+    );
+
+    let suffix = &machine_id[expected_prefix.len()..];
+    assert_eq!(suffix.len(), 4, "node suffix should be 4 hex chars");
+    assert!(
+        suffix.chars().all(|c| c.is_ascii_hexdigit()),
+        "node suffix should be hex, got `{suffix}`"
+    );
 }
 
 fn write_sync_repo_files(path: &Path, lead: &str, default_branch: &str, node_id: &str) {
@@ -745,6 +783,82 @@ async fn scenario_contribute_improved() {
     .await;
 
     assert!(result.is_ok(), "contribute should succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn scenario_contribute_auto_creates_login_prefixed_node() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("contrib-auto-node");
+    repo.init_git();
+
+    repo.write_program_md("lead");
+    repo.write_prepare_md();
+    repo.write_results_tsv();
+
+    let thesis_num = 11;
+    let agent_cmd = mock_agent_command("no_improvement");
+    let (issue, comments) = make_approved_thesis(thesis_num, "Auto-created node id", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(thesis_num, comments);
+
+    let contribute_args = ContributeArgs {
+        url: None,
+        once: true,
+        max_parallel: Some(1),
+        sleep_secs: 0,
+        overrides: NodeOverrides {
+            agent_command: Some(agent_cmd),
+            ..Default::default()
+        },
+    };
+    let contribute_ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        true,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides {
+                agent_command: contribute_args.overrides.agent_command.clone(),
+                ..Default::default()
+            },
+        }),
+    );
+
+    let result = commands::contribute::run(&contribute_ctx, &contribute_args).await;
+    assert!(result.is_ok(), "contribute should succeed: {result:?}");
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    assert_login_prefixed_node_id(&node_config.node_id, "contributor");
+
+    let claim_ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Claim(IssueArgs { issue: thesis_num }),
+    );
+
+    let claim_result = commands::claim::run(&claim_ctx, &IssueArgs { issue: thesis_num }).await;
+    assert!(
+        claim_result.is_ok(),
+        "claim should succeed: {claim_result:?}"
+    );
+
+    let expected_claim = ProtocolComment::Claim {
+        thesis: thesis_num,
+        node: node_config.node_id.clone(),
+    }
+    .render();
+    let bodies = github.comment_bodies_on(thesis_num);
+    assert!(
+        bodies.iter().any(|body| body == &expected_claim),
+        "claim should use the login-prefixed node id, got: {bodies:?}"
+    );
 }
 
 #[tokio::test]

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -192,7 +192,7 @@ fn expected_hostname() -> String {
     if let Ok(hostname) = env::var("HOSTNAME")
         && !hostname.trim().is_empty()
     {
-        return hostname;
+        return hostname.trim().to_string();
     }
 
     let output = Command::new("hostname").output();


### PR DESCRIPTION
## Summary
- make auto-created node ids use the same `login/hostname-xxxx` format as `polyresearch init`
- pass the current GitHub login into `contribute` and `bootstrap` when they need to create `.polyresearch-node.toml`
- add e2e and scenario coverage for login-prefixed auto-config creation and the same-machine/different-format claim regression

## Test plan
- [x] `cargo test`

Closes #156.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches node identity generation and claim eligibility behavior; a formatting mistake could break claim/attempt attribution across existing contributors or scripts.
> 
> **Overview**
> Auto-created node configs now use the same `login/hostname-xxxx` node ID format as `polyresearch init`, and `bootstrap`/`contribute` thread the current GitHub login into `ensure_node_config` when initializing `.polyresearch-node.toml`.
> 
> Refactors hostname/machine-id generation into shared helpers (`default_machine_id`/`resolve_hostname`), updates contributor workflow docs to mark `polyresearch init` as setup-only, and adds unit/e2e/scenario coverage for login-prefixed auto-config creation plus a regression test for claim rejection when an active claim uses a different node-id format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04d2444213646674c7d418d1fdaba624e8255a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->