### PR TITLE
Fix lead queue refill when generation is skipped

### DIFF
--- a/cli/prompts/lead-workflow.md
+++ b/cli/prompts/lead-workflow.md
@@ -22,6 +22,8 @@ You MUST complete ALL steps (1 through 6) in every iteration. Do not exit after 
 
 Keeping the queue at or above `min_queue_depth` is the primary goal of every iteration. Steps 1-3 are housekeeping; step 4 (queue check and generation) is the critical deliverable.
 
+Priority rule: if context, budget, or time is getting tight while you are in steps 1-3, stop starting new housekeeping work and go straight to step 4. Do not let sync, policy-check, or decide consume the whole iteration before the queue check runs.
+
 LOOP FOREVER:
 
 ### 1. Sync the ledger

--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -429,6 +429,23 @@ pub fn lead_workflow_prompt(once: bool, sleep_secs: u64) -> String {
     prompt
 }
 
+pub fn lead_generation_retry_prompt(current_depth: usize, min_depth: usize) -> String {
+    format!(
+        "You are the polyresearch lead agent.\n\n\
+         The previous lead iteration exited before refilling the thesis queue. \
+         The queue depth is currently {current_depth}, and min_queue_depth is {min_depth}.\n\n\
+         Your only task in this run is to refill the queue.\n\n\
+         1. Run `polyresearch status` to confirm the current queue depth.\n\
+         2. Run `polyresearch audit` and resolve any critical findings that block thesis generation.\n\
+         3. Read `PROGRAM.md` for the research goal and strategy.\n\
+         4. Read `results.tsv` to avoid duplicating prior work.\n\
+         5. Generate only enough theses to bring the queue back to at least {min_depth} using `polyresearch generate --title \"<title>\" --body \"<body>\"`.\n\
+         6. Run `polyresearch status` again to confirm the queue is now at or above {min_depth}.\n\n\
+         Do not spend this run on sync, policy-check, decide, or other housekeeping. \
+         Refill the queue before exiting.\n"
+    )
+}
+
 pub fn thesis_generation_prompt(count: usize) -> String {
     let base = include_str!("../prompts/thesis-generation.md");
     format!("{base}\n\nGenerate exactly {count} thesis proposals.")
@@ -883,6 +900,44 @@ mod tests {
         assert!(
             step3.contains("Run `polyresearch duties` again"),
             "step 3 should refresh duties after policy checks: {step3}"
+        );
+    }
+
+    #[test]
+    fn lead_generation_retry_prompt_contains_depths() {
+        let prompt = lead_generation_retry_prompt(2, 5);
+        assert!(
+            prompt.contains("currently 2"),
+            "retry prompt must include the current queue depth"
+        );
+        assert!(
+            prompt.contains("min_queue_depth is 5"),
+            "retry prompt must include the minimum queue depth"
+        );
+        assert!(
+            prompt.contains("polyresearch generate"),
+            "retry prompt must mention thesis generation"
+        );
+        assert!(
+            prompt.contains("polyresearch status"),
+            "retry prompt must mention queue verification"
+        );
+    }
+
+    #[test]
+    fn lead_generation_retry_prompt_mentions_program() {
+        let prompt = lead_generation_retry_prompt(1, 5);
+        assert!(
+            prompt.contains("PROGRAM.md"),
+            "retry prompt must tell the agent to read PROGRAM.md"
+        );
+        assert!(
+            prompt.contains("results.tsv"),
+            "retry prompt must tell the agent to read results.tsv"
+        );
+        assert!(
+            prompt.contains("only task in this run is to refill the queue"),
+            "retry prompt must keep the agent focused on queue refill"
         );
     }
 }

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Result, eyre};
@@ -40,17 +41,15 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
     let sleep_secs = args.sleep_secs;
 
     loop {
-        let cmd = agent_command.clone();
-        let root = repo_root.clone();
-        let p = prompt.clone();
-
-        let result = tokio::task::spawn_blocking(move || {
-            agent::spawn_workflow_agent(&cmd, &root, &p, verbose)
-        })
+        match run_workflow_agent_once(
+            &agent_command,
+            &repo_root,
+            &prompt,
+            verbose,
+            "lead workflow",
+        )
         .await
-        .map_err(|e| eyre!("lead workflow agent task failed: {e}"))?;
-
-        match result {
+        {
             Ok(()) => {
                 match RepositoryState::derive(&ctx.github, &ctx.config).await {
                     Ok(repo_state) => {
@@ -58,16 +57,88 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
                             eprintln!("Warning: post-agent decide sweep failed: {err}");
                         }
 
+                        let repo_state = match RepositoryState::derive(&ctx.github, &ctx.config)
+                            .await
+                        {
+                            Ok(repo_state) => repo_state,
+                            Err(err) => {
+                                eprintln!(
+                                    "Warning: could not verify queue depth after post-agent decide sweep: {err}"
+                                );
+                                break;
+                            }
+                        };
+
                         if repo_state.queue_depth < config.min_queue_depth {
                             eprintln!(
                                 "Warning: queue depth is {} (min = {}). \
                                  Lead agent may not have generated enough theses.",
                                 repo_state.queue_depth, config.min_queue_depth
                             );
-                            if !once {
-                                eprintln!("Restarting agent to refill queue in {sleep_secs}s...");
-                                tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
-                                continue;
+                            eprintln!("Running a focused queue refill retry...");
+
+                            let retry_prompt = agent::lead_generation_retry_prompt(
+                                repo_state.queue_depth,
+                                config.min_queue_depth,
+                            );
+                            match run_workflow_agent_once(
+                                &agent_command,
+                                &repo_root,
+                                &retry_prompt,
+                                verbose,
+                                "lead queue refill",
+                            )
+                            .await
+                            {
+                                Ok(()) => match RepositoryState::derive(&ctx.github, &ctx.config)
+                                    .await
+                                {
+                                    Ok(repo_state)
+                                        if repo_state.queue_depth < config.min_queue_depth =>
+                                    {
+                                        let err = eyre!(
+                                            "queue depth is {} (min = {}) after the lead workflow and focused refill retry",
+                                            repo_state.queue_depth,
+                                            config.min_queue_depth
+                                        );
+                                        if once {
+                                            return Err(err);
+                                        }
+                                        eprintln!("Warning: {err}");
+                                        eprintln!(
+                                            "Restarting agent to refill queue in {sleep_secs}s..."
+                                        );
+                                        tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                                        continue;
+                                    }
+                                    Err(err) => {
+                                        if once {
+                                            return Err(eyre!(
+                                                "could not verify queue depth after focused refill retry: {err}"
+                                            ));
+                                        }
+                                        eprintln!(
+                                            "Warning: could not verify queue depth after focused refill retry: {err}"
+                                        );
+                                        eprintln!(
+                                            "Restarting agent to refill queue in {sleep_secs}s..."
+                                        );
+                                        tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                                        continue;
+                                    }
+                                    _ => {}
+                                },
+                                Err(err) => {
+                                    eprintln!("Lead queue refill retry failed: {err}");
+                                    if once {
+                                        return Err(err);
+                                    }
+                                    eprintln!(
+                                        "Restarting agent to refill queue in {sleep_secs}s..."
+                                    );
+                                    tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+                                    continue;
+                                }
                             }
                         }
                     }
@@ -89,6 +160,22 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn run_workflow_agent_once(
+    agent_command: &str,
+    repo_root: &Path,
+    prompt: &str,
+    verbose: bool,
+    task_name: &'static str,
+) -> Result<()> {
+    let cmd = agent_command.to_string();
+    let root = repo_root.to_path_buf();
+    let prompt = prompt.to_string();
+
+    tokio::task::spawn_blocking(move || agent::spawn_workflow_agent(&cmd, &root, &prompt, verbose))
+        .await
+        .map_err(|e| eyre!("{task_name} agent task failed: {e}"))?
 }
 
 pub fn decide_ready_prs(

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1237,6 +1237,101 @@ async fn lead_only_command_rejects_non_lead_login() {
 }
 
 #[tokio::test]
+async fn lead_once_deficient_queue_spawns_retry_and_fails() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("lead-once-deficient");
+    init_git_repo(&repo.path);
+    write_program_md(&repo.path);
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
+    run_git(&repo.path, &["add", "-A"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        vec![],
+        HashMap::new(),
+        vec![],
+        HashMap::new(),
+    ));
+    let args = polyresearch::cli::LeadArgs {
+        once: true,
+        sleep_secs: 0,
+        overrides: NodeOverrides {
+            agent_command: Some("true".to_string()),
+            ..Default::default()
+        },
+    };
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Lead(args.clone()),
+    );
+
+    let error = commands::lead::run(&ctx, &args).await.unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("queue depth") && message.contains("focused refill retry"),
+        "lead --once should fail when the queue stays deficient after retry: {message}"
+    );
+}
+
+#[tokio::test]
+async fn lead_once_sufficient_queue_succeeds() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("lead-once-sufficient");
+    init_git_repo(&repo.path);
+    write_program_md(&repo.path);
+    fs::write(
+        repo.path.join("results.tsv"),
+        "thesis\tattempt\tmetric\tbaseline\tstatus\tsummary\n",
+    )
+    .unwrap();
+    run_git(&repo.path, &["add", "-A"]);
+    run_git(&repo.path, &["commit", "-m", "setup"]);
+
+    let mut issues = Vec::new();
+    let mut issue_comments = HashMap::new();
+    for number in 1..=5 {
+        issues.push(make_open_issue(
+            number,
+            &format!("Approved thesis {number}"),
+        ));
+        issue_comments.insert(number, vec![make_approval_comment(number, "lead")]);
+    }
+
+    let mock = Arc::new(MockGitHubClient::new(
+        "lead",
+        issues,
+        issue_comments,
+        vec![],
+        HashMap::new(),
+    ));
+    let args = polyresearch::cli::LeadArgs {
+        once: true,
+        sleep_secs: 0,
+        overrides: NodeOverrides {
+            agent_command: Some("true".to_string()),
+            ..Default::default()
+        },
+    };
+    let ctx = make_ctx(
+        repo.path.clone(),
+        mock,
+        "lead",
+        false,
+        Commands::Lead(args.clone()),
+    );
+
+    commands::lead::run(&ctx, &args).await.unwrap();
+}
+
+#[tokio::test]
 async fn valid_claim_succeeds_in_dry_run_without_writing() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("valid-claim");
@@ -1999,6 +2094,18 @@ fn make_open_issue(number: u64, title: &str) -> Issue {
         closed_at: None,
         author: None,
         url: None,
+    }
+}
+
+fn make_approval_comment(thesis: u64, lead_login: &str) -> IssueComment {
+    IssueComment {
+        id: thesis * 100,
+        body: ProtocolComment::Approval { thesis }.render(),
+        user: CommentUser {
+            login: lead_login.to_string(),
+        },
+        created_at: chrono::Utc::now(),
+        updated_at: None,
     }
 }
 

--- a/cli/tests/mock_agent.sh
+++ b/cli/tests/mock_agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Mock agent for scenario tests.
 # Controlled by MOCK_AGENT_RESULT: improved, no_improvement, crashed, fail,
-#   fail_once, hang, no_improvement_with_changes
+#   fail_once, hang, noop, no_improvement_with_changes
 RESULT_DIR="$PWD/.polyresearch"
 mkdir -p "$RESULT_DIR"
 
@@ -42,6 +42,9 @@ RESULT
         if [ "$COUNT" -le 2 ]; then
             exit 1
         fi
+        exit 0
+        ;;
+    noop)
         exit 0
         ;;
     hang)

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -1527,6 +1527,102 @@ async fn scenario_lead_once_error_propagation() {
 }
 
 #[tokio::test]
