### PR TITLE
Fix contributor resume flow for stale claims

### DIFF
--- a/cli/prompts/contribute-workflow.md
+++ b/cli/prompts/contribute-workflow.md
@@ -10,6 +10,7 @@ All coordination goes through the `polyresearch` CLI. Key commands:
 - `polyresearch pace` — check hardware budget and API quota. Tells you how many parallel theses you can run.
 - `polyresearch status` — see queue depth, thesis states, claimable work.
 - `polyresearch claim <issue>` — claim a thesis. Prints the worktree path.
+- `polyresearch resume <issue>` — resume a thesis this node already claimed. Ensures the worktree and thesis context exist, then prints the worktree path.
 - `polyresearch attempt <issue> --metric <val> --baseline <val> --observation <obs> --summary "<text>"` — record an experiment result.
 - `polyresearch commit <issue> [--message "..."]` — commit only editable-surface changes. Always use this instead of raw `git commit`.
 - `polyresearch submit <issue>` — push and create a PR for an improved thesis. Run from the thesis worktree.
@@ -26,6 +27,7 @@ LOOP FOREVER:
 ### 1. Check duties
 
 Run `polyresearch duties`. If blocking duties exist, resolve each one:
+- **resume**: run `polyresearch resume <issue>`. It prints the thesis worktree path. `cd` into that worktree, then continue with step 4.
 - **submit**: go to the thesis worktree, run `polyresearch submit <issue>`.
 - If submit fails because a PR already exists for the branch, check if the PR was closed. If closed as stale (merge conflicts), try rebasing the branch onto the default branch and resubmit. If the PR was decided as non_improvement, release the thesis instead: `polyresearch release <issue> --reason no_improvement`.
 
@@ -61,7 +63,7 @@ If no work is available, sleep 60 seconds and restart the loop.
 ### 4. Run the experiment
 
 For each claimed thesis:
