### PR TITLE
Fix lead policy-pass without decide follow-through

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -38,7 +38,7 @@ If there are no policy-check duties, proceed to step 3.
 
 ### 3. Decide ready PRs
 
-Look for decide duties. For each ready PR, run `polyresearch decide <pr>`. The CLI evaluates the PR's metric, compares it against the baseline and best accepted, and posts the decision.
+Run `polyresearch duties` again to refresh the duty list. Policy-checks from step 2 may have made new PRs eligible for decisions. Look for decide duties. For each ready PR, run `polyresearch decide <pr>`. The CLI evaluates the PR's metric, compares it against the baseline and best accepted, and posts the decision.
 
 If decide fails because of merge conflicts, the CLI will attempt a rebase. If that also fails, the PR will be closed as stale — this is expected. The contributor can rebase and resubmit.
 

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -452,10 +452,7 @@ pub fn spawn_workflow_agent(
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
 
-    eprintln!(
-        "Spawning workflow agent in {}...",
-        work_dir.display(),
-    );
+    eprintln!("Spawning workflow agent in {}...", work_dir.display(),);
     let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;
 
     {
@@ -468,9 +465,7 @@ pub fn spawn_workflow_agent(
             .wrap_err("failed to write prompt to agent stdin")?;
     }
 
-    let status = child
-        .wait()
-        .wrap_err("failed to wait for workflow agent")?;
+    let status = child.wait().wrap_err("failed to wait for workflow agent")?;
 
     if !status.success() {
         let code = status
@@ -761,10 +756,7 @@ mod tests {
             parse_prepare_key(&dir, "prereq_command"),
             Some("npm run build".to_string())
         );
-        assert_eq!(
-            parse_prepare_key(&dir, "eval_cores"),
-            Some("2".to_string())
-        );
+        assert_eq!(parse_prepare_key(&dir, "eval_cores"), Some("2".to_string()));
 
         fs::remove_dir_all(dir).unwrap();
     }
@@ -773,11 +765,7 @@ mod tests {
     fn parse_prepare_key_returns_none_for_missing_key() {
         let dir = std::env::temp_dir().join(format!("prepare-missing-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
-        fs::write(
-            dir.join("PREPARE.md"),
-            "# Evaluation\n\neval_cores: 1\n",
-        )
-        .unwrap();
+        fs::write(dir.join("PREPARE.md"), "# Evaluation\n\neval_cores: 1\n").unwrap();
 
         assert_eq!(parse_prepare_key(&dir, "prereq_command"), None);
 
@@ -788,11 +776,7 @@ mod tests {
     fn parse_prepare_key_returns_none_for_empty_value() {
         let dir = std::env::temp_dir().join(format!("prepare-empty-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
-        fs::write(
-            dir.join("PREPARE.md"),
-            "# Evaluation\n\nprereq_command:\n",
-        )
-        .unwrap();
+        fs::write(dir.join("PREPARE.md"), "# Evaluation\n\nprereq_command:\n").unwrap();
 
         assert_eq!(parse_prepare_key(&dir, "prereq_command"), None);
 
@@ -881,6 +865,24 @@ mod tests {
         assert!(
             prompt.contains("primary goal"),
             "base prompt must frame queue depth as the primary goal"
+        );
+    }
+
+    #[test]
+    fn lead_prompt_reruns_duties_before_decide() {
+        let prompt = lead_workflow_prompt(false, 60);
+        let step3 = prompt
+            .split("### 3. Decide ready PRs")
+            .nth(1)
+            .and_then(|rest| {
+                rest.split("### 4. Check the queue and generate theses")
+                    .next()
+            })
+            .expect("prompt should contain steps 3 and 4");
+
+        assert!(
+            step3.contains("Run `polyresearch duties` again"),
+            "step 3 should refresh duties after policy checks: {step3}"
         );
     }
 }

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -4,8 +4,8 @@ use color_eyre::eyre::{Result, eyre};
 
 use crate::agent;
 use crate::cli::LeadArgs;
-use crate::commands::{self, AppContext};
 use crate::commands::decide;
+use crate::commands::{self, AppContext};
 use crate::comments::{Outcome, ProtocolComment};
 use crate::config::{NodeConfig, ProtocolConfig};
 use crate::ledger::Ledger;
@@ -53,28 +53,27 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
         match result {
             Ok(()) => {
                 match RepositoryState::derive(&ctx.github, &ctx.config).await {
-                    Ok(repo_state)
-                        if repo_state.queue_depth < config.min_queue_depth =>
-                    {
-                        eprintln!(
-                            "Warning: queue depth is {} (min = {}). \
-                             Lead agent may not have generated enough theses.",
-                            repo_state.queue_depth, config.min_queue_depth
-                        );
-                        if !once {
+                    Ok(repo_state) => {
+                        if let Err(err) = decide_ready_prs(ctx, &config, &repo_state) {
+                            eprintln!("Warning: post-agent decide sweep failed: {err}");
+                        }
+
+                        if repo_state.queue_depth < config.min_queue_depth {
                             eprintln!(
-                                "Restarting agent to refill queue in {sleep_secs}s..."
+                                "Warning: queue depth is {} (min = {}). \
+                                 Lead agent may not have generated enough theses.",
+                                repo_state.queue_depth, config.min_queue_depth
                             );
-                            tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
-                            continue;
+                            if !once {
+                                eprintln!("Restarting agent to refill queue in {sleep_secs}s...");
+                                tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                                continue;
+                            }
                         }
                     }
                     Err(err) => {
-                        eprintln!(
-                            "Warning: could not verify queue depth after agent run: {err}"
-                        );
+                        eprintln!("Warning: could not verify queue depth after agent run: {err}");
                     }
-                    _ => {}
                 }
                 break;
             }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -10,8 +10,7 @@ use color_eyre::eyre::{Result, eyre};
 use polyresearch::agent;
 use polyresearch::cli::{
     AdminArgs, AdminCommands, AdminReleaseClaimArgs, AdminReopenThesisArgs, AttemptArgs,
-    CommitArgs,
-    BatchClaimArgs, Cli, Commands, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
+    BatchClaimArgs, Cli, Commands, CommitArgs, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
     NodeOverrides, PrArgs, ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
@@ -2167,6 +2166,89 @@ async fn duties_lead_duties_included_in_lead_context() {
 }
 
 #[tokio::test]
+async fn duties_transition_from_policy_check_to_decide_after_policy_pass() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("duties-policy-to-decide");
+    let now = chrono::Utc::now();
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Duties);
+
+    let mut thesis = make_approved_thesis(1);
+    thesis.pull_requests.push(PullRequestState {
+        pr: PullRequest {
+            number: 8,
+            title: "Candidate PR".to_string(),
+            body: None,
+            state: "OPEN".to_string(),
+            head_ref_name: "thesis/1-test-attempt-1".to_string(),
+            head_ref_oid: Some("abc123".to_string()),
+            base_ref_name: Some("main".to_string()),
+            created_at: now,
+            closed_at: None,
+            merged_at: None,
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
+            url: None,
+            mergeable: None,
+        },
+        thesis_number: Some(1),
+        policy_pass: false,
+        maintainer_approved: true,
+        maintainer_rejected: false,
+        review_claims: vec![],
+        reviews: vec![],
+        decision: None,
+        findings: vec![],
+    });
+    thesis.phase = ThesisPhase::CandidateSubmitted;
+
+    let report = commands::duties::check(
+        &ctx,
+        &make_repo_state(vec![thesis.clone()], 1, 1, None),
+        DutyContext::Lead,
+    )
+    .unwrap();
+    assert!(
+        report.blocking.iter().any(|d| d.category == "policy-check"),
+        "lead context should require policy-check before policy_pass: {:?}",
+        report.blocking
+    );
+    assert!(
+        !report.blocking.iter().any(|d| d.category == "decide"),
+        "lead context should not offer decide before policy_pass: {:?}",
+        report.blocking
+    );
+
+    thesis.pull_requests[0].policy_pass = true;
+    thesis.phase = ThesisPhase::InReview;
+
+    let report = commands::duties::check(
+        &ctx,
+        &make_repo_state(vec![thesis], 1, 1, None),
+        DutyContext::Lead,
+    )
+    .unwrap();
+    assert!(
+        report.blocking.iter().any(|d| d.category == "decide"),
+        "lead context should offer decide after policy_pass: {:?}",
+        report.blocking
+    );
+    assert!(
+        !report.blocking.iter().any(|d| d.category == "policy-check"),
+        "policy-check duty should disappear after policy_pass: {:?}",
+        report.blocking
+    );
+}
+
+#[tokio::test]
 async fn duties_submit_skipped_for_closed_thesis() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-closed-submit");
@@ -2347,9 +2429,13 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2363,7 +2449,8 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 outcome: Outcome::NonImprovement,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2430,7 +2517,9 @@ async fn duties_submit_present_after_single_rejection() {
             created_at: now - chrono::Duration::hours(1),
             closed_at: Some(now - chrono::Duration::minutes(30)),
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2509,9 +2598,13 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2525,7 +2618,8 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 outcome: Outcome::Stale,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2641,9 +2735,13 @@ async fn duties_submit_present_when_prior_rejections_predate_claim() {
                 head_ref_oid: Some("old-sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(8) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2983,9 +3081,7 @@ Test goal.
 fn write_node_config(path: &PathBuf, node_id: &str) {
     fs::write(
         path.join(".polyresearch-node.toml"),
-        format!(
-            "node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"
-        ),
+        format!("node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"),
     )
     .unwrap();
 }
@@ -4668,6 +4764,61 @@ fn make_decidable_state(
         vec![pr],
         HashMap::from([(pr_number, pr_comments)]),
     )
+}
+
+#[tokio::test]
+async fn lead_decide_ready_prs_decides_policy_passed_pr() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("lead-decide-ready");
+    init_git_repo(&repo.path);
+    write_program_md(&repo.path);
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
+    run_git(&repo.path, &["add", "-A"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+
+    let (issues, issue_comments, prs, pr_comments) =
+        make_decidable_state(10, 50, 95.0, 90.0, "lead");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        issues,
+        issue_comments,
+        prs,
+        pr_comments,
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        "lead",
+        false,
+        Commands::Duties,
+    );
+    let config = ProtocolConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &config).await.unwrap();
+
+    commands::lead::decide_ready_prs(&ctx, &config, &repo_state).unwrap();
+
+    assert!(
+        mock.merged_prs.lock().unwrap().contains(&50),
+        "policy-passed PR should be decided and merged"
+    );
+    assert!(
+        mock.closed_issues.lock().unwrap().contains(&10),
+        "accepted thesis should be closed"
+    );
+    assert!(
+        mock.posted_issue_comments
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(number, body)| *number == 50
+                && body.contains("polyresearch:decision")
+                && body.contains("accepted")),
+        "should post an accepted decision comment on the PR"
+    );
 }
 
 #[tokio::test]

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use polyresearch::cli::{BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides};
+use polyresearch::cli::{
+    BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides, PrArgs,
+};
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
 use polyresearch::config::{DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig};
@@ -2940,6 +2942,199 @@ fn seed_decidable_pr(github: &ScenarioGitHub, thesis_num: u64, pr_num: u64, lead
             filename: "src/decidable.js".to_string(),
         }],
     );
+}
+
+fn seed_pr_needing_policy_check(github: &ScenarioGitHub, thesis_num: u64, pr_num: u64, lead: &str) {
+    let now = chrono::Utc::now();
+    let branch = format!("thesis/{thesis_num}-policy-check-thesis");
+    let (issue, mut issue_comments) = make_approved_thesis(thesis_num, "Policy-check thesis", lead);
+
+    issue_comments.push(IssueComment {
+        id: thesis_num * 100 + 1,
+        body: ProtocolComment::Claim {
+            thesis: thesis_num,
+            node: "worker-a".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(30),
+        updated_at: None,
+    });
+
+    issue_comments.push(IssueComment {
+        id: thesis_num * 100 + 2,
+        body: ProtocolComment::Attempt {
+            thesis: thesis_num,
+            branch: branch.clone(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Improvement awaiting policy check".to_string(),
+            annotations: None,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(20),
+        updated_at: None,
+    });
+
+    let pr = PullRequest {
+        number: pr_num,
+        title: format!("Thesis #{thesis_num}: Policy-check thesis"),
+        body: Some(format!("References #{thesis_num}")),
+        state: "OPEN".to_string(),
+        head_ref_name: branch,
+        head_ref_oid: Some("candidate-sha".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(15),
+        closed_at: None,
+        merged_at: None,
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
+        url: Some(format!("https://github.com/test/repo/pull/{pr_num}")),
+        mergeable: Some("MERGEABLE".to_string()),
+    };
+
+    github.seed_issue(issue);
+    github.seed_issue_comments(thesis_num, issue_comments);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(pr_num, vec![]);
+    github.seed_pr_files(
+        pr_num,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/policy-check.js".to_string(),
+        }],
+    );
+}
+
+#[tokio::test]
+async fn scenario_policy_check_then_decide_catches_up() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("policy-then-decide");
+    repo.init_git();
+    repo.write_full_setup("lead", "lead-node-policy", "echo noop");
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    seed_pr_needing_policy_check(&github, 64, 164, "lead");
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::PolicyCheck(PrArgs { pr: 164 }),
+    );
+
+    commands::policy_check::run(&ctx, &PrArgs { pr: 164 })
+        .await
+        .unwrap();
+
+    let pr_bodies = github.comment_bodies_on(164);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:policy-pass")),
+        "policy_check should post a policy-pass comment: {pr_bodies:?}"
+    );
+
+    let config = ProtocolConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
+    let pr_state = repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| thesis.pull_requests.iter())
+        .find(|pr_state| pr_state.pr.number == 164)
+        .expect("PR #164 should be present in derived state");
+    assert!(
+        pr_state.policy_pass,
+        "policy_check should make PR #164 decidable"
+    );
+    assert!(
+        pr_state.decision.is_none(),
+        "policy_check alone should not post a decision"
+    );
+
+    let lead_ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+    commands::lead::decide_ready_prs(&lead_ctx, &config, &repo_state).unwrap();
+
+    let pr_bodies = github.comment_bodies_on(164);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:decision") && body.contains("accepted")),
+        "decide_ready_prs should post an accepted decision after policy-check: {pr_bodies:?}"
+    );
+    assert!(github.is_pr_merged(164), "PR #164 should be merged");
+    assert!(github.is_issue_closed(64), "thesis #64 should be closed");
+}
+
+#[tokio::test]
+async fn scenario_lead_run_decides_policy_passed_pr_after_agent_exit() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("lead-post-agent-decide");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("no_improvement");
+    repo.write_full_setup("lead", "lead-node-post", &agent_cmd);
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    seed_decidable_pr(&github, 65, 165, "lead");
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "lead::run should succeed and apply the post-agent decide sweep: {result:?}"
+    );
+
+    let pr_bodies = github.comment_bodies_on(165);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:decision") && body.contains("accepted")),
+        "lead::run should post a decision comment after the agent exits: {pr_bodies:?}"
+    );
+    assert!(github.is_pr_merged(165), "PR #165 should be merged");
+    assert!(github.is_issue_closed(65), "thesis #65 should be closed");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- refresh lead duties between policy-check and decide so newly policy-passed PRs can surface as decide work in the same iteration
- add a post-agent decide sweep in `lead::run` so policy-passed PRs are still decided even if the workflow agent exits early
- cover the regression with prompt, e2e, and scenario tests for both the duty transition and the post-agent fallback path

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo test duties_transition_from_policy_check_to_decide_after_policy_pass`
- [x] `cargo test lead_decide_ready_prs_decides_policy_passed_pr`
- [x] `cargo test lead_prompt_reruns_duties_before_decide`
- [x] `cargo test scenario_policy_check_then_decide_catches_up`
- [x] `cargo test scenario_lead_run_decides_policy_passed_pr_after_agent_exit`

Closes #153.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates additional decision-making in the lead workflow (merging/closing PRs) and changes when those actions trigger; mistakes could prematurely decide PRs, but scope is limited to lead duty processing and is covered by new tests.
> 
> **Overview**
> Fixes a lead-workflow gap where PRs that become policy-passed weren’t reliably surfaced/decided in the same iteration.
> 
> Updates the lead agent prompt to **rerun `polyresearch duties` before deciding**, and adds a **post-agent `decide_ready_prs` sweep** in `commands::lead::run` so newly-decidable PRs are still merged/closed after the workflow agent finishes.
> 
> Adds targeted regression coverage: a prompt test asserting the refreshed-duty instruction, plus new e2e/scenario tests validating the **policy-check → decide duty transition** and the **post-agent decision fallback** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c8358b4572280e307c03f1fc42b2b848ec7f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->