+async fn scenario_lead_once_deficient_queue_returns_error() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("lead-once-deficient");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("noop");
+    repo.write_full_setup("lead", "lead-node-def", &agent_cmd);
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: true,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "lead --once should fail when the queue stays below min_queue_depth"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("queue depth") && err_msg.contains("focused refill retry"),
+        "error should mention the deficient queue after retry: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_lead_continuous_generation_retry() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("lead-queue-retry");
+    repo.init_git();
+
+    let agent_cmd = "bash -c 'sleep 1'".to_string();
+    repo.write_full_setup("lead", "lead-node-queue", &agent_cmd);
+    repo.commit_all("setup");
+
+    let github = Arc::new(ScenarioGitHub::new("lead"));
+    let github_refill = Arc::clone(&github);
+    let refill_thread = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(2500));
+        for number in 200..205 {
+            let (issue, comments) =
+                make_approved_thesis(number, &format!("Generated thesis {number}"), "lead");
+            github_refill.seed_issue(issue);
+            github_refill.seed_issue_comments(number, comments);
+        }
+    });
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        false,
+        Commands::Lead(LeadArgs {
+            once: false,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::lead::run(
+        &ctx,
+        &LeadArgs {
+            once: false,
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    refill_thread.join().unwrap();
+    assert!(
+        result.is_ok(),
+        "continuous lead mode should succeed after the focused queue refill retry: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn scenario_lead_continuous_recovery() {
     let _guard = EnvGuard::lock_clean();
     let repo = ScenarioRepo::new("lead-recover");
@@ -3305,6 +3401,12 @@ async fn scenario_lead_run_decides_policy_passed_pr_after_agent_exit() {
 
     let agent_cmd = mock_agent_command("no_improvement");
     repo.write_full_setup("lead", "lead-node-post", &agent_cmd);
+    let program = fs::read_to_string(repo.path.join("PROGRAM.md")).unwrap();
+    fs::write(
+        repo.path.join("PROGRAM.md"),
+        program.replace("min_queue_depth: 5", "min_queue_depth: 0"),
+    )
+    .unwrap();
     repo.commit_all("setup");
 
     let github = Arc::new(ScenarioGitHub::new("lead"));


### PR DESCRIPTION
## Summary
- add a focused lead queue refill retry prompt and invoke it from the Rust wrapper when the post-run queue is still below `min_queue_depth`
- fail `lead --once` after the focused retry if the queue remains deficient, so skipped generation is surfaced as a real error instead of a warning-only success
- cover the new behavior with unit, scenario, and e2e tests, plus a `noop` mock-agent mode that simulates an agent exiting successfully without generating theses

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo test lead_generation_retry_prompt --lib`
- [x] `cargo test --test scenarios scenario_lead_`
- [x] `cargo test --test e2e lead_once_`

Closes #125.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts lead-loop control flow to add a second, focused agent run and new failure conditions, which could affect automation behavior and exit semantics for `lead --once`/continuous mode.
> 
> **Overview**
> Ensures the lead wrapper *actively refills* the thesis queue when an agent run exits with `queue_depth < min_queue_depth` by invoking a new focused retry prompt (`lead_generation_retry_prompt`) instead of only warning and returning success.
> 
> `lead --once` now returns an error if the queue is still deficient after this focused retry (continuous mode keeps retrying with sleeps), and the lead workflow prompt text is updated to prioritize reaching the queue check when time/budget is tight.
> 
> Adds unit tests for the retry prompt plus new e2e/scenario coverage (including a `noop` mock-agent mode) to validate retry + failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed1d87ec6657f87a6c6b38b464b6bd1faa5c290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->