### PR TITLE
Fix contribute --once after the first thesis cycle

### DIFF
--- a/cli/src/agent.rs
+++ b/cli/src/agent.rs
@@ -455,6 +455,7 @@ pub fn spawn_workflow_agent(
     agent_command: &str,
     work_dir: &Path,
     prompt: &str,
+    once_guard: Option<&Path>,
     verbose: bool,
 ) -> Result<()> {
     let parts = shell_words(agent_command);
@@ -468,6 +469,9 @@ pub fn spawn_workflow_agent(
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
+    if let Some(path) = once_guard {
+        cmd.env(crate::cycle_guard::GUARD_ENV_VAR, path);
+    }
 
     eprintln!("Spawning workflow agent in {}...", work_dir.display(),);
     let mut child = cmd.spawn().wrap_err("failed to spawn workflow agent")?;

--- a/cli/src/commands/batch_claim.rs
+++ b/cli/src/commands/batch_claim.rs
@@ -18,6 +18,7 @@ struct BatchClaimOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &BatchClaimArgs) -> Result<()> {
+    crate::cycle_guard::check_cycle_limit()?;
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 

--- a/cli/src/commands/claim.rs
+++ b/cli/src/commands/claim.rs
@@ -21,6 +21,7 @@ pub(crate) struct ClaimOutput {
 }
 
 pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
+    crate::cycle_guard::check_cycle_limit()?;
     let node = read_node_id(&ctx.repo_root)?;
     let repo_state = RepositoryState::derive(&ctx.github, &ctx.config).await?;
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -72,32 +72,42 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
     let verbose = local_ctx.cli.verbose;
     let once = args.once;
     let sleep_secs = args.sleep_secs;
+    let once_guard = if once {
+        Some(crate::cycle_guard::create(&repo_root)?)
+    } else {
+        None
+    };
 
-    loop {
+    let result = loop {
         let cmd = agent_command.clone();
         let root = repo_root.clone();
         let p = prompt.clone();
+        let guard = once_guard.clone();
 
         let result = tokio::task::spawn_blocking(move || {
-            agent::spawn_workflow_agent(&cmd, &root, &p, verbose)
+            agent::spawn_workflow_agent(&cmd, &root, &p, guard.as_deref(), verbose)
         })
         .await
         .map_err(|e| eyre!("contributor workflow agent task failed: {e}"))?;
 
         match result {
-            Ok(()) => break,
+            Ok(()) => break Ok(()),
             Err(err) => {
                 eprintln!("Contributor agent failed: {err}");
                 if once {
-                    return Err(err);
+                    break Err(err);
                 }
                 eprintln!("Restarting in {sleep_secs}s...");
                 tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
             }
         }
+    };
+
+    if let Some(path) = once_guard.as_deref() {
+        crate::cycle_guard::remove(path);
     }
 
-    Ok(())
+    result
 }
 
 fn clone_repo(url: &str, repo_root: &Path) -> Result<()> {
@@ -133,7 +143,10 @@ pub fn is_crash_cooldown(
 
     for r in &thesis.releases {
         if r.node == node_id
-            && matches!(r.reason, ReleaseReason::InfraFailure | ReleaseReason::Timeout)
+            && matches!(
+                r.reason,
+                ReleaseReason::InfraFailure | ReleaseReason::Timeout
+            )
         {
             count += 1;
             last_crash = Some(match last_crash {
@@ -311,10 +324,7 @@ mod tests {
         let now = Utc::now();
         let mut releases = Vec::new();
         for i in 0..20 {
-            releases.push(infra_release(
-                "node-a",
-                now - chrono::Duration::seconds(i),
-            ));
+            releases.push(infra_release("node-a", now - chrono::Duration::seconds(i)));
         }
         let thesis = make_thesis_with_releases(releases);
 

--- a/cli/src/commands/contribute.rs
+++ b/cli/src/commands/contribute.rs
@@ -84,11 +84,14 @@ pub async fn run(ctx: &AppContext, args: &ContributeArgs) -> Result<()> {
         let p = prompt.clone();
         let guard = once_guard.clone();
 
-        let result = tokio::task::spawn_blocking(move || {
+        let result = match tokio::task::spawn_blocking(move || {
             agent::spawn_workflow_agent(&cmd, &root, &p, guard.as_deref(), verbose)
         })
         .await
-        .map_err(|e| eyre!("contributor workflow agent task failed: {e}"))?;
+        {
+            Ok(result) => result,
+            Err(error) => break Err(eyre!("contributor workflow agent task failed: {error}")),
+        };
 
         match result {
             Ok(()) => break Ok(()),

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -140,6 +140,7 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
                                     continue;
                                 }
                             }
+                        }
                     }
                     Err(err) => {
                         eprintln!("Warning: could not verify queue depth after agent run: {err}");

--- a/cli/src/commands/lead.rs
+++ b/cli/src/commands/lead.rs
@@ -140,7 +140,6 @@ pub async fn run(ctx: &AppContext, args: &LeadArgs) -> Result<()> {
                                     continue;
                                 }
                             }
-                        }
                     }
                     Err(err) => {
                         eprintln!("Warning: could not verify queue depth after agent run: {err}");
@@ -173,9 +172,11 @@ async fn run_workflow_agent_once(
     let root = repo_root.to_path_buf();
     let prompt = prompt.to_string();
 
-    tokio::task::spawn_blocking(move || agent::spawn_workflow_agent(&cmd, &root, &prompt, verbose))
-        .await
-        .map_err(|e| eyre!("{task_name} agent task failed: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        agent::spawn_workflow_agent(&cmd, &root, &prompt, None, verbose)
+    })
+    .await
+    .map_err(|e| eyre!("{task_name} agent task failed: {e}"))?
 }
 
 pub fn decide_ready_prs(

--- a/cli/src/commands/release.rs
+++ b/cli/src/commands/release.rs
@@ -28,6 +28,7 @@ pub async fn run(ctx: &AppContext, args: &ReleaseArgs) -> Result<()> {
         ctx.github
             .post_issue_comment(args.issue, &comment.render())?;
         close_if_exhausted(ctx, args.issue, args.reason).await?;
+        crate::cycle_guard::mark_done()?;
     }
 
     let output = ReleaseOutput {

--- a/cli/src/commands/submit.rs
+++ b/cli/src/commands/submit.rs
@@ -60,7 +60,7 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
     let pr = if ctx.cli.dry_run {
         None
     } else {
-        Some(ctx.github.create_pull_request(
+        let pr = ctx.github.create_pull_request(
             &branch,
             &format!("Thesis #{}: {}", args.issue, thesis.issue.title),
             &match improved_attempt.baseline_metric {
@@ -74,7 +74,9 @@ pub async fn run(ctx: &AppContext, args: &IssueArgs) -> Result<()> {
                 ),
             },
             &default_branch,
-        )?)
+        )?;
+        crate::cycle_guard::mark_done()?;
+        Some(pr)
     };
 
     let output = SubmitOutput {

--- a/cli/src/cycle_guard.rs
+++ b/cli/src/cycle_guard.rs
@@ -1,0 +1,203 @@
+use std::env;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, eyre};
+
+pub const GUARD_ENV_VAR: &str = "POLYRESEARCH_ONCE_GUARD";
+
+const ACTIVE_STATE: &str = "active";
+const DONE_STATE: &str = "done";
+
+fn guard_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(".polyresearch").join(".once-guard")
+}
+
+pub fn create(repo_root: &Path) -> Result<PathBuf> {
+    let path = guard_path(repo_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, ACTIVE_STATE)
+        .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+pub fn mark_done() -> Result<()> {
+    let Some(path) = env::var_os(GUARD_ENV_VAR) else {
+        return Ok(());
+    };
+
+    match fs::write(&path, DONE_STATE) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).wrap_err_with(|| {
+            format!(
+                "failed to mark once guard done at {}",
+                PathBuf::from(path).display()
+            )
+        }),
+    }
+}
+
+pub fn check_cycle_limit() -> Result<()> {
+    let Some(path) = env::var_os(GUARD_ENV_VAR) else {
+        return Ok(());
+    };
+    let path = PathBuf::from(path);
+
+    let state = match fs::read_to_string(&path) {
+        Ok(state) => state,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .wrap_err_with(|| format!("failed to read once guard at {}", path.display()));
+        }
+    };
+
+    if state.trim() == DONE_STATE {
+        return Err(eyre!(
+            "--once cycle limit reached: one thesis cycle is already complete"
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn remove(path: &Path) {
+    let _ = fs::remove_file(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct GuardEnvLock {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl GuardEnvLock {
+        fn lock_clean() -> Self {
+            let guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+            clear_guard_env();
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for GuardEnvLock {
+        fn drop(&mut self) {
+            clear_guard_env();
+        }
+    }
+
+    fn clear_guard_env() {
+        unsafe {
+            env::remove_var(GUARD_ENV_VAR);
+        }
+    }
+
+    fn set_guard_env(path: &Path) {
+        unsafe {
+            env::set_var(GUARD_ENV_VAR, path);
+        }
+    }
+
+    fn temp_repo_root(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = env::temp_dir().join(format!("polyresearch-cycle-guard-{name}-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn create_writes_active_guard() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("create-active");
+
+        let path = create(&repo_root).unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), ACTIVE_STATE);
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn check_returns_ok_when_active() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("check-active");
+
+        let path = create(&repo_root).unwrap();
+        set_guard_env(&path);
+
+        check_cycle_limit().unwrap();
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn mark_done_transitions_guard() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("mark-done");
+
+        let path = create(&repo_root).unwrap();
+        set_guard_env(&path);
+        mark_done().unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), DONE_STATE);
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn check_returns_err_when_done() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("check-done");
+
+        let path = create(&repo_root).unwrap();
+        set_guard_env(&path);
+        mark_done().unwrap();
+
+        let error = check_cycle_limit().unwrap_err();
+        assert!(error.to_string().contains("cycle limit"));
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn check_returns_ok_when_env_unset() {
+        let _env = GuardEnvLock::lock_clean();
+        check_cycle_limit().unwrap();
+    }
+
+    #[test]
+    fn remove_deletes_guard_file() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("remove");
+
+        let path = create(&repo_root).unwrap();
+        remove(&path);
+
+        assert!(!path.exists(), "guard file should be removed");
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+
+    #[test]
+    fn remove_noop_when_file_missing() {
+        let _env = GuardEnvLock::lock_clean();
+        let repo_root = temp_repo_root("remove-missing");
+        let path = guard_path(&repo_root);
+
+        remove(&path);
+
+        assert!(!path.exists(), "missing guard file should stay absent");
+        fs::remove_dir_all(repo_root).unwrap();
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod commands;
 pub mod comments;
 pub mod config;
+pub mod cycle_guard;
 pub mod github;
 pub mod github_debug;
 pub mod hardware;

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -68,9 +68,12 @@ struct MockGitHubClient {
     merged_prs: Mutex<Vec<u64>>,
     closed_prs: Mutex<Vec<u64>>,
     created_issues: Mutex<Vec<Issue>>,
+    created_pull_requests: Mutex<Vec<PullRequest>>,
     assigned_issues: Mutex<Vec<(u64, Vec<String>)>>,
     next_issue_id: Mutex<u64>,
     rate_limit_remaining: AtomicU64,
+    next_pr_id: Mutex<u64>,
+    allow_create_pull_request: bool,
 }
 
 impl MockGitHubClient {
@@ -82,6 +85,11 @@ impl MockGitHubClient {
         pr_comments: HashMap<u64, Vec<IssueComment>>,
     ) -> Self {
         let max_issue = issues.iter().map(|i| i.number).max().unwrap_or(0);
+        let max_pr = pull_requests
+            .iter()
+            .map(|pr| pr.number)
+            .max()
+            .unwrap_or(199);
         Self {
             current_login: current_login.into(),
             issues,
@@ -95,9 +103,12 @@ impl MockGitHubClient {
             merged_prs: Mutex::new(Vec::new()),
             closed_prs: Mutex::new(Vec::new()),
             created_issues: Mutex::new(Vec::new()),
+            created_pull_requests: Mutex::new(Vec::new()),
             assigned_issues: Mutex::new(Vec::new()),
             next_issue_id: Mutex::new(max_issue + 100),
             rate_limit_remaining: AtomicU64::new(4_000),
+            next_pr_id: Mutex::new(max_pr + 1),
+            allow_create_pull_request: false,
         }
     }
 
@@ -109,6 +120,11 @@ impl MockGitHubClient {
     fn set_rate_limit_remaining(&self, remaining: u64) {
         self.rate_limit_remaining
             .store(remaining, Ordering::Relaxed);
+    }
+
+    fn with_create_pull_request(mut self) -> Self {
+        self.allow_create_pull_request = true;
+        self
     }
 }
 
@@ -252,12 +268,16 @@ impl GitHubApi for MockGitHubClient {
     }
 
     fn list_pull_requests(&self, _state: PullRequestListState) -> Result<Vec<PullRequest>> {
-        Ok(self.pull_requests.clone())
+        let mut pull_requests = self.pull_requests.clone();
+        pull_requests.extend(self.created_pull_requests.lock().unwrap().clone());
+        Ok(pull_requests)
     }
 
     fn get_pull_request(&self, pr_number: u64) -> Result<PullRequest> {
+        let created = self.created_pull_requests.lock().unwrap();
         self.pull_requests
             .iter()
+            .chain(created.iter())
             .find(|pr| pr.number == pr_number)
             .cloned()
             .ok_or_else(|| eyre!("mock PR #{} not found", pr_number))
@@ -297,12 +317,37 @@ impl GitHubApi for MockGitHubClient {
 
     fn create_pull_request(
         &self,
-        _branch: &str,
-        _title: &str,
-        _body: &str,
-        _base: &str,
+        branch: &str,
+        title: &str,
+        body: &str,
+        base: &str,
     ) -> Result<PullRequest> {
-        Err(eyre!("unexpected create_pull_request call in test"))
+        if !self.allow_create_pull_request {
+            return Err(eyre!("unexpected create_pull_request call in test"));
+        }
+
+        let mut next_pr_id = self.next_pr_id.lock().unwrap();
+        let number = *next_pr_id;
+        *next_pr_id += 1;
+        let pr = PullRequest {
+            number,
+            title: title.to_string(),
+            body: Some(body.to_string()),
+            state: "OPEN".to_string(),
+            head_ref_name: branch.to_string(),
+            head_ref_oid: Some("abc123".to_string()),
+            base_ref_name: Some(base.to_string()),
+            created_at: chrono::Utc::now(),
+            closed_at: None,
+            merged_at: None,
+            author: Some(Author {
+                login: self.current_login.clone(),
+            }),
+            url: Some(format!("https://github.com/test/repo/pull/{number}")),
+            mergeable: None,
+        };
+        self.created_pull_requests.lock().unwrap().push(pr.clone());
+        Ok(pr)
     }
 
     fn close_pull_request(&self, pr_number: u64) -> Result<serde_json::Value> {
@@ -352,6 +397,15 @@ fn init_git_repo(path: &PathBuf) {
     run_git(path, &["branch", "-M", "main"]);
 }
 
+fn add_bare_remote(path: &PathBuf, branch: &str) -> PathBuf {
+    let bare = path.join("origin.git");
+    let bare_arg = bare.to_string_lossy().into_owned();
+    run_git(path, &["init", "--bare", &bare_arg]);
+    run_git(path, &["remote", "add", "origin", &bare_arg]);
+    run_git(path, &["push", "-u", "origin", branch]);
+    bare
+}
+
 fn run_git(path: &PathBuf, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
@@ -366,6 +420,40 @@ fn run_git(path: &PathBuf, args: &[&str]) {
     );
 }
 
+fn clone_issue_fixture_with_new_number(
+    source: &IssueFixture,
+    number: u64,
+    title: &str,
+) -> IssueFixture {
+    let old_number = source.issue.number;
+    let mut issue = source.issue.clone();
+    issue.number = number;
+    issue.title = title.to_string();
+    issue.url = Some(format!("https://example.test/issues/{number}"));
+
+    let mut comments = source.comments.clone();
+    for comment in &mut comments {
+        comment.body = comment
+            .body
+            .replace(&format!("#{old_number}"), &format!("#{number}"))
+            .replace(
+                &format!("thesis: {old_number}"),
+                &format!("thesis: {number}"),
+            )
+            .replace(&format!("issue #{old_number}"), &format!("issue #{number}"))
+            .replace(
+                &format!("target: issue #{old_number}"),
+                &format!("target: issue #{number}"),
+            );
+    }
+
+    IssueFixture {
+        lead_github_login: source.lead_github_login.clone(),
+        issue,
+        comments,
+    }
+}
+
 fn env_lock() -> &'static Mutex<()> {
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     ENV_LOCK.get_or_init(|| Mutex::new(()))
@@ -378,14 +466,14 @@ struct NodeIdEnvGuard {
 impl NodeIdEnvGuard {
     fn lock_clean() -> Self {
         let guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
-        clear_node_id_env();
+        clear_test_env();
         Self { _guard: guard }
     }
 }
 
 impl Drop for NodeIdEnvGuard {
     fn drop(&mut self) {
-        clear_node_id_env();
+        clear_test_env();
     }
 }
 
@@ -435,6 +523,23 @@ fn assert_login_prefixed_node_id(node_id: &str, login: &str) {
         suffix.chars().all(|c| c.is_ascii_hexdigit()),
         "node suffix should be hex, got `{suffix}`"
     );
+}
+
+fn set_once_guard_env(path: &std::path::Path) {
+    unsafe {
+        env::set_var(polyresearch::cycle_guard::GUARD_ENV_VAR, path);
+    }
+}
+
+fn clear_once_guard_env() {
+    unsafe {
+        env::remove_var(polyresearch::cycle_guard::GUARD_ENV_VAR);
+    }
+}
+
+fn clear_test_env() {
+    clear_node_id_env();
+    clear_once_guard_env();
 }
 
 #[tokio::test]
@@ -1274,6 +1379,99 @@ async fn submit_rejects_branch_without_diff_from_default_branch() {
 }
 
 #[tokio::test]
+async fn cycle_guard_submit_marks_done() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("submit-marks-guard-done");
+    init_git_repo(&repo.path);
+    let _remote = add_bare_remote(&repo.path, "main");
+    run_git(
+        &repo.path,
+        &["checkout", "-b", "thesis/21-improved-attempt-1"],
+    );
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "console.log('improved');\n").unwrap();
+    run_git(&repo.path, &["add", "src/main.js"]);
+    run_git(&repo.path, &["commit", "-m", "Improved attempt"]);
+
+    let submit_fixture = load_issue_fixture("improved_no_submit_issue.json");
+    let follow_up_fixture = clone_issue_fixture_with_new_number(
+        &load_issue_fixture("acknowledged_invalid_issue.json"),
+        submit_fixture.issue.number + 1,
+        "Follow-up thesis",
+    );
+    let mock = Arc::new(
+        MockGitHubClient::new(
+            "alice",
+            vec![
+                submit_fixture.issue.clone(),
+                follow_up_fixture.issue.clone(),
+            ],
+            HashMap::from([
+                (submit_fixture.issue.number, submit_fixture.comments.clone()),
+                (
+                    follow_up_fixture.issue.number,
+                    follow_up_fixture.comments.clone(),
+                ),
+            ]),
+            vec![],
+            HashMap::new(),
+        )
+        .with_create_pull_request(),
+    );
+    let submit_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &submit_fixture.lead_github_login,
+        false,
+        Commands::Submit(IssueArgs {
+            issue: submit_fixture.issue.number,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let guard_path = polyresearch::cycle_guard::create(&repo.path).unwrap();
+    set_once_guard_env(&guard_path);
+
+    commands::submit::run(
+        &submit_ctx,
+        &IssueArgs {
+            issue: submit_fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fs::read_to_string(&guard_path).unwrap(), "done");
+    assert_eq!(
+        mock.created_pull_requests.lock().unwrap().len(),
+        1,
+        "submit should create exactly one PR in the mock client"
+    );
+
+    let claim_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &submit_fixture.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: follow_up_fixture.issue.number,
+        }),
+    );
+    let error = commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: follow_up_fixture.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("cycle limit"),
+        "submit should mark the once guard done, got: {error}"
+    );
+}
+
+#[tokio::test]
 async fn generate_is_blocked_by_dirty_audit() {
     let _guard = NodeIdEnvGuard::lock_clean();
     let repo = TestRepo::new("generate-dirty");
@@ -1642,6 +1840,244 @@ async fn batch_claim_reports_partial_success_when_later_claim_fails() {
         mock.posted_issue_comments.lock().unwrap().len(),
         1,
         "first claim should have been posted before the second claim failed"
+    );
+}
+
+#[tokio::test]
+async fn cycle_guard_blocks_second_claim_after_release() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("guard-claim-block");
+    init_git_repo(&repo.path);
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let fixture_two = clone_issue_fixture_with_new_number(
+        &fixture_one,
+        fixture_one.issue.number + 1,
+        "Second guarded thesis",
+    );
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
+        HashMap::from([
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let claim_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture_one.issue.number,
+        }),
+    );
+    let release_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let guard_path = polyresearch::cycle_guard::create(&repo.path).unwrap();
+    set_once_guard_env(&guard_path);
+
+    commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: fixture_one.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+    commands::release::run(
+        &release_ctx,
+        &ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fs::read_to_string(&guard_path).unwrap(), "done");
+
+    let error = commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: fixture_two.issue.number,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("cycle limit"),
+        "second claim should be blocked by the once guard, got: {error}"
+    );
+    assert_eq!(
+        mock.posted_issue_comments.lock().unwrap().len(),
+        2,
+        "claim and release should post comments before the second claim is blocked"
+    );
+}
+
+#[tokio::test]
+async fn cycle_guard_blocks_batch_claim_after_release() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("guard-batch-claim-block");
+    init_git_repo(&repo.path);
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let fixture_two = clone_issue_fixture_with_new_number(
+        &fixture_one,
+        fixture_one.issue.number + 1,
+        "Second guarded batch thesis",
+    );
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
+        HashMap::from([
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let claim_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture_one.issue.number,
+        }),
+    );
+    let release_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        }),
+    );
+    let batch_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::BatchClaim(BatchClaimArgs { count: Some(1) }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    let guard_path = polyresearch::cycle_guard::create(&repo.path).unwrap();
+    set_once_guard_env(&guard_path);
+
+    commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: fixture_one.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+    commands::release::run(
+        &release_ctx,
+        &ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        },
+    )
+    .await
+    .unwrap();
+
+    let error = commands::batch_claim::run(&batch_ctx, &BatchClaimArgs { count: Some(1) })
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("cycle limit"),
+        "batch-claim should be blocked after the cycle completes, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn cycle_guard_inactive_when_env_unset() {
+    let _guard = NodeIdEnvGuard::lock_clean();
+    let repo = TestRepo::new("guard-unset");
+    init_git_repo(&repo.path);
+    let fixture_one = load_issue_fixture("acknowledged_invalid_issue.json");
+    let fixture_two = clone_issue_fixture_with_new_number(
+        &fixture_one,
+        fixture_one.issue.number + 1,
+        "Second unguarded thesis",
+    );
+    let mock = Arc::new(MockGitHubClient::new(
+        "alice",
+        vec![fixture_one.issue.clone(), fixture_two.issue.clone()],
+        HashMap::from([
+            (fixture_one.issue.number, fixture_one.comments.clone()),
+            (fixture_two.issue.number, fixture_two.comments.clone()),
+        ]),
+        vec![],
+        HashMap::new(),
+    ));
+    let claim_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Claim(IssueArgs {
+            issue: fixture_one.issue.number,
+        }),
+    );
+    let release_ctx = make_ctx(
+        repo.path.clone(),
+        mock.clone(),
+        &fixture_one.lead_github_login,
+        false,
+        Commands::Release(ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        }),
+    );
+    commands::write_node_id(&repo.path, "test-node").unwrap();
+
+    commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: fixture_one.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+    commands::release::run(
+        &release_ctx,
+        &ReleaseArgs {
+            issue: fixture_one.issue.number,
+            reason: ReleaseReason::NoImprovement,
+        },
+    )
+    .await
+    .unwrap();
+    commands::claim::run(
+        &claim_ctx,
+        &IssueArgs {
+            issue: fixture_two.issue.number,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        mock.posted_issue_comments.lock().unwrap().len(),
+        3,
+        "without the once guard env var, claim-release-claim should all succeed"
     );
 }
 

--- a/cli/tests/mock_agent.sh
+++ b/cli/tests/mock_agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Mock agent for scenario tests.
 # Controlled by MOCK_AGENT_RESULT: improved, no_improvement, crashed, fail,
-#   fail_once, hang, noop, no_improvement_with_changes
+#   fail_once, hang, noop, no_improvement_with_changes, check_guard, check_no_guard
 RESULT_DIR="$PWD/.polyresearch"
 mkdir -p "$RESULT_DIR"
 
@@ -42,6 +42,26 @@ RESULT
         if [ "$COUNT" -le 2 ]; then
             exit 1
         fi
+        exit 0
+        ;;
+    check_guard)
+        if [ -z "$POLYRESEARCH_ONCE_GUARD" ]; then
+            echo "unset" > "$RESULT_DIR/.guard-check-result"
+            exit 1
+        fi
+        if [ ! -f "$POLYRESEARCH_ONCE_GUARD" ]; then
+            echo "missing" > "$RESULT_DIR/.guard-check-result"
+            exit 1
+        fi
+        echo "$POLYRESEARCH_ONCE_GUARD" > "$RESULT_DIR/.guard-check-result"
+        exit 0
+        ;;
+    check_no_guard)
+        if [ -n "$POLYRESEARCH_ONCE_GUARD" ]; then
+            echo "unexpectedly_set" > "$RESULT_DIR/.guard-check-result"
+            exit 1
+        fi
+        echo "unset" > "$RESULT_DIR/.guard-check-result"
         exit 0
         ;;
     noop)

--- a/cli/tests/scenarios.rs
+++ b/cli/tests/scenarios.rs
@@ -460,18 +460,21 @@ struct EnvGuard {
 impl EnvGuard {
     fn lock_clean() -> Self {
         let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            env::remove_var(polyresearch::config::NODE_ID_ENV_VAR);
-        }
+        clear_test_env();
         Self { _guard: guard }
     }
 }
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
-        unsafe {
-            env::remove_var(polyresearch::config::NODE_ID_ENV_VAR);
-        }
+        clear_test_env();
+    }
+}
+
+fn clear_test_env() {
+    unsafe {
+        env::remove_var(polyresearch::config::NODE_ID_ENV_VAR);
+        env::remove_var(polyresearch::cycle_guard::GUARD_ENV_VAR);
     }
 }
 
@@ -3298,6 +3301,138 @@ async fn scenario_contribute_agent_failure_recovers() {
     assert!(
         result.is_ok(),
         "continuous mode should recover after transient agent failure: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn scenario_contribute_once_propagates_guard_to_agent() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("contrib-once-guard");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("check_guard");
+    repo.write_full_setup("lead", "test-node-guard", &agent_cmd);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(94, "Guard propagation test", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(94, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-guard");
+    }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        true,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: true,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "once mode should pass the guard path into the workflow agent: {result:?}"
+    );
+
+    let check_result = repo.path.join(".polyresearch/.guard-check-result");
+    let guard_path = fs::read_to_string(&check_result).unwrap();
+    let guard_path = guard_path.trim();
+    assert!(
+        Path::new(guard_path).is_absolute(),
+        "workflow agent should receive an absolute once guard path, got: {guard_path}"
+    );
+    assert!(
+        guard_path.ends_with(".once-guard"),
+        "workflow agent should receive the once guard file path, got: {guard_path}"
+    );
+    assert!(
+        !repo.path.join(".polyresearch/.once-guard").exists(),
+        "once guard file should be cleaned up after contribute exits"
+    );
+}
+
+#[tokio::test]
+async fn scenario_contribute_without_once_has_no_guard() {
+    let _guard = EnvGuard::lock_clean();
+    let repo = ScenarioRepo::new("contrib-no-guard");
+    repo.init_git();
+
+    let agent_cmd = mock_agent_command("check_no_guard");
+    repo.write_full_setup("lead", "test-node-no-guard", &agent_cmd);
+    fs::create_dir_all(repo.path.join("src")).unwrap();
+    fs::write(repo.path.join("src/main.js"), "// original\n").unwrap();
+    repo.commit_all("setup");
+
+    let (issue, comments) = make_approved_thesis(95, "No guard propagation test", "lead");
+    let github = Arc::new(ScenarioGitHub::new("contributor"));
+    github.seed_issue(issue);
+    github.seed_issue_comments(95, comments);
+
+    unsafe {
+        env::set_var(polyresearch::config::NODE_ID_ENV_VAR, "test-node-no-guard");
+    }
+
+    let ctx = make_scenario_ctx(
+        repo.path.clone(),
+        Arc::clone(&github) as Arc<dyn GitHubApi>,
+        "lead",
+        true,
+        Commands::Contribute(ContributeArgs {
+            url: None,
+            once: false,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        }),
+    );
+
+    let result = commands::contribute::run(
+        &ctx,
+        &ContributeArgs {
+            url: None,
+            once: false,
+            max_parallel: Some(1),
+            sleep_secs: 0,
+            overrides: NodeOverrides::default(),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "continuous mode should not inject a once guard: {result:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(repo.path.join(".polyresearch/.guard-check-result"))
+            .unwrap()
+            .trim(),
+        "unset"
+    );
+    assert!(
+        !repo.path.join(".polyresearch/.once-guard").exists(),
+        "continuous mode should not leave a once guard file behind"
     );
 }
 


### PR DESCRIPTION
## Summary
- enforce `contribute --once` with a Rust-side guard file so workflow agents cannot claim a second thesis after a completed release/submit cycle
- pass the guard path into workflow agents through `POLYRESEARCH_ONCE_GUARD`, mark it done from `release`/`submit`, and clean it up when `contribute` exits
- add unit, e2e, and scenario coverage for claim/release/submit guard behavior and workflow-agent env propagation

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets`

## References
- fixes #152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core CLI control flow around claiming/releasing/submitting and introduces new filesystem/env-var state that can block work if mis-set, though it’s gated behind `--once`/env and covered by tests.
> 
> **Overview**
> Fixes `contribute --once` so a node can’t start a second thesis cycle after completing the first. This introduces a file-backed cycle guard (`.polyresearch/.once-guard`) wired via `POLYRESEARCH_ONCE_GUARD`: `contribute --once` creates it, passes its path into workflow agents, and cleans it up on exit.
> 
> `claim` and `batch-claim` now refuse to run once the guard is marked `done`, and `release`/`submit` mark the guard `done` after successfully posting/creating remote updates (non-dry-run). Tests are expanded with new unit coverage for `cycle_guard`, enhanced GitHub mocks for PR creation, and new e2e/scenario cases validating guard behavior and env propagation to agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16521e3bd072fec38a5ef2bd1724c4265482fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->