### PR TITLE
Add regression coverage for resolved thesis claims

### DIFF
--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -7160,6 +7160,151 @@ fn admin_note_acknowledge_invalid_format_detected() {
     }
 }
 
+#[tokio::test]
+async fn repository_state_derive_excludes_resolved_claims_from_active_nodes() {
+    let resolved_fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let now = chrono::Utc::now();
+    let active_issue = Issue {
+        number: 21,
+        title: "Still claimed thesis".to_string(),
+        body: Some("Thesis with an active claim.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(2),
+        closed_at: None,
+        author: Some(Author {
+            login: resolved_fixture.lead_github_login.clone(),
+        }),
+        url: Some("https://example.test/issues/21".to_string()),
+    };
+    let active_issue_comments = vec![
+        IssueComment {
+            id: 2101,
+            body: ProtocolComment::Approval { thesis: 21 }.render(),
+            user: CommentUser {
+                login: resolved_fixture.lead_github_login.clone(),
+            },
+            created_at: now - chrono::Duration::minutes(90),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 2102,
+            body: ProtocolComment::Claim {
+                thesis: 21,
+                node: "worker-live".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "bob".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(60),
+            updated_at: None,
+        },
+    ];
+    let resolved_pr = PullRequest {
+        number: 90,
+        title: "Candidate for thesis #20".to_string(),
+        body: None,
+        state: "MERGED".to_string(),
+        head_ref_name: "thesis/20-claimed-attempt-1".to_string(),
+        head_ref_oid: Some("deadbeef".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(30),
+        closed_at: None,
+        merged_at: Some(now),
+        author: Some(Author {
+            login: "alice".to_string(),
+        }),
+        url: Some("https://example.test/pulls/90".to_string()),
+        mergeable: None,
+    };
+    let resolved_pr_comments = vec![
+        IssueComment {
+            id: 9000,
+            body: ProtocolComment::PolicyPass {
+                thesis: resolved_fixture.issue.number,
+                candidate_sha: "deadbeef".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: resolved_fixture.lead_github_login.clone(),
+            },
+            created_at: now - chrono::Duration::minutes(20),
+            updated_at: None,
+        },
+        IssueComment {
+            id: 9001,
+            body: ProtocolComment::Decision {
+                thesis: resolved_fixture.issue.number,
+                candidate_sha: "deadbeef".to_string(),
+                outcome: Outcome::Accepted,
+                confirmations: 0,
+            }
+            .render(),
+            user: CommentUser {
+                login: resolved_fixture.lead_github_login.clone(),
+            },
+            created_at: now - chrono::Duration::minutes(10),
+            updated_at: None,
+        },
+    ];
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![resolved_fixture.issue.clone(), active_issue.clone()],
+        HashMap::from([
+            (
+                resolved_fixture.issue.number,
+                resolved_fixture.comments.clone(),
+            ),
+            (active_issue.number, active_issue_comments),
+        ]),
+        vec![resolved_pr],
+        HashMap::from([(90, resolved_pr_comments)]),
+    ));
+    let config = ProtocolConfig {
+        required_confirmations: 0,
+        metric_tolerance: Some(0.01),
+        metric_direction: MetricDirection::HigherIsBetter,
+        metric_bound: None,
+        lead_github_login: Some(resolved_fixture.lead_github_login.clone()),
+        maintainer_github_login: Some("maintainer".to_string()),
+        auto_approve: true,
+        assignment_timeout: Duration::from_secs(24 * 60 * 60),
+        review_timeout: Duration::from_secs(12 * 60 * 60),
+        min_queue_depth: 5,
+        max_queue_depth: Some(10),
+        cli_version: None,
+        default_branch: None,
+    };
+
+    let state = RepositoryState::derive(&(mock as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
+    let resolved = state.get_thesis(resolved_fixture.issue.number).unwrap();
+    let active = state.get_thesis(active_issue.number).unwrap();
+
+    assert!(matches!(
+        resolved.phase,
+        ThesisPhase::Resolved {
+            outcome: Outcome::Accepted
+        }
+    ));
+    assert!(
+        resolved.active_claims.is_empty(),
+        "resolved thesis should not keep stale claims, got: {:?}",
+        resolved.active_claims
+    );
+    assert!(matches!(active.phase, ThesisPhase::Claimed));
+    assert_eq!(
+        state.active_nodes,
+        vec!["worker-live".to_string()],
+        "only still-claimed theses should contribute to active_nodes"
+    );
+}
+
 fn load_issue_fixture(name: &str) -> IssueFixture {
     serde_json::from_str(include_fixture(name)).unwrap()
 }

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -1264,6 +1264,168 @@ fn execute_decision_accepted_merges_and_closes() {
     );
 }
 
+#[tokio::test]
+async fn execute_decision_accepted_clears_claims_in_derived_state() {
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let now = chrono::Utc::now();
+    let thesis_number = 73;
+    let pr_number = 173;
+
+    github.seed_issue(Issue {
+        number: thesis_number,
+        title: "Accepted thesis".to_string(),
+        body: Some("Test accepted thesis.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(1),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: Some(format!(
+            "https://github.com/test/repo/issues/{thesis_number}"
+        )),
+    });
+    github.seed_issue_comments(
+        thesis_number,
+        vec![
+            IssueComment {
+                id: 7301,
+                body: ProtocolComment::Approval {
+                    thesis: thesis_number,
+                }
+                .render(),
+                user: CommentUser {
+                    login: "lead".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(50),
+                updated_at: None,
+            },
+            IssueComment {
+                id: 7302,
+                body: ProtocolComment::Claim {
+                    thesis: thesis_number,
+                    node: "worker-a".to_string(),
+                }
+                .render(),
+                user: CommentUser {
+                    login: "contributor".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(40),
+                updated_at: None,
+            },
+            IssueComment {
+                id: 7303,
+                body: ProtocolComment::Attempt {
+                    thesis: thesis_number,
+                    branch: "thesis/73-test".to_string(),
+                    metric: 0.95,
+                    baseline_metric: Some(0.90),
+                    observation: polyresearch::comments::Observation::Improved,
+                    summary: "Improved result".to_string(),
+                    annotations: None,
+                }
+                .render(),
+                user: CommentUser {
+                    login: "contributor".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(30),
+                updated_at: None,
+            },
+        ],
+    );
+    github.seed_pull_request(PullRequest {
+        number: pr_number,
+        title: "Candidate".to_string(),
+        body: Some(format!("References #{thesis_number}")),
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/73-test".to_string(),
+        head_ref_oid: Some("sha73".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(20),
+        closed_at: None,
+        merged_at: None,
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
+        url: Some(format!("https://github.com/test/repo/pull/{pr_number}")),
+        mergeable: None,
+    });
+    github.seed_pr_comments(
+        pr_number,
+        vec![IssueComment {
+            id: 17301,
+            body: ProtocolComment::PolicyPass {
+                thesis: thesis_number,
+                candidate_sha: "sha73".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(10),
+            updated_at: None,
+        }],
+    );
+
+    commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
+        pr_number,
+        thesis_number,
+        "sha73".to_string(),
+        "thesis/73-test",
+        polyresearch::comments::Outcome::Accepted,
+        0,
+        0,
+    )
+    .unwrap();
+
+    let config = ProtocolConfig {
+        required_confirmations: 0,
+        metric_tolerance: Some(0.01),
+        metric_direction: polyresearch::config::MetricDirection::HigherIsBetter,
+        metric_bound: None,
+        lead_github_login: Some("lead".to_string()),
+        maintainer_github_login: Some("lead".to_string()),
+        auto_approve: true,
+        assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
+        review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
+        min_queue_depth: 5,
+        max_queue_depth: Some(10),
+        cli_version: None,
+        default_branch: None,
+    };
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
+    let thesis = repo_state.get_thesis(thesis_number).unwrap();
+
+    assert!(github.is_pr_merged(pr_number), "PR should be merged");
+    assert!(
+        github.is_issue_closed(thesis_number),
+        "thesis should be closed after acceptance"
+    );
+    assert!(matches!(
+        thesis.phase,
+        polyresearch::state::ThesisPhase::Resolved {
+            outcome: polyresearch::comments::Outcome::Accepted
+        }
+    ));
+    assert!(
+        thesis.active_claims.is_empty(),
+        "resolved thesis should not retain stale claims, got: {:?}",
+        thesis.active_claims
+    );
+    assert!(
+        repo_state.active_nodes.is_empty(),
+        "resolved thesis should be removed from active_nodes, got: {:?}",
+        repo_state.active_nodes
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Lead hybrid loop error handling (issue #126)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an e2e regression test that derives repository state from issue and PR comments and ensures resolved theses do not contribute stale entries to `active_nodes`
- add a scenario regression test that runs `execute_decision` and re-derives state to confirm accepted theses clear `active_claims`
- note that `hybrid-agent-cli` already contains the state-level fix; this PR locks in higher-level coverage for issue #139

## Test plan
- [x] `cargo test`

## Issue
- Closes #139

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-only and add coverage to ensure resolved theses do not retain `active_claims` or contribute to `active_nodes`. The only risk is potential test flakiness due to time-based fixtures, but it uses deterministic relative timestamps.
> 
> **Overview**
> Adds regression tests to ensure **resolved/accepted theses clear stale claim state** when deriving `RepositoryState`.
> 
> One new e2e test asserts a resolved thesis has empty `active_claims` and does not contribute to `state.active_nodes` when another thesis is still claimed. A new scenario test runs `execute_decision` with an accepted outcome and then re-derives state to verify the thesis is resolved, the PR/issue are merged/closed, and claims/nodes are cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe007386cef797c28ff730bc52d9a137623f987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->