### PR TITLE
Fix secondary rate limit misclassification and shorten retry backoff

### DIFF
--- a/cli/src/github.rs
+++ b/cli/src/github.rs
@@ -18,8 +18,8 @@ use crate::throttle;
 
 const COMMENT_FETCH_CONCURRENCY_LIMIT: usize = 2;
 const TRANSIENT_RETRY_DELAYS_SECS: [u64; 3] = [5, 10, 20];
-const SECONDARY_RETRY_DELAYS_SECS: [u64; 3] = [90, 180, 300];
-const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
+const SECONDARY_RETRY_DELAYS_SECS: [u64; 4] = [30, 60, 90, 120];
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(180);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepoRef {
@@ -877,22 +877,37 @@ fn run_command_with_retries(command: &mut Command, idempotent: bool) -> Result<S
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let Some(retry) = classify_retry(&stderr, idempotent) else {
+        let Some(classified_retry) = classify_retry(&stderr, idempotent) else {
             return Err(error_with_hint(&stderr));
         };
+        let rate_limit_status = match classified_retry {
+            RetryReason::RateLimited(_) => current_rate_limit_status(),
+            RetryReason::Transient => None,
+        };
+        let retry = refine_rate_limit_kind(classified_retry, rate_limit_status.as_ref());
+
+        if retry != classified_retry
+            && let Some((remaining, limit)) = core_rate_limit_snapshot(rate_limit_status.as_ref())
+        {
+            eprintln!(
+                "GitHub CLI command looked like a primary rate limit, but GitHub core quota still has {remaining}/{limit} remaining. Treating it as a secondary rate limit."
+            );
+        }
 
         let retry_after = match retry {
             RetryReason::Transient => jittered_delay(Duration::from_secs(
                 TRANSIENT_RETRY_DELAYS_SECS
                     [attempt.min(TRANSIENT_RETRY_DELAYS_SECS.len().saturating_sub(1))],
             )),
-            RetryReason::RateLimited(kind) => resolve_rate_limit_delay(kind, attempt, &stderr)
-                .unwrap_or_else(|| {
-                    jittered_delay(Duration::from_secs(
-                        SECONDARY_RETRY_DELAYS_SECS
-                            [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
-                    ))
-                }),
+            RetryReason::RateLimited(kind) => {
+                resolve_rate_limit_delay(kind, attempt, &stderr, rate_limit_status.as_ref())
+                    .unwrap_or_else(|| {
+                        jittered_delay(Duration::from_secs(
+                            SECONDARY_RETRY_DELAYS_SECS
+                                [attempt.min(SECONDARY_RETRY_DELAYS_SECS.len().saturating_sub(1))],
+                        ))
+                    })
+            }
         };
 
         let max_retries = match retry {
@@ -913,11 +928,20 @@ fn run_command_with_retries(command: &mut Command, idempotent: bool) -> Result<S
             };
         }
 
-        eprintln!(
-            "GitHub CLI command hit a {} condition. Retrying in {}s...",
-            retry,
-            retry_after.as_secs()
-        );
+        match core_rate_limit_snapshot(rate_limit_status.as_ref()) {
+            Some((remaining, limit)) => eprintln!(
+                "GitHub CLI command hit a {} condition (core {}/{}). Retrying in {}s...",
+                retry,
+                remaining,
+                limit,
+                retry_after.as_secs()
+            ),
+            None => eprintln!(
+                "GitHub CLI command hit a {} condition. Retrying in {}s...",
+                retry,
+                retry_after.as_secs()
+            ),
+        }
         thread::sleep(retry_after);
     }
 
@@ -1003,6 +1027,29 @@ fn classify_retry(stderr: &str, idempotent: bool) -> Option<RetryReason> {
     None
 }
 
+fn refine_rate_limit_kind(reason: RetryReason, status: Option<&RateLimitStatus>) -> RetryReason {
+    match reason {
+        RetryReason::RateLimited(RateLimitKind::Primary)
+            if status.map(core_has_ample_headroom).unwrap_or(false) =>
+        {
+            RetryReason::RateLimited(RateLimitKind::Secondary)
+        }
+        _ => reason,
+    }
+}
+
+fn core_has_ample_headroom(status: &RateLimitStatus) -> bool {
+    let core = &status.resources.core;
+    core.limit > 0 && core.remaining.saturating_mul(10) > core.limit
+}
+
+fn core_rate_limit_snapshot(status: Option<&RateLimitStatus>) -> Option<(u64, u64)> {
+    status.map(|status| {
+        let core = &status.resources.core;
+        (core.remaining, core.limit)
+    })
+}
+
 fn classify_error_hint(stderr: &str) -> Option<&'static str> {
     let lowered = stderr.to_ascii_lowercase();
 
@@ -1043,21 +1090,31 @@ fn error_with_hint(stderr: &str) -> color_eyre::Report {
     }
 }
 