-1. The claim command prints the worktree path. `cd` into it.
+1. The claim or resume command prints the worktree path. `cd` into it.
 2. Read `.polyresearch/thesis.md` for the thesis context and prior attempts.
 3. Run the experiment: implement the idea, run the evaluation per PREPARE.md, iterate if needed.
 4. Write `.polyresearch/result.json` with the result.

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -277,12 +277,12 @@ pub fn parse_prepare_key(worktree_path: &Path, key: &str) -> Option<String> {
     let contents = fs::read_to_string(path).ok()?;
     for line in contents.lines() {
         let trimmed = line.trim();
-        if let Some((k, v)) = trimmed.split_once(':') {
-            if k.trim() == key {
-                let val = v.trim();
-                if !val.is_empty() {
-                    return Some(val.to_string());
-                }
+        if let Some((k, v)) = trimmed.split_once(':')
+            && k.trim() == key
+        {
+            let val = v.trim();
+            if !val.is_empty() {
+                return Some(val.to_string());
             }
         }
     }
@@ -452,10 +452,7 @@ pub fn spawn_workflow_agent(
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
 
-    eprintln!(
-        "Spawning workflow agent in {}...",
-        work_dir.display(),
-    );
+    eprintln!("Spawning workflow agent in {}...", work_dir.display(),);
     let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;
 
     {
@@ -468,9 +465,7 @@ pub fn spawn_workflow_agent(
             .wrap_err("failed to write prompt to agent stdin")?;
     }
 
-    let status = child
-        .wait()
-        .wrap_err("failed to wait for workflow agent")?;
+    let status = child.wait().wrap_err("failed to wait for workflow agent")?;
 
     if !status.success() {
         let code = status
@@ -761,10 +756,7 @@ mod tests {
             parse_prepare_key(&dir, "prereq_command"),
             Some("npm run build".to_string())
         );
-        assert_eq!(
-            parse_prepare_key(&dir, "eval_cores"),
-            Some("2".to_string())
-        );
+        assert_eq!(parse_prepare_key(&dir, "eval_cores"), Some("2".to_string()));
 
         fs::remove_dir_all(dir).unwrap();
     }
@@ -773,11 +765,7 @@ mod tests {
     fn parse_prepare_key_returns_none_for_missing_key() {
         let dir = std::env::temp_dir().join(format!("prepare-missing-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
-        fs::write(
-            dir.join("PREPARE.md"),
-            "# Evaluation\n\neval_cores: 1\n",
-        )
-        .unwrap();
+        fs::write(dir.join("PREPARE.md"), "# Evaluation\n\neval_cores: 1\n").unwrap();
 
         assert_eq!(parse_prepare_key(&dir, "prereq_command"), None);
 
@@ -788,11 +776,7 @@ mod tests {
     fn parse_prepare_key_returns_none_for_empty_value() {
         let dir = std::env::temp_dir().join(format!("prepare-empty-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
-        fs::write(
-            dir.join("PREPARE.md"),
-            "# Evaluation\n\nprereq_command:\n",
-        )
-        .unwrap();
+        fs::write(dir.join("PREPARE.md"), "# Evaluation\n\nprereq_command:\n").unwrap();
 
         assert_eq!(parse_prepare_key(&dir, "prereq_command"), None);
 
@@ -842,6 +826,24 @@ mod tests {
         assert!(
             prompt.contains("50%"),
             "prompt must include the capacity percentage"
+        );
+    }
+
+    #[test]
+    fn contribute_prompt_mentions_resume_command() {
+        let prompt = contribute_workflow_prompt(false, 60, None, 75);
+        assert!(
+            prompt.contains("polyresearch resume <issue>"),
+            "prompt must teach the workflow agent how to resume stale claims"
+        );
+    }
+
+    #[test]
+    fn contribute_prompt_mentions_resume_duty_resolution() {
+        let prompt = contribute_workflow_prompt(false, 60, None, 75);
+        assert!(
+            prompt.contains("**resume**: run `polyresearch resume <issue>`"),
+            "prompt must explain how to resolve resume duties"
         );
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -34,6 +34,7 @@ pub enum Commands {
     Pace,
     Status(StatusArgs),
     Claim(IssueArgs),
+    Resume(IssueArgs),
     Commit(CommitArgs),
     BatchClaim(BatchClaimArgs),
     Attempt(AttemptArgs),

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -21,7 +21,7 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
-    let duty_report = duties::check(ctx, &repo_state, duties::context_for(ctx))?;
+    let duty_report = duties::claim_gate(ctx, &repo_state)?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report
             .blocking

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -21,7 +21,7 @@ pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
-    let duty_report = duties::check(ctx, &repo_state, duties::DutyContext::Contribute)?;
+    let duty_report = duties::check(ctx, &repo_state, duties::context_for(ctx))?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report
             .blocking

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -24,7 +24,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
-    let duty_report = duties::check(ctx, &repo_state, duties::DutyContext::Contribute)?;
+    let duty_report = duties::check(ctx, &repo_state, duties::context_for(ctx))?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report
             .blocking

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -24,7 +24,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 
-    let duty_report = duties::check(ctx, &repo_state, duties::context_for(ctx))?;
+    let duty_report = duties::claim_gate(ctx, &repo_state)?;
     if !duty_report.blocking.is_empty() {
         let items: Vec<String> = duty_report
             .blocking

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -28,6 +28,16 @@ pub struct DutyReport {
     pub clean: bool,
 }
 
+pub fn context_for(ctx: &AppContext) -> DutyContext {
+    match (
+        ctx.github.current_login().ok(),
+        ctx.config.lead_github_login.as_deref(),
+    ) {
+        (Some(login), Some(lead)) if login == lead => DutyContext::Lead,
+        _ => DutyContext::Contribute,
+    }
+}
+
 pub fn check(
     ctx: &AppContext,
     repo_state: &RepositoryState,
@@ -464,14 +474,7 @@ fn render_report(value: &DutyReport) -> String {
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let context = match (
-        ctx.github.current_login().ok(),
-        ctx.config.lead_github_login.as_deref(),
-    ) {
-        (Some(login), Some(lead)) if login == lead => DutyContext::Lead,
-        _ => DutyContext::Contribute,
-    };
-    let report = check(ctx, &repo_state, context)?;
+    let report = check(ctx, &repo_state, context_for(ctx))?;
 
     print_value(ctx, &report, render_report)
 }

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -38,6 +38,27 @@ pub fn context_for(ctx: &AppContext) -> DutyContext {
     }
 }
 
+pub fn claim_gate(ctx: &AppContext, repo_state: &RepositoryState) -> Result<DutyReport> {
+    let node_id = read_node_id(&ctx.repo_root).unwrap_or_default();
+    let mut blocking = Vec::new();
+    let mut advisory = Vec::new();
+
+    collect_claim_lifecycle_duties(
+        repo_state,
+        &node_id,
+        context_for(ctx),
+        &mut blocking,
+        &mut advisory,
+    );
+
+    let clean = blocking.is_empty();
+    Ok(DutyReport {
+        blocking,
+        advisory,
+        clean,
+    })
+}
+
 pub fn check(
     ctx: &AppContext,
     repo_state: &RepositoryState,
@@ -55,12 +76,44 @@ pub fn check(
     let mut blocking = Vec::new();
     let mut advisory = Vec::new();
 
+    collect_claim_lifecycle_duties(
+        repo_state,
+        &node_id,
+        context,
+        &mut blocking,
+        &mut advisory,
+    );
+
+    if is_lead && context == DutyContext::Lead {
+        check_lead_duties(ctx, repo_state, &mut blocking, &mut advisory)?;
+    }
+
+    let has_review_work = check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
+    if !is_lead || context == DutyContext::Contribute {
+        check_contributor_idle_state(ctx, repo_state, &node_id, has_review_work, &mut advisory)?;
+    }
+
+    let clean = blocking.is_empty();
+    Ok(DutyReport {
+        blocking,
+        advisory,
+        clean,
+    })
+}
+
+fn collect_claim_lifecycle_duties(
+    repo_state: &RepositoryState,
+    node_id: &str,
+    context: DutyContext,
+    blocking: &mut Vec<DutyItem>,
+    advisory: &mut Vec<DutyItem>,
+) {
     for thesis in &repo_state.theses {
         if thesis.issue.state != "OPEN" {
             continue;
         }
 
-        let claimed_by_me = thesis.is_claimed_by(&node_id);
+        let claimed_by_me = thesis.is_claimed_by(node_id);
         if !claimed_by_me {
             continue;
         }
@@ -144,22 +197,6 @@ pub fn check(
             }
         }
     }
-
-    if is_lead && context == DutyContext::Lead {
-        check_lead_duties(ctx, repo_state, &mut blocking, &mut advisory)?;
-    }
-
-    let has_review_work = check_review_opportunities(repo_state, &node_id, &login, &mut advisory);
-    if !is_lead || context == DutyContext::Contribute {
-        check_contributor_idle_state(ctx, repo_state, &node_id, has_review_work, &mut advisory)?;
-    }
-
-    let clean = blocking.is_empty();
-    Ok(DutyReport {
-        blocking,
-        advisory,
-        clean,
-    })
 }
 
 fn check_lead_duties(

--- a/cli/src/commands/duties.rs
+++ b/cli/src/commands/duties.rs
@@ -28,7 +28,11 @@ pub struct DutyReport {
     pub clean: bool,
 }
 
-pub fn check(ctx: &AppContext, repo_state: &RepositoryState, context: DutyContext) -> Result<DutyReport> {
+pub fn check(
+    ctx: &AppContext,
+    repo_state: &RepositoryState,
+    context: DutyContext,
+) -> Result<DutyReport> {
     let node_id = read_node_id(&ctx.repo_root).unwrap_or_default();
     let login = ctx.github.current_login().unwrap_or_default();
     let is_lead = ctx
@@ -63,17 +67,31 @@ pub fn check(ctx: &AppContext, repo_state: &RepositoryState, context: DutyContex
             .collect();
 
         if my_attempts.is_empty() {
-            advisory.push(DutyItem {
-                category: "attempt".to_string(),
-                message: format!(
-                    "Thesis #{}: claimed with 0 attempts posted yet.",
-                    thesis.issue.number
-                ),
-                command: format!(
-                    "polyresearch attempt {} --metric ... --observation ... --baseline ... --summary \"...\" OR polyresearch release {} --reason no_improvement",
-                    thesis.issue.number, thesis.issue.number
-                ),
-            });
+            let item = match context {
+                DutyContext::Lead => DutyItem {
+                    category: "attempt".to_string(),
+                    message: format!(
+                        "Thesis #{}: claimed with 0 attempts posted yet.",
+                        thesis.issue.number
+                    ),
+                    command: format!(
+                        "polyresearch attempt {} --metric ... --observation ... --baseline ... --summary \"...\" OR polyresearch release {} --reason no_improvement",
+                        thesis.issue.number, thesis.issue.number
+                    ),
+                },
+                DutyContext::Contribute => DutyItem {
+                    category: "resume".to_string(),
+                    message: format!(
+                        "Thesis #{}: claimed by this node with 0 attempts posted yet.",
+                        thesis.issue.number
+                    ),
+                    command: format!("polyresearch resume {}", thesis.issue.number),
+                },
+            };
+            match context {
+                DutyContext::Lead => advisory.push(item),
+                DutyContext::Contribute => blocking.push(item),
+            }
         }
 
         let has_improved = my_attempts
@@ -446,7 +464,14 @@ fn render_report(value: &DutyReport) -> String {
 
 pub async fn run(ctx: &AppContext) -> Result<()> {
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
-    let report = check(ctx, &repo_state, DutyContext::Lead)?;
+    let context = match (
+        ctx.github.current_login().ok(),
+        ctx.config.lead_github_login.as_deref(),
+    ) {
+        (Some(login), Some(lead)) if login == lead => DutyContext::Lead,
+        _ => DutyContext::Contribute,
+    };
+    let report = check(ctx, &repo_state, context)?;
 
     print_value(ctx, &report, render_report)
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod pace;
 pub mod policy_check;
 pub mod prune;
 pub mod release;
+pub mod resume;
 pub mod review;
 pub mod review_claim;
 pub mod status;
@@ -67,6 +68,7 @@ pub async fn run(ctx: AppContext) -> Result<()> {
         Commands::Pace => pace::run(&ctx).await,
         Commands::Status(args) => status::run(&ctx, args).await,
         Commands::Claim(args) => claim::run(&ctx, args).await,
+        Commands::Resume(args) => resume::run(&ctx, args).await,
         Commands::Commit(args) => commit::run(&ctx, args).await,
         Commands::BatchClaim(args) => batch_claim::run(&ctx, args).await,
         Commands::Attempt(args) => attempt::run(&ctx, args).await,

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -166,6 +166,17 @@ pub fn ensure_node_config(repo_root: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn sync_node_config_to_worktree(repo_root: &Path, worktree_path: &Path) -> Result<()> {
+    let src = repo_root.join(".polyresearch-node.toml");
+    if src.exists() {
+        let dst = worktree_path.join(".polyresearch-node.toml");
+        fs::copy(&src, &dst).wrap_err_with(|| {
+            format!("failed to sync node config to {}", worktree_path.display())
+        })?;
+    }
+    Ok(())
+}
+
 pub fn node_active_claims(repo_state: &RepositoryState, node_id: &str) -> usize {
     repo_state
         .theses

--- a/cli/src/commands/prune.rs
+++ b/cli/src/commands/prune.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{Context, Result};
 use serde::Serialize;
@@ -36,23 +36,24 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
                 continue;
             }
 
-            if let Some(issue_num) = parse_issue_from_dirname(&path) {
-                if terminal_issues.contains(&issue_num) {
-                    if registered.contains(&path) {
-                        let path_arg = path.to_string_lossy().into_owned();
-                        run_git(&ctx.repo_root, &["worktree", "remove", "--force", &path_arg])
-                            .wrap_err_with(|| {
-                                format!("failed to remove worktree {}", path.display())
-                            })?;
-                        registered.remove(&path);
-                    } else {
-                        fs::remove_dir_all(&path).wrap_err_with(|| {
-                            format!("failed to remove directory {}", path.display())
-                        })?;
-                    }
-                    removed_worktrees.push(path.display().to_string());
-                    continue;
+            if let Some(issue_num) = parse_issue_from_dirname(&path)
+                && terminal_issues.contains(&issue_num)
+            {
+                if registered.contains(&path) {
+                    let path_arg = path.to_string_lossy().into_owned();
+                    run_git(
+                        &ctx.repo_root,
+                        &["worktree", "remove", "--force", &path_arg],
+                    )
+                    .wrap_err_with(|| format!("failed to remove worktree {}", path.display()))?;
+                    registered.remove(&path);
+                } else {
+                    fs::remove_dir_all(&path).wrap_err_with(|| {
+                        format!("failed to remove directory {}", path.display())
+                    })?;
                 }
+                removed_worktrees.push(path.display().to_string());
+                continue;
             }
 
             if registered.contains(&path) {
@@ -121,7 +122,7 @@ fn registered_worktree_paths(repo_root: &PathBuf) -> Result<HashSet<PathBuf>> {
     Ok(paths)
 }
 
-fn parse_issue_from_dirname(path: &PathBuf) -> Option<u64> {
+fn parse_issue_from_dirname(path: &Path) -> Option<u64> {
     let name = path.file_name()?.to_str()?;
     let (number, _) = name.split_once('-')?;
     number.parse::<u64>().ok()
@@ -130,7 +131,9 @@ fn parse_issue_from_dirname(path: &PathBuf) -> Option<u64> {
 async fn terminal_thesis_issues(ctx: &AppContext) -> HashSet<u64> {
     let state = RepositoryState::derive(&ctx.github, &ctx.config).await;
     let Ok(state) = state else {
-        eprintln!("warning: could not fetch thesis state from GitHub; skipping resolved-worktree cleanup");
+        eprintln!(
+            "warning: could not fetch thesis state from GitHub; skipping resolved-worktree cleanup"
+        );
         return HashSet::new();
     };
 

--- a/cli/src/commands/resume.rs
+++ b/cli/src/commands/resume.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use color_eyre::eyre::{Context, Result, eyre};
 
@@ -8,7 +8,8 @@ use crate::cli::IssueArgs;
 use crate::commands::claim::ClaimOutput;
 use crate::commands::guards::require_claimed_thesis;
 use crate::commands::{
-    AppContext, current_branch, print_value, read_node_id, run_git, slugify, thesis_worktree_path,
+    AppContext, current_branch, print_value, read_node_id, run_git, slugify,
+    sync_node_config_to_worktree, thesis_worktree_path,
 };
 use crate::state::{RepositoryState, ThesisState};
 use crate::worker;
@@ -50,7 +51,7 @@ pub(crate) fn resume_selected_thesis(
     if !ctx.cli.dry_run {
         let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
         ensure_worktree(&ctx.repo_root, &worktree_path, &branch, &default_branch)?;
-        sync_node_config(&ctx.repo_root, &worktree_path)?;
+        sync_node_config_to_worktree(&ctx.repo_root, &worktree_path)?;
 
         let prior_attempts = worker::format_prior_attempts(thesis);
         agent::write_thesis_context(
@@ -100,16 +101,5 @@ fn ensure_worktree(
         )?;
     }
 
-    Ok(())
-}
-
-fn sync_node_config(repo_root: &Path, worktree_path: &Path) -> Result<()> {
-    let src = repo_root.join(".polyresearch-node.toml");
-    if src.exists() {
-        let dst = worktree_path.join(".polyresearch-node.toml");
-        fs::copy(&src, &dst).wrap_err_with(|| {
-            format!("failed to sync node config to {}", worktree_path.display())
-        })?;
-    }
     Ok(())
 }

--- a/cli/src/commands/resume.rs
+++ b/cli/src/commands/resume.rs
@@ -1,0 +1,115 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, eyre};
+
+use crate::agent;
+use crate::cli::IssueArgs;
+use crate::commands::claim::ClaimOutput;
+use crate::commands::guards::require_claimed_thesis;
+use crate::commands::{
+    AppContext, current_branch, print_value, read_node_id, run_git, slugify, thesis_worktree_path,
+};
+use crate::state::{RepositoryState, ThesisState};
+use crate::worker;
+
+pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
+    let node = read_node_id(&ctx.repo_root)?;
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
+    let thesis = require_claimed_thesis(&repo_state, args.issue, &node)?;
+    let output = resume_selected_thesis(ctx, thesis, &node)?;
+
+    print_value(ctx, &output, |value| {
+        if ctx.cli.dry_run {
+            format!(
+                "Would resume thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
+                value.issue, value.node, value.branch, value.worktree_path
+            )
+        } else {
+            format!(
+                "Resumed thesis #{} as node `{}` on branch `{}` in worktree `{}`.",
+                value.issue, value.node, value.branch, value.worktree_path
+            )
+        }
+    })
+}
+
+pub(crate) fn resume_selected_thesis(
+    ctx: &AppContext,
+    thesis: &ThesisState,
+    node: &str,
+) -> Result<ClaimOutput> {
+    let branch = format!(
+        "thesis/{}-{}",
+        thesis.issue.number,
+        slugify(&thesis.issue.title)
+    );
+    let worktree_path =
+        thesis_worktree_path(&ctx.repo_root, thesis.issue.number, &thesis.issue.title);
+
+    if !ctx.cli.dry_run {
+        let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
+        ensure_worktree(&ctx.repo_root, &worktree_path, &branch, &default_branch)?;
+        sync_node_config(&ctx.repo_root, &worktree_path)?;
+
+        let prior_attempts = worker::format_prior_attempts(thesis);
+        agent::write_thesis_context(
+            &worktree_path,
+            &thesis.issue.title,
+            thesis.issue.body.as_deref().unwrap_or(""),
+            &prior_attempts,
+        )?;
+    }
+
+    Ok(ClaimOutput {
+        issue: thesis.issue.number,
+        node: node.to_string(),
+        branch,
+        worktree_path: worktree_path.display().to_string(),
+    })
+}
+
+fn ensure_worktree(
+    repo_root: &PathBuf,
+    worktree_path: &PathBuf,
+    branch: &str,
+    default_branch: &str,
+) -> Result<()> {
+    let worktree_root = repo_root.join(".worktrees");
+    fs::create_dir_all(&worktree_root)
+        .wrap_err_with(|| format!("failed to create {}", worktree_root.display()))?;
+
+    if worktree_path.exists() {
+        let current = current_branch(worktree_path)?;
+        if current != branch {
+            return Err(eyre!(
+                "existing worktree `{}` is on branch `{current}`, expected `{branch}`",
+                worktree_path.display()
+            ));
+        }
+        return Ok(());
+    }
+
+    let path_arg = worktree_path.to_string_lossy().into_owned();
+    if run_git(repo_root, &["rev-parse", "--verify", branch]).is_ok() {
+        run_git(repo_root, &["worktree", "add", &path_arg, branch])?;
+    } else {
+        run_git(
+            repo_root,
+            &["worktree", "add", "-b", branch, &path_arg, default_branch],
+        )?;
+    }
+
+    Ok(())
+}
+
+fn sync_node_config(repo_root: &Path, worktree_path: &Path) -> Result<()> {
+    let src = repo_root.join(".polyresearch-node.toml");
+    if src.exists() {
+        let dst = worktree_path.join(".polyresearch-node.toml");
+        fs::copy(&src, &dst).wrap_err_with(|| {
+            format!("failed to sync node config to {}", worktree_path.display())
+        })?;
+    }
+    Ok(())
+}

--- a/cli/src/commands/sync.rs
+++ b/cli/src/commands/sync.rs
@@ -60,8 +60,7 @@ fn pull_default_branch(repo_root: &PathBuf, branch: &str) -> Result<PullOutcome>
     }
 
     let rebase_result = run_git(repo_root, &["rebase", &remote_ref]);
-    if rebase_result.is_err() {
-        let rebase_error = rebase_result.unwrap_err();
+    if let Err(rebase_error) = rebase_result {
         let _ = run_git(repo_root, &["rebase", "--abort"]);
         if local_sync_commits_only(repo_root, &remote_ref)? {
             eprintln!(
@@ -111,12 +110,10 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
 
     let default_branch = ctx.config.resolve_default_branch(&ctx.repo_root)?;
 
-    if !ctx.cli.dry_run {
-        if current_branch(&ctx.repo_root)? != default_branch {
-            return Err(eyre!(
-                "`polyresearch sync` must run from the `{default_branch}` branch"
-            ));
-        }
+    if !ctx.cli.dry_run && current_branch(&ctx.repo_root)? != default_branch {
+        return Err(eyre!(
+            "`polyresearch sync` must run from the `{default_branch}` branch"
+        ));
     }
 
     let mut restart_count = 0;

--- a/cli/src/preflight.rs
+++ b/cli/src/preflight.rs
@@ -226,7 +226,10 @@ mod tests {
         let result = smoke_test_agent("/nonexistent/binary", &dir, Duration::from_secs(5));
         assert!(result.is_err(), "should fail with nonexistent binary");
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("failed to start"), "error should mention start failure: {msg}");
+        assert!(
+            msg.contains("failed to start"),
+            "error should mention start failure: {msg}"
+        );
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -257,8 +260,14 @@ mod tests {
         let result = check_clean_working_tree(&dir);
         assert!(result.is_err(), "dirty tree should fail");
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("uncommitted"), "error should mention uncommitted: {msg}");
-        assert!(msg.contains("README.md"), "error should list the file: {msg}");
+        assert!(
+            msg.contains("uncommitted"),
+            "error should mention uncommitted: {msg}"
+        );
+        assert!(
+            msg.contains("README.md"),
+            "error should list the file: {msg}"
+        );
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -301,7 +310,10 @@ mod tests {
     #[test]
     fn root_flag_check_passes_without_flag() {
         let result = check_root_dangerous_flag("claude -p");
-        assert!(result.is_ok(), "command without the flag should always pass: {result:?}");
+        assert!(
+            result.is_ok(),
+            "command without the flag should always pass: {result:?}"
+        );
     }
 
     fn test_is_root() -> bool {

--- a/cli/src/worker.rs
+++ b/cli/src/worker.rs
@@ -369,17 +369,7 @@ impl ThesisWorker {
     }
 
     fn sync_node_config(&self) -> Result<()> {
-        let src = self.ctx.repo_root.join(".polyresearch-node.toml");
-        if src.exists() {
-            let dst = self.worktree_path.join(".polyresearch-node.toml");
-            fs::copy(&src, &dst).wrap_err_with(|| {
-                format!(
-                    "failed to sync node config to {}",
-                    self.worktree_path.display()
-                )
-            })?;
-        }
-        Ok(())
+        commands::sync_node_config_to_worktree(&self.ctx.repo_root, &self.worktree_path)
     }
 
     fn write_thesis_context(&self) -> Result<()> {

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -2196,6 +2196,89 @@ async fn claim_rejects_new_claim_when_resume_duty_exists() {
     );
 }
 
+#[tokio::test]
+async fn lead_claim_allows_new_claim_when_resume_duty_is_advisory() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("lead-claim-gate");
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
+        HashMap::from([
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
+            (fixture_open.issue.number, fixture_open.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_claimed.lead_github_login,
+        true,
+        Commands::Claim(IssueArgs {
+            issue: fixture_open.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::claim::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture_open.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        mock.posted_issue_comments.lock().unwrap().is_empty(),
+        "dry-run lead claim should not post any claim comments"
+    );
+}
+
+#[tokio::test]
+async fn lead_batch_claim_allows_new_claim_when_resume_duty_is_advisory() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("lead-batch-claim-gate");
+    let fixture_claimed = load_issue_fixture("claimed_no_attempts_issue.json");
+    let fixture_open = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture_claimed.issue.clone(), fixture_open.issue.clone()],
+        HashMap::from([
+            (
+                fixture_claimed.issue.number,
+                fixture_claimed.comments.clone(),
+            ),
+            (fixture_open.issue.number, fixture_open.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_claimed.lead_github_login,
+        true,
+        Commands::BatchClaim(BatchClaimArgs { count: Some(1) }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::batch_claim::run(&ctx, &BatchClaimArgs { count: Some(1) })
+        .await
+        .unwrap();
+
+    assert!(
+        mock.posted_issue_comments.lock().unwrap().is_empty(),
+        "dry-run lead batch-claim should not post any claim comments"
+    );
+}
+
 fn make_ctx(
     repo_root: PathBuf,
     github: Arc<dyn GitHubApi>,
@@ -5153,9 +5236,9 @@ async fn lead_decide_ready_prs_decides_policy_passed_pr() {
             .lock()
             .unwrap()
             .iter()
-            .any(|(number, body)| *number == 50
-                && body.contains("polyresearch:decision")
-                && body.contains("accepted")),
+            .any(|(number, body)| {
+                *number == 50 && body.contains("polyresearch:decision") && body.contains("accepted")
+            }),
         "should post an accepted decision comment on the PR"
     );
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -10,8 +10,7 @@ use color_eyre::eyre::{Result, eyre};
 use polyresearch::agent;
 use polyresearch::cli::{
     AdminArgs, AdminCommands, AdminReleaseClaimArgs, AdminReopenThesisArgs, AttemptArgs,
-    CommitArgs,
-    BatchClaimArgs, Cli, Commands, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
+    BatchClaimArgs, Cli, Commands, CommitArgs, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
     NodeOverrides, PrArgs, ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
@@ -1274,6 +1273,218 @@ async fn claim_creates_worktree_by_default() {
 }
 
 #[tokio::test]
+async fn resume_command_sets_up_worktree_for_existing_claim() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("resume-create");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Resume(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::resume::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    let expected_branch = format!(
+        "thesis/{}-{}",
+        fixture.issue.number,
+        commands::slugify(&fixture.issue.title)
+    );
+    let worktree_path = repo.path.join(".worktrees").join(format!(
+        "{}-{}",
+        fixture.issue.number,
+        commands::slugify(&fixture.issue.title)
+    ));
+
+    assert!(
+        worktree_path.exists(),
+        "expected worktree at {}",
+        worktree_path.display()
+    );
+    assert_eq!(
+        commands::current_branch(&worktree_path).unwrap(),
+        expected_branch
+    );
+    assert!(
+        worktree_path.join(".polyresearch/thesis.md").exists(),
+        "resume should write thesis context"
+    );
+    assert!(
+        worktree_path.join(".polyresearch-node.toml").exists(),
+        "resume should sync node config into the worktree"
+    );
+    assert!(
+        mock.posted_issue_comments.lock().unwrap().is_empty(),
+        "resume should not post a duplicate claim comment"
+    );
+}
+
+#[tokio::test]
+async fn resume_command_reuses_existing_worktree() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("resume-reuse");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture.lead_github_login,
+        false,
+        Commands::Resume(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let workspace = commands::create_thesis_worktree(
+        &repo.path,
+        fixture.issue.number,
+        &fixture.issue.title,
+        "main",
+    )
+    .unwrap();
+    let thesis_dir = workspace.worktree_path.join(".polyresearch");
+    fs::create_dir_all(&thesis_dir).unwrap();
+    fs::write(thesis_dir.join("thesis.md"), "stale thesis context\n").unwrap();
+
+    commands::resume::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    let thesis_content =
+        fs::read_to_string(workspace.worktree_path.join(".polyresearch/thesis.md")).unwrap();
+    assert!(
+        thesis_content.contains(&format!("# Thesis: {}", fixture.issue.title)),
+        "resume should refresh thesis context in an existing worktree"
+    );
+    assert_eq!(
+        commands::current_branch(&workspace.worktree_path).unwrap(),
+        workspace.branch
+    );
+    assert!(
+        workspace
+            .worktree_path
+            .join(".polyresearch-node.toml")
+            .exists(),
+        "resume should sync node config into the existing worktree"
+    );
+    assert!(
+        mock.posted_issue_comments.lock().unwrap().is_empty(),
+        "resume should not post a duplicate claim comment"
+    );
+}
+
+#[tokio::test]
+async fn resume_command_rejects_unclaimed_thesis() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("resume-unclaimed");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Resume(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "other-node").unwrap();
+
+    let error = commands::resume::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("is not currently claimed by node `other-node`")
+    );
+}
+
+#[tokio::test]
+async fn resume_command_rejects_approved_not_claimed() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("resume-not-claimed");
+    init_git_repo(&repo.path);
+    let fixture = load_issue_fixture("acknowledged_invalid_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Resume(IssueArgs {
+            issue: fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let error = commands::resume::run(
+        &ctx,
+        &IssueArgs {
+            issue: fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("is not currently claimed by node `test-node`")
+    );
+}
+
+#[tokio::test]
 async fn batch_claim_claims_requested_count() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("batch-claim");
@@ -1546,7 +1757,7 @@ fn observation_value_enum_accepts_snake_case() {
 // --- B5: Duties command ---
 
 #[tokio::test]
-async fn duties_reports_advisory_when_claim_has_no_attempts() {
+async fn duties_blocks_on_uncompleted_claims_for_contribute() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("duties-claim");
     let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
@@ -1571,8 +1782,53 @@ async fn duties_reports_advisory_when_claim_has_no_attempts() {
         .unwrap();
     let report = commands::duties::check(&ctx, &repo_state, DutyContext::Contribute).unwrap();
     assert!(
+        report.blocking.iter().any(|d| {
+            d.category == "resume"
+                && d.command == format!("polyresearch resume {}", fixture.issue.number)
+        }),
+        "should require contributors to resume their stale claim before claiming more work"
+    );
+    assert!(
+        report
+            .advisory
+            .iter()
+            .all(|d| d.category != "attempt" && d.category != "resume"),
+        "the claim-without-attempt item should not remain advisory for contributors"
+    );
+}
+
+#[tokio::test]
+async fn duties_advisory_on_uncompleted_claims_for_lead() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("duties-claim-lead");
+    let fixture = load_issue_fixture("claimed_no_attempts_issue.json");
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![fixture.issue.clone()],
+        HashMap::from([(fixture.issue.number, fixture.comments.clone())]),
+        vec![],
+        HashMap::new(),
+    ));
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        &fixture.lead_github_login,
+        false,
+        Commands::Duties,
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let report = commands::duties::check(&ctx, &repo_state, DutyContext::Lead).unwrap();
+    assert!(
         report.advisory.iter().any(|d| d.category == "attempt"),
-        "should report a claim-without-attempt advisory"
+        "lead duties should keep the claim-without-attempt item advisory"
+    );
+    assert!(
+        report.blocking.iter().all(|d| d.category != "resume"),
+        "lead duties should not block on resume"
     );
 }
 
@@ -1818,7 +2074,7 @@ async fn duties_reports_waiting_for_approval_when_queue_has_only_submitted_these
 // --- B6: Duty gate on claim ---
 
 #[tokio::test]
-async fn claim_allows_additional_claims_under_sub_agent_capacity() {
+async fn claim_rejects_new_claim_when_resume_duty_exists() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("claim-gate");
     init_git_repo(&repo.path);
@@ -1848,14 +2104,28 @@ async fn claim_allows_additional_claims_under_sub_agent_capacity() {
     );
     commands::write_node_id(&repo.path, "test-node").unwrap();
 
-    commands::claim::run(
+    let error = commands::claim::run(
         &ctx,
         &IssueArgs {
             issue: fixture_open.issue.number,
         },
     )
     .await
-    .unwrap();
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("cannot claim while blocking duties exist"),
+        "claim should be blocked until the stale claim is resumed"
+    );
+    assert!(
+        error.to_string().contains(&format!(
+            "polyresearch resume {}",
+            fixture_claimed.issue.number
+        )),
+        "claim error should point the user at the resume command"
+    );
 }
 
 fn make_ctx(
@@ -2347,9 +2617,13 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2363,7 +2637,8 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 outcome: Outcome::NonImprovement,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2430,7 +2705,9 @@ async fn duties_submit_present_after_single_rejection() {
             created_at: now - chrono::Duration::hours(1),
             closed_at: Some(now - chrono::Duration::minutes(30)),
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2509,9 +2786,13 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2525,7 +2806,8 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 outcome: Outcome::Stale,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2641,9 +2923,13 @@ async fn duties_submit_present_when_prior_rejections_predate_claim() {
                 head_ref_oid: Some("old-sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(8) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2983,9 +3269,7 @@ Test goal.
 fn write_node_config(path: &PathBuf, node_id: &str) {
     fs::write(
         path.join(".polyresearch-node.toml"),
-        format!(
-            "node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"
-        ),
+        format!("node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"),
     )
     .unwrap();
 }

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use polyresearch::cli::{BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides};
+use polyresearch::cli::{
+    BootstrapArgs, Cli, Commands, ContributeArgs, IssueArgs, LeadArgs, NodeOverrides,
+};
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
 use polyresearch::config::{DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig};
@@ -696,6 +698,151 @@ Ensure lead_github_login: upstream-owner appears in docs unchanged.
 // ---------------------------------------------------------------------------
 // Contribute scenarios
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_resume_creates_missing_worktree_for_claimed_thesis() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("resume-missing");
+    repo.init_git();
+    repo.write_full_setup("lead", "test-node-resume", "echo noop");
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let title = "Resume missing worktree";
+    let (issue, mut comments) = make_approved_thesis(80, title, "lead");
+    comments.push(IssueComment {
+        id: 8001,
+        body: ProtocolComment::Claim {
+            thesis: 80,
+            node: "test-node-resume".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: chrono::Utc::now(),
+        updated_at: None,
+    });
+
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(80, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-resume");
+    }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Resume(IssueArgs { issue: 80 }),
+    );
+
+    commands::resume::run(&ctx, &IssueArgs { issue: 80 })
+        .await
+        .unwrap();
+
+    let expected_branch = format!("thesis/80-{}", commands::slugify(title));
+    let worktree_path = commands::thesis_worktree_path(&repo.path, 80, title);
+
+    assert!(
+        worktree_path.exists(),
+        "resume should create the missing worktree"
+    );
+    assert_eq!(
+        commands::current_branch(&worktree_path).unwrap(),
+        expected_branch
+    );
+    assert!(
+        worktree_path.join(".polyresearch/thesis.md").exists(),
+        "resume should write thesis context into the worktree"
+    );
+    assert!(
+        worktree_path.join(".polyresearch-node.toml").exists(),
+        "resume should sync the node config into the worktree"
+    );
+    assert!(
+        github.posted_comments().is_empty(),
+        "resume should not post a duplicate claim comment"
+    );
+}
+
+#[tokio::test]
+async fn scenario_resume_reuses_existing_worktree_for_claimed_thesis() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("resume-reuse");
+    repo.init_git();
+    repo.write_full_setup("lead", "test-node-reuse", "echo noop");
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let title = "Resume existing worktree";
+    let (issue, mut comments) = make_approved_thesis(81, title, "lead");
+    comments.push(IssueComment {
+        id: 8101,
+        body: ProtocolComment::Claim {
+            thesis: 81,
+            node: "test-node-reuse".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: chrono::Utc::now(),
+        updated_at: None,
+    });
+
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(81, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-reuse");
+    }
+
+    let workspace = commands::create_thesis_worktree(&repo.path, 81, title, "main").unwrap();
+    let poly_dir = workspace.worktree_path.join(".polyresearch");
+    fs::create_dir_all(&poly_dir).unwrap();
+    fs::write(poly_dir.join("thesis.md"), "stale thesis context\n").unwrap();
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Resume(IssueArgs { issue: 81 }),
+    );
+
+    commands::resume::run(&ctx, &IssueArgs { issue: 81 })
+        .await
+        .unwrap();
+
+    let thesis_content =
+        fs::read_to_string(workspace.worktree_path.join(".polyresearch/thesis.md")).unwrap();
+    assert!(
+        thesis_content.contains(&format!("# Thesis: {title}")),
+        "resume should refresh thesis context in an existing worktree"
+    );
+    assert_eq!(
+        commands::current_branch(&workspace.worktree_path).unwrap(),
+        workspace.branch
+    );
+    assert!(
+        workspace
+            .worktree_path
+            .join(".polyresearch-node.toml")
+            .exists(),
+        "resume should sync the node config into the existing worktree"
+    );
+    assert!(
+        github.posted_comments().is_empty(),
+        "resume should not post a duplicate claim comment"
+    );
+}
 
 #[tokio::test]
 async fn scenario_contribute_improved() {

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -439,6 +439,55 @@ impl Drop for EnvGuard {
 }
 
 // ---------------------------------------------------------------------------
+// Pace scenarios
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_pace_reports_low_rate_limit() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("pace-low");
+    repo.init_git();
+    repo.write_full_setup("lead", "test-node", "echo noop");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let (issue_one, comments_one) = make_approved_thesis(1, "First thesis", "lead");
+    let issue_one_number = issue_one.number;
+    github.seed_issue(issue_one);
+    github.seed_issue_comments(issue_one_number, comments_one);
+
+    let (issue_two, comments_two) = make_approved_thesis(2, "Second thesis", "lead");
+    let issue_two_number = issue_two.number;
+    github.seed_issue(issue_two);
+    github.seed_issue_comments(issue_two_number, comments_two);
+    github.set_rate_limit_remaining(3);
+
+    let ctx = make_scenario_ctx(repo.path.clone(), github, "lead", false, Commands::Pace);
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let rate_limit = ctx.github.get_rate_limit_status().unwrap();
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &rate_limit,
+    );
+
+    assert_eq!(output.rate_limit.remaining, 3);
+    assert_eq!(output.rate_limit.derive_cost, 4);
+    assert_eq!(output.rate_limit.commands_left, 0);
+    assert!(output.rate_limit.is_low);
+
+    let err = commands::pace::run(&ctx).await.unwrap_err();
+    let process_exit = err
+        .downcast_ref::<commands::ProcessExit>()
+        .expect("pace should return a process exit when the scenario quota is exhausted");
+    assert_eq!(process_exit.code, 75);
+}
+
+// ---------------------------------------------------------------------------
 // Bootstrap scenarios
 // ---------------------------------------------------------------------------
 
@@ -832,7 +881,10 @@ async fn scenario_resume_reuses_existing_worktree_for_claimed_thesis() {
         workspace.branch
     );
     assert!(
-        workspace.worktree_path.join(".polyresearch-node.toml").exists(),
+        workspace
+            .worktree_path
+            .join(".polyresearch-node.toml")
+            .exists(),
         "resume should sync the node config into the existing worktree"
     );
     assert!(
@@ -1405,6 +1457,168 @@ fn execute_decision_accepted_merges_and_closes() {
     assert!(
         github.is_issue_closed(72),
         "thesis should be closed on accepted"
+    );
+}
+
+#[tokio::test]
+async fn execute_decision_accepted_clears_claims_in_derived_state() {
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let now = chrono::Utc::now();
+    let thesis_number = 73;
+    let pr_number = 173;
+
+    github.seed_issue(Issue {
+        number: thesis_number,
+        title: "Accepted thesis".to_string(),
+        body: Some("Test accepted thesis.".to_string()),
+        state: "OPEN".to_string(),
+        labels: vec![Label {
+            name: "thesis".to_string(),
+        }],
+        created_at: now - chrono::Duration::hours(1),
+        closed_at: None,
+        author: Some(Author {
+            login: "lead".to_string(),
+        }),
+        url: Some(format!(
+            "https://github.com/test/repo/issues/{thesis_number}"
+        )),
+    });
+    github.seed_issue_comments(
+        thesis_number,
+        vec![
+            IssueComment {
+                id: 7301,
+                body: ProtocolComment::Approval {
+                    thesis: thesis_number,
+                }
+                .render(),
+                user: CommentUser {
+                    login: "lead".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(50),
+                updated_at: None,
+            },
+            IssueComment {
+                id: 7302,
+                body: ProtocolComment::Claim {
+                    thesis: thesis_number,
+                    node: "worker-a".to_string(),
+                }
+                .render(),
+                user: CommentUser {
+                    login: "contributor".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(40),
+                updated_at: None,
+            },
+            IssueComment {
+                id: 7303,
+                body: ProtocolComment::Attempt {
+                    thesis: thesis_number,
+                    branch: "thesis/73-test".to_string(),
+                    metric: 0.95,
+                    baseline_metric: Some(0.90),
+                    observation: polyresearch::comments::Observation::Improved,
+                    summary: "Improved result".to_string(),
+                    annotations: None,
+                }
+                .render(),
+                user: CommentUser {
+                    login: "contributor".to_string(),
+                },
+                created_at: now - chrono::Duration::minutes(30),
+                updated_at: None,
+            },
+        ],
+    );
+    github.seed_pull_request(PullRequest {
+        number: pr_number,
+        title: "Candidate".to_string(),
+        body: Some(format!("References #{thesis_number}")),
+        state: "OPEN".to_string(),
+        head_ref_name: "thesis/73-test".to_string(),
+        head_ref_oid: Some("sha73".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(20),
+        closed_at: None,
+        merged_at: None,
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
+        url: Some(format!("https://github.com/test/repo/pull/{pr_number}")),
+        mergeable: None,
+    });
+    github.seed_pr_comments(
+        pr_number,
+        vec![IssueComment {
+            id: 17301,
+            body: ProtocolComment::PolicyPass {
+                thesis: thesis_number,
+                candidate_sha: "sha73".to_string(),
+            }
+            .render(),
+            user: CommentUser {
+                login: "lead".to_string(),
+            },
+            created_at: now - chrono::Duration::minutes(10),
+            updated_at: None,
+        }],
+    );
+
+    commands::decide::execute_decision(
+        &(Arc::clone(&github) as Arc<dyn GitHubApi>),
+        None,
+        pr_number,
+        thesis_number,
+        "sha73".to_string(),
+        "thesis/73-test",
+        polyresearch::comments::Outcome::Accepted,
+        0,
+        0,
+    )
+    .unwrap();
+
+    let config = ProtocolConfig {
+        required_confirmations: 0,
+        metric_tolerance: Some(0.01),
+        metric_direction: polyresearch::config::MetricDirection::HigherIsBetter,
+        metric_bound: None,
+        lead_github_login: Some("lead".to_string()),
+        maintainer_github_login: Some("lead".to_string()),
+        auto_approve: true,
+        assignment_timeout: std::time::Duration::from_secs(24 * 60 * 60),
+        review_timeout: std::time::Duration::from_secs(12 * 60 * 60),
+        min_queue_depth: 5,
+        max_queue_depth: Some(10),
+        cli_version: None,
+        default_branch: None,
+    };
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
+    let thesis = repo_state.get_thesis(thesis_number).unwrap();
+
+    assert!(github.is_pr_merged(pr_number), "PR should be merged");
+    assert!(
+        github.is_issue_closed(thesis_number),
+        "thesis should be closed after acceptance"
+    );
+    assert!(matches!(
+        thesis.phase,
+        polyresearch::state::ThesisPhase::Resolved {
+            outcome: polyresearch::comments::Outcome::Accepted
+        }
+    ));
+    assert!(
+        thesis.active_claims.is_empty(),
+        "resolved thesis should not retain stale claims, got: {:?}",
+        thesis.active_claims
+    );
+    assert!(
+        repo_state.active_nodes.is_empty(),
+        "resolved thesis should be removed from active_nodes, got: {:?}",
+        repo_state.active_nodes
     );
 }
 
@@ -3084,6 +3298,199 @@ fn seed_decidable_pr(github: &ScenarioGitHub, thesis_num: u64, pr_num: u64, lead
             filename: "src/decidable.js".to_string(),
         }],
     );
+}
+
+fn seed_pr_needing_policy_check(github: &ScenarioGitHub, thesis_num: u64, pr_num: u64, lead: &str) {
+    let now = chrono::Utc::now();
+    let branch = format!("thesis/{thesis_num}-policy-check-thesis");
+    let (issue, mut issue_comments) = make_approved_thesis(thesis_num, "Policy-check thesis", lead);
+
+    issue_comments.push(IssueComment {
+        id: thesis_num * 100 + 1,
+        body: ProtocolComment::Claim {
+            thesis: thesis_num,
+            node: "worker-a".to_string(),
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(30),
+        updated_at: None,
+    });
+
+    issue_comments.push(IssueComment {
+        id: thesis_num * 100 + 2,
+        body: ProtocolComment::Attempt {
+            thesis: thesis_num,
+            branch: branch.clone(),
+            metric: 0.95,
+            baseline_metric: Some(0.90),
+            observation: polyresearch::comments::Observation::Improved,
+            summary: "Improvement awaiting policy check".to_string(),
+            annotations: None,
+        }
+        .render(),
+        user: CommentUser {
+            login: "contributor".to_string(),
+        },
+        created_at: now - chrono::Duration::minutes(20),
+        updated_at: None,
+    });
+
+    let pr = PullRequest {
+        number: pr_num,
+        title: format!("Thesis #{thesis_num}: Policy-check thesis"),
+        body: Some(format!("References #{thesis_num}")),
+        state: "OPEN".to_string(),
+        head_ref_name: branch,
+        head_ref_oid: Some("candidate-sha".to_string()),
+        base_ref_name: Some("main".to_string()),
+        created_at: now - chrono::Duration::minutes(15),
+        closed_at: None,
+        merged_at: None,
+        author: Some(Author {
+            login: "contributor".to_string(),
+        }),
+        url: Some(format!("https://github.com/test/repo/pull/{pr_num}")),
+        mergeable: Some("MERGEABLE".to_string()),
+    };
+
+    github.seed_issue(issue);
+    github.seed_issue_comments(thesis_num, issue_comments);
+    github.seed_pull_request(pr);
+    github.seed_pr_comments(pr_num, vec![]);
+    github.seed_pr_files(
+        pr_num,
+        vec![polyresearch::github::PullRequestFile {
+            filename: "src/policy-check.js".to_string(),
+        }],
+    );
+}
+
+#[tokio::test]
+async fn scenario_policy_check_then_decide_catches_up() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("policy-then-decide");
+    repo.init_git();
+    repo.write_full_setup("lead", "lead-node-policy", "echo noop");
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    seed_pr_needing_policy_check(&github, 64, 164, "lead");
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::PolicyCheck(PrArgs { pr: 164 }),
+    );
+
+    commands::policy_check::run(&ctx, &PrArgs { pr: 164 })
+        .await
+        .unwrap();
+
+    let pr_bodies = github.comment_bodies_on(164);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:policy-pass")),
+        "policy_check should post a policy-pass comment: {pr_bodies:?}"
+    );
+
+    let config = ProtocolConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&(Arc::clone(&github) as Arc<dyn GitHubApi>), &config)
+        .await
+        .unwrap();
+    let pr_state = repo_state
+        .theses
+        .iter()
+        .flat_map(|thesis| thesis.pull_requests.iter())
+        .find(|pr_state| pr_state.pr.number == 164)
+        .expect("PR #164 should be present in derived state");
+    assert!(
+        pr_state.policy_pass,
+        "policy_check should make PR #164 decidable"
+    );
+    assert!(
+        pr_state.decision.is_none(),
+        "policy_check alone should not post a decision"
+    );
+
+    let lead_ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+    commands::lead::decide_ready_prs(&lead_ctx, &config, &repo_state).unwrap();
+
+    let pr_bodies = github.comment_bodies_on(164);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:decision") && body.contains("accepted")),
+        "decide_ready_prs should post an accepted decision after policy-check: {pr_bodies:?}"
+    );
+    assert!(github.is_pr_merged(164), "PR #164 should be merged");
+    assert!(github.is_issue_closed(64), "thesis #64 should be closed");
+}
+
+#[tokio::test]
+async fn scenario_lead_run_decides_policy_passed_pr_after_agent_exit() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("lead-post-agent-decide");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("no_improvement");
+    repo.write_full_setup("lead", "lead-node-post", &agent_cmd);
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    seed_decidable_pr(&github, 65, 165, "lead");
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "lead::run should succeed and apply the post-agent decide sweep: {result:?}"
+    );
+
+    let pr_bodies = github.comment_bodies_on(165);
+    assert!(
+        pr_bodies
+            .iter()
+            .any(|body| body.contains("polyresearch:decision") && body.contains("accepted")),
+        "lead::run should post a decision comment after the agent exits: {pr_bodies:?}"
+    );
+    assert!(github.is_pr_merged(165), "PR #165 should be merged");
+    assert!(github.is_issue_closed(65), "thesis #65 should be closed");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `polyresearch resume <issue>` so a node can recreate or reuse its claimed thesis worktree and rewrite `.polyresearch/thesis.md`
- make contributor duties block on stale zero-attempt claims and teach the workflow prompt how to resolve them before claiming new work
- add e2e and scenario coverage for resume behavior, and keep strict verification green with the small clippy cleanups needed in shared helpers

## Test plan
- [x] `cargo test --test e2e resume_command_`
- [x] `cargo test --test e2e duties_`
- [x] `cargo test --test scenarios scenario_resume_`
- [x] `cargo test contribute_prompt_ --lib`
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test -q`

Closes #154.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI workflow control paths (`duties`, `claim`/`batch-claim`, worktree setup), so regressions could prevent claiming or resuming worktrees; changes are well-covered by new end-to-end and scenario tests.
> 
> **Overview**
> Adds a new `polyresearch resume <issue>` command that recreates or reuses the thesis git worktree for an existing claim, re-syncs `.polyresearch-node.toml`, and rewrites `.polyresearch/thesis.md` without posting another claim comment.
> 
> Updates duties/claim gating so *contributors* with a claimed thesis that has zero attempts get a **blocking** `resume` duty (and `claim`/`batch-claim` fail until resolved), while *leads* keep this as advisory; the contributor workflow prompt is updated to teach `resume` as the resolution step. Includes new e2e/scenario tests for resume behavior and duty gating, plus small refactors/clippy cleanups (e.g., shared node-config sync helper, minor condition/formatting changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ea711cf88e12182f1741af18525ed2e67a5b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->