-fn resolve_rate_limit_delay(kind: RateLimitKind, attempt: usize, stderr: &str) -> Option<Duration> {
+fn resolve_rate_limit_delay(
+    kind: RateLimitKind,
+    attempt: usize,
+    stderr: &str,
+    status: Option<&RateLimitStatus>,
+) -> Option<Duration> {
     match kind {
-        RateLimitKind::Primary => current_rate_limit_status().and_then(|status| {
-            status.resources.core.reset_at().map(|reset_at| {
-                let wait = (reset_at - Utc::now())
-                    .to_std()
-                    .unwrap_or(Duration::from_secs(5));
-                let wait = if wait.is_zero() {
-                    Duration::from_secs(5)
-                } else {
-                    wait
-                };
-                capped_delay(server_jittered_delay(wait + Duration::from_secs(1)))
-            })
-        }),
+        RateLimitKind::Primary => {
+            status
+                .cloned()
+                .or_else(current_rate_limit_status)
+                .and_then(|status| {
+                    status.resources.core.reset_at().map(|reset_at| {
+                        let wait = (reset_at - Utc::now())
+                            .to_std()
+                            .unwrap_or(Duration::from_secs(5));
+                        let wait = if wait.is_zero() {
+                            Duration::from_secs(5)
+                        } else {
+                            wait
+                        };
+                        capped_delay(server_jittered_delay(wait + Duration::from_secs(1)))
+                    })
+                })
+        }
         RateLimitKind::Secondary => parse_retry_after(stderr)
             .map(|d| capped_delay(server_jittered_delay(d)))
             .or_else(|| {
@@ -1151,6 +1208,53 @@ mod tests {
     }
 
     #[test]
+    fn refine_downgrades_primary_when_core_has_headroom() {
+        let status = rate_limit_status(5_000, 4_500);
+        assert_eq!(
+            refine_rate_limit_kind(
+                RetryReason::RateLimited(RateLimitKind::Primary),
+                Some(&status)
+            ),
+            RetryReason::RateLimited(RateLimitKind::Secondary)
+        );
+    }
+
+    #[test]
+    fn refine_keeps_primary_when_core_is_exhausted() {
+        let status = rate_limit_status(5_000, 50);
+        assert_eq!(
+            refine_rate_limit_kind(
+                RetryReason::RateLimited(RateLimitKind::Primary),
+                Some(&status)
+            ),
+            RetryReason::RateLimited(RateLimitKind::Primary)
+        );
+    }
+
+    #[test]
+    fn refine_keeps_primary_when_status_unavailable() {
+        assert_eq!(
+            refine_rate_limit_kind(RetryReason::RateLimited(RateLimitKind::Primary), None),
+            RetryReason::RateLimited(RateLimitKind::Primary)
+        );
+    }
+
+    #[test]
+    fn refine_passes_through_non_primary_reasons() {
+        assert_eq!(
+            refine_rate_limit_kind(RetryReason::Transient, None),
+            RetryReason::Transient
+        );
+        assert_eq!(
+            refine_rate_limit_kind(
+                RetryReason::RateLimited(RateLimitKind::Secondary),
+                Some(&rate_limit_status(5_000, 4_500))
+            ),
+            RetryReason::RateLimited(RateLimitKind::Secondary)
+        );
+    }
+
+    #[test]
     fn jittered_delay_stays_within_plus_minus_50_percent() {
         let base = Duration::from_secs(90);
         let low = base / 2;
@@ -1185,7 +1289,7 @@ mod tests {
     #[test]
     fn secondary_rate_limit_uses_short_backoff() {
         let stderr = "secondary rate limit hit";
-        let delay = resolve_rate_limit_delay(RateLimitKind::Secondary, 0, stderr).unwrap();
+        let delay = resolve_rate_limit_delay(RateLimitKind::Secondary, 0, stderr, None).unwrap();
         let base = Duration::from_secs(SECONDARY_RETRY_DELAYS_SECS[0]);
         assert!(
             delay >= base / 2 && delay <= base + base / 2,
@@ -1193,13 +1297,25 @@ mod tests {
         );
         let last_attempt = SECONDARY_RETRY_DELAYS_SECS.len() - 1;
         for _ in 0..100 {
-            let d =
-                resolve_rate_limit_delay(RateLimitKind::Secondary, last_attempt, stderr).unwrap();
+            let d = resolve_rate_limit_delay(RateLimitKind::Secondary, last_attempt, stderr, None)
+                .unwrap();
             assert!(
                 d <= MAX_RETRY_DELAY,
                 "secondary fallback delay {d:?} exceeded MAX_RETRY_DELAY at max attempt"
             );
         }
+    }
+
+    #[test]
+    fn secondary_retry_delays_total_within_budget() {
+        let total_delay = SECONDARY_RETRY_DELAYS_SECS.iter().sum::<u64>();
+        assert_eq!(total_delay, 300);
+        assert!(total_delay <= 300);
+    }
+
+    #[test]
+    fn updated_max_retry_delay_matches_constant() {
+        assert_eq!(MAX_RETRY_DELAY, Duration::from_secs(180));
     }
 
     #[test]
@@ -1277,6 +1393,19 @@ mod tests {
             Some(Duration::from_secs(120))
         );
         assert_eq!(parse_retry_after("no header here"), None);
+    }
+
+    fn rate_limit_status(limit: u64, remaining: u64) -> RateLimitStatus {
+        RateLimitStatus {
+            resources: RateLimitResources {
+                core: RateLimitBucket {
+                    limit,
+                    remaining,
+                    used: limit.saturating_sub(remaining),
+                    reset: (Utc::now() + chrono::Duration::minutes(5)).timestamp() as u64,
+                },
+            },
+        }
     }
 
     #[test]

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -3,15 +3,17 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::sync::{
+    Arc, Mutex, MutexGuard, OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch::agent;
 use polyresearch::cli::{
     AdminArgs, AdminCommands, AdminReleaseClaimArgs, AdminReopenThesisArgs, AttemptArgs,
-    CommitArgs,
-    BatchClaimArgs, Cli, Commands, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
+    BatchClaimArgs, Cli, Commands, CommitArgs, ContributeArgs, GenerateArgs, InitArgs, IssueArgs,
     NodeOverrides, PrArgs, ReleaseArgs, StatusArgs,
 };
 use polyresearch::commands;
@@ -68,6 +70,7 @@ struct MockGitHubClient {
     created_issues: Mutex<Vec<Issue>>,
     assigned_issues: Mutex<Vec<(u64, Vec<String>)>>,
     next_issue_id: Mutex<u64>,
+    rate_limit_remaining: AtomicU64,
 }
 
 impl MockGitHubClient {
@@ -94,12 +97,18 @@ impl MockGitHubClient {
             created_issues: Mutex::new(Vec::new()),
             assigned_issues: Mutex::new(Vec::new()),
             next_issue_id: Mutex::new(max_issue + 100),
+            rate_limit_remaining: AtomicU64::new(4_000),
         }
     }
 
     fn with_pr_files(mut self, pr_number: u64, files: Vec<PullRequestFile>) -> Self {
         self.pr_files.insert(pr_number, files);
         self
+    }
+
+    fn set_rate_limit_remaining(&self, remaining: u64) {
+        self.rate_limit_remaining
+            .store(remaining, Ordering::Relaxed);
     }
 }
 
@@ -117,7 +126,9 @@ impl GitHubApi for MockGitHubClient {
     }
 
     fn get_rate_limit_status(&self) -> Result<RateLimitStatus> {
-        Ok(default_rate_limit_status(4_000))
+        Ok(default_rate_limit_status(
+            self.rate_limit_remaining.load(Ordering::Relaxed),
+        ))
     }
 
     fn repo_has_issues(&self) -> Result<bool> {
@@ -601,6 +612,62 @@ async fn pace_reports_exhausted_when_quota_below_derive_cost() {
     assert_eq!(output.rate_limit.commands_left, 0);
     assert!(output.rate_limit.is_low);
     assert!(output.rate_limit.remaining < output.rate_limit.derive_cost);
+}
+
+#[tokio::test]
+async fn pace_exits_with_rate_limit_code_when_remaining_below_derive_cost() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("pace-run-exhausted");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    mock.set_rate_limit_remaining(1);
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let err = commands::pace::run(&ctx).await.unwrap_err();
+    let process_exit = err
+        .downcast_ref::<commands::ProcessExit>()
+        .expect("pace should return a process exit when quota is exhausted");
+    assert_eq!(process_exit.code, 75);
+    assert!(process_exit.message.contains("RATE LIMITED"));
+}
+
+#[tokio::test]
+async fn pace_reports_secondary_headroom_context() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("pace-headroom");
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    mock.set_rate_limit_remaining(4_500);
+    let ctx = make_ctx(repo.path.clone(), mock, "lead", false, Commands::Pace);
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let rate_limit = ctx.github.get_rate_limit_status().unwrap();
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &rate_limit,
+    );
+
+    assert_eq!(output.rate_limit.remaining, 4_500);
+    assert!(!output.rate_limit.is_low);
+    assert!(output.rate_limit.commands_left > 0);
 }
 
 #[tokio::test]
@@ -2347,9 +2414,13 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2363,7 +2434,8 @@ async fn duties_submit_replaced_by_release_after_two_rejections() {
                 outcome: Outcome::NonImprovement,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2430,7 +2502,9 @@ async fn duties_submit_present_after_single_rejection() {
             created_at: now - chrono::Duration::hours(1),
             closed_at: Some(now - chrono::Duration::minutes(30)),
             merged_at: None,
-            author: Some(Author { login: "alice".to_string() }),
+            author: Some(Author {
+                login: "alice".to_string(),
+            }),
             url: None,
             mergeable: None,
         },
@@ -2509,9 +2583,13 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 head_ref_oid: Some("sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(1) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2525,7 +2603,8 @@ async fn duties_submit_replaced_by_release_after_stale_decisions() {
                 outcome: Outcome::Stale,
                 candidate_sha: "sha".to_string(),
                 confirmations: 0,
-                created_at: now - chrono::Duration::minutes(30) + chrono::Duration::minutes(i as i64),
+                created_at: now - chrono::Duration::minutes(30)
+                    + chrono::Duration::minutes(i as i64),
             }),
             findings: vec![],
         });
@@ -2641,9 +2720,13 @@ async fn duties_submit_present_when_prior_rejections_predate_claim() {
                 head_ref_oid: Some("old-sha".to_string()),
                 base_ref_name: Some("main".to_string()),
                 created_at: now - chrono::Duration::hours(8) + chrono::Duration::minutes(i as i64),
-                closed_at: Some(now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64)),
+                closed_at: Some(
+                    now - chrono::Duration::hours(5) + chrono::Duration::minutes(i as i64),
+                ),
                 merged_at: None,
-                author: Some(Author { login: "alice".to_string() }),
+                author: Some(Author {
+                    login: "alice".to_string(),
+                }),
                 url: None,
                 mergeable: None,
             },
@@ -2983,9 +3066,7 @@ Test goal.
 fn write_node_config(path: &PathBuf, node_id: &str) {
     fs::write(
         path.join(".polyresearch-node.toml"),
-        format!(
-            "node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"
-        ),
+        format!("node_id = \"{node_id}\"\ncapacity = 75\n\n[agent]\ncommand = \"true\"\n"),
     )
     .unwrap();
 }

--- a/cli/tests/scenario_mock.rs
+++ b/cli/tests/scenario_mock.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{
+    Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 use color_eyre::eyre::{Result, eyre};
 use polyresearch::github::{
@@ -28,6 +31,7 @@ struct ScenarioState {
 #[allow(dead_code)]
 pub struct ScenarioGitHub {
     state: Mutex<ScenarioState>,
+    rate_limit_remaining: AtomicU64,
 }
 
 impl ScenarioGitHub {
@@ -50,7 +54,13 @@ impl ScenarioGitHub {
                 deleted_refs: Vec::new(),
                 merge_attempt_counts: HashMap::new(),
             }),
+            rate_limit_remaining: AtomicU64::new(4_000),
         }
+    }
+
+    pub fn set_rate_limit_remaining(&self, remaining: u64) {
+        self.rate_limit_remaining
+            .store(remaining, Ordering::Relaxed);
     }
 
     pub fn seed_issue(&self, issue: Issue) {
@@ -188,13 +198,14 @@ impl GitHubApi for ScenarioGitHub {
     }
 
     fn get_rate_limit_status(&self) -> Result<RateLimitStatus> {
+        let remaining = self.rate_limit_remaining.load(Ordering::Relaxed);
         Ok(RateLimitStatus {
             resources: RateLimitResources {
                 core: RateLimitBucket {
                     limit: 5000,
-                    remaining: 4000,
+                    remaining,
                     reset: 0,
-                    used: 1000,
+                    used: 5000_u64.saturating_sub(remaining),
                 },
             },
         })

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -10,7 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use polyresearch::cli::{BootstrapArgs, Cli, Commands, ContributeArgs, LeadArgs, NodeOverrides};
 use polyresearch::commands::{self, AppContext};
 use polyresearch::comments::ProtocolComment;
-use polyresearch::config::{DEFAULT_API_BUDGET, ProgramSpec, ProtocolConfig};
+use polyresearch::config::{DEFAULT_API_BUDGET, NodeConfig, ProgramSpec, ProtocolConfig};
 use polyresearch::github::{
     Author, CommentUser, GitHubApi, Issue, IssueComment, Label, PullRequest, RepoRef,
 };
@@ -434,6 +434,55 @@ impl Drop for EnvGuard {
             env::remove_var(polyresearch::config::NODE_ID_ENV_VAR);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Pace scenarios
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scenario_pace_reports_low_rate_limit() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("pace-low");
+    repo.init_git();
+    repo.write_full_setup("lead", "test-node", "echo noop");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let (issue_one, comments_one) = make_approved_thesis(1, "First thesis", "lead");
+    let issue_one_number = issue_one.number;
+    github.seed_issue(issue_one);
+    github.seed_issue_comments(issue_one_number, comments_one);
+
+    let (issue_two, comments_two) = make_approved_thesis(2, "Second thesis", "lead");
+    let issue_two_number = issue_two.number;
+    github.seed_issue(issue_two);
+    github.seed_issue_comments(issue_two_number, comments_two);
+    github.set_rate_limit_remaining(3);
+
+    let ctx = make_scenario_ctx(repo.path.clone(), github, "lead", false, Commands::Pace);
+    let node_config = NodeConfig::load(&repo.path).unwrap();
+    let repo_state = RepositoryState::derive(&ctx.github, &ctx.config)
+        .await
+        .unwrap();
+    let rate_limit = ctx.github.get_rate_limit_status().unwrap();
+    let output = commands::pace::build_output(
+        ctx.repo.slug(),
+        ctx.api_budget,
+        &node_config,
+        &repo_state,
+        &rate_limit,
+    );
+
+    assert_eq!(output.rate_limit.remaining, 3);
+    assert_eq!(output.rate_limit.derive_cost, 4);
+    assert_eq!(output.rate_limit.commands_left, 0);
+    assert!(output.rate_limit.is_low);
+
+    let err = commands::pace::run(&ctx).await.unwrap_err();
+    let process_exit = err
+        .downcast_ref::<commands::ProcessExit>()
+        .expect("pace should return a process exit when the scenario quota is exhausted");
+    assert_eq!(process_exit.code, 75);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reclassify ambiguous GitHub "primary rate limit" errors as secondary limits when the core quota still has headroom, and log the observed core quota on retries.
- Shorten the fallback secondary retry schedule to 30/60/90/120 seconds with a 180 second max retry cap.
- Add regression coverage in `github.rs`, `e2e.rs`, and `scenarios.rs` for the new classification and pace quota behavior.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy`

Closes #155.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub CLI retry/rate-limit handling and backoff timing; mistakes could cause premature failures or overly aggressive retrying under real quota conditions.
> 
> **Overview**
> Fixes misclassification of ambiguous GitHub CLI "primary rate limit" errors by **downgrading to secondary** when `rate_limit` shows ample core headroom, and includes core quota snapshots in retry logs.
> 
> Shortens the secondary fallback backoff schedule to `30/60/90/120s` and reduces `MAX_RETRY_DELAY` to `180s`, while updating `resolve_rate_limit_delay` to reuse an already-fetched `RateLimitStatus`.
> 
> Expands test coverage: unit tests for the new refinement logic and retry constants, and e2e/scenario mocks now support configurable rate-limit remaining values to validate `pace` exits with code `75` when quota is insufficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8d322396c3876da32799455c17af9e60d03feